### PR TITLE
feat(metadata): dynamic generation

### DIFF
--- a/packages/client/src/layers/network/api/admin.ts
+++ b/packages/client/src/layers/network/api/admin.ts
@@ -29,7 +29,7 @@ export function createAdminAPI(systems: any) {
 
     // init general
     systems["system._Init"].executeTyped(); // creates food and modifier registry  
-    systems["system.ERC721.metadata"]._setRevealed("123", "https://kamigotchi.nyc3.cdn.digitaloceanspaces.com/images%2F");
+    systems["system.ERC721.metadata"]._setRevealed("123", "http://159.223.244.145:8080/image/");
     // systems["system.ERC721.metadata"]._setMaxElements(['9', '1', '7', '8', '1']); 
     systems["system.ERC721.metadata"]._setMaxElements(['2', '1', '2', '2', '1']);
 

--- a/packages/contracts/src/systems/PetMetadataSystem.sol
+++ b/packages/contracts/src/systems/PetMetadataSystem.sol
@@ -58,7 +58,8 @@ contract PetMetadataSystem is System {
     );
     mediaComp.set(
       entityID,
-      LibString.concat(_baseURI, LibString.concat(LibString.toString(packed), ".gif"))
+      // LibString.concat(_baseURI, LibString.concat(LibString.toString(packed), ".gif"))
+      LibString.concat(_baseURI, LibString.toString(packed))
     );
 
     uint256[] memory permTraits = LibMetadata._packedToArray(packed, _numElements);


### PR DESCRIPTION
uses a simple express backend to dynamically generate kami images

backend is at [kamigotchi-backend-metadata](https://github.com/Asphodel-OS/kamigotchi-backend-metadata). Running on a DO droplet

do note that although the backend is able to generate all images, randomness will be very limited for now because random elements are still hard locked on the contracts