### PR TITLE
temp kami image fix

### DIFF
--- a/packages/client/src/layers/react/components/modals/Kami.tsx
+++ b/packages/client/src/layers/react/components/modals/Kami.tsx
@@ -159,7 +159,8 @@ export function registerKamiModal() {
               padding: '15px',
             }}
           >
-            <KamiImage src={dets?.uri} />
+            {/* <KamiImage src={dets?.uri} /> */}
+            <KamiImage src='https://kamigotchi.nyc3.cdn.digitaloceanspaces.com/tempKami.gif' />
             <div
               style={{
                 display: 'flex',


### PR DESCRIPTION
replaces kami image to a static one to avoid cdn, to remove later