### PR TITLE
fix: yarn deploy foundry breaking change 

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -24,7 +24,7 @@
     "abi:types": "rimraf ../client/types && mkdir ../client/types && yarn abi:types:gen && yarn abi:types:mappings && rimraf ../client/types/ethers-contracts/factories",
     "abi:types:gen": "yarn typechain --target=ethers-v5 --out-dir ../client/types/ethers-contracts ../client/abi/*.json ",
     "abi:types:mappings": "mud system-types --outputDir ../client/types/ && cp ../client/types/SystemAbis.mts ../client/types/SystemAbis.mjs",
-    "build:systems": "forge build -c src/systems --skip test --skip script",
+    "build:systems": "forge build --contracts src/systems --skip test --skip script",
     "deploy:local": "mud deploy --deployerPrivateKey 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
     "dev:local": "yarn build && yarn start",
     "node:local": "anvil -b 1 --block-base-fee-per-gas 0",


### PR DESCRIPTION
latest version of foundry breaks `-c`, which `yarn build` relies on. new foundry versions use `-C`. changed to `--contracts` to work with all versions