### PR TITLE
proper 2-step minting reveal

### DIFF
--- a/packages/client/src/layers/react/components/index.ts
+++ b/packages/client/src/layers/react/components/index.ts
@@ -9,7 +9,8 @@ import { registerFoodShopButton } from './buttons/FoodShop';
 
 import { registerChatModal } from './modals/Chat';
 import { regiesterDetectAccountModal } from './modals/DetectAccount';
-import { registerKamiMintModal } from './modals/KamiMint';
+import { registerKamiMintModal } from './modals/MintKami';
+import { registerMintAfterModal } from './modals/MintAfter';
 import { registerKamiModal } from './modals/Kami';
 import { registerMapModal } from './modals/Map';
 import { registerMerchantModal } from './modals/Merchant';
@@ -31,11 +32,12 @@ export function registerUIComponents() {
   registerChatModal();
   regiesterDetectAccountModal();
   registerKamiMintModal();
-  registerKamiModal();
+  registerMintAfterModal();
   registerMapModal();
   registerNodeModal();
   registerMerchantModal();
   registerPartyModal();
+  registerKamiModal();
   // registerRequestQueue();
   // registerTradeModal();
 }

--- a/packages/client/src/layers/react/components/library/KamiCard.tsx
+++ b/packages/client/src/layers/react/components/library/KamiCard.tsx
@@ -7,10 +7,11 @@ interface Props {
   subtext: string;
   description: string[];
   cornerContent?: React.ReactNode;
+  info?: React.ReactNode;
   action: React.ReactNode;
 }
 
-// KamiCard is a card that displays information about a Kami. It is designed to display
+// KamiC  rd is a card that displays information about a Kami. It is designed to display
 // information ranging from current production or death as well as support common actions.
 export const KamiCard = (props: Props) => {
   // generate the styled text divs for the description
@@ -30,6 +31,7 @@ export const KamiCard = (props: Props) => {
       <Image src={props.image} />
       <Container>
         <TitleBar>
+          <TitleCorner>{props.info}</TitleCorner>
           <TitleText>{props.title}</TitleText>
           <TitleCorner>{props.cornerContent}</TitleCorner>
         </TitleBar>

--- a/packages/client/src/layers/react/components/modals/Kami.tsx
+++ b/packages/client/src/layers/react/components/modals/Kami.tsx
@@ -17,7 +17,7 @@ export function registerKamiModal() {
       colStart: 23,
       colEnd: 80,
       rowStart: 5,
-      rowEnd: 85,
+      rowEnd: 90,
     },
     (layers) => {
       const {
@@ -82,16 +82,6 @@ export function registerKamiModal() {
           console.log('KamiDetails: kami', dets);
         }
       }, [description]);
-
-      // const petTypes = (val: string[] | undefined) => {
-      //   if (!val) return;
-      //   let result = val[0];
-
-      //   for (let i = 1; i < val.length; i++) {
-      //     result = result + ' | ' + val[i];
-      //   }
-      //   return result;
-      // };
 
       const traitBox = () => {
         return (

--- a/packages/client/src/layers/react/components/modals/MintAfter.tsx
+++ b/packages/client/src/layers/react/components/modals/MintAfter.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { of } from 'rxjs';
+import { registerUIComponent } from 'layers/react/engine/store';
+import { dataStore } from 'layers/react/store/createStore';
+import styled from 'styled-components';
+import 'layers/react/styles/font.css';
+import { ModalWrapperFull } from '../library/ModalWrapper';
+import { ActionButton } from 'layers/react/components/library/ActionButton';
+
+// TODO: update this file and component name to be more desctiptive
+export function registerMintAfterModal() {
+  registerUIComponent(
+    'PostMint',
+    {
+      colStart: 35,
+      colEnd: 60,
+      rowStart: 40,
+      rowEnd: 60,
+    },
+    (layers) => of(layers),
+    () => {
+      const {
+        visibleModals,
+        setVisibleModals,
+      } = dataStore();
+
+      const OpenPartyModal = () => {
+        setVisibleModals({ ...visibleModals, kamiMintPost: false, party: true });
+      }
+
+      const PartyButton = (
+        <ActionButton
+          id='button-mint'
+          onClick={OpenPartyModal}
+          size='large'
+          text='View my party'
+        />
+      );
+
+      return (
+        <ModalWrapperFull divName="kamiMintPost" id="postMintModal">
+          <CenterBox>
+            <Description>Minted!</Description>
+          </CenterBox>
+          {PartyButton}
+        </ModalWrapperFull>
+      );
+    }
+  );
+}
+
+const CenterBox = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0px 10px 10px 10px;
+`;
+
+const Description = styled.p`
+  font-size: 22px;
+  color: #333;
+  text-align: center;
+  padding: 10px;
+  font-family: Pixel;
+`;
+
+const KamiImage = styled.img`
+  border-style: solid;
+  border-width: 0px;
+  border-color: black;
+  height: 90px;
+  margin: 0px;
+  padding: 0px;
+`;

--- a/packages/client/src/layers/react/components/shapes/Kami.tsx
+++ b/packages/client/src/layers/react/components/shapes/Kami.tsx
@@ -21,6 +21,7 @@ export interface Kami {
   name: string;
   uri: string;
   health: number;
+  state: string;
   lastUpdated: number;
   account?: Account;
   production?: Production;
@@ -63,6 +64,7 @@ export const getKami = (
         Name,
         PetID,
         PetIndex,
+        State,
         TraitIndex,
       },
     },
@@ -75,6 +77,7 @@ export const getKami = (
     name: getComponentValue(Name, index)?.value as string,
     uri: getComponentValue(MediaURI, index)?.value as string,
     health: getComponentValue(HealthCurrent, index)?.value as number,
+    state: getComponentValue(State, index)?.value as string,
     lastUpdated: getComponentValue(LastActionTime, index)?.value as number,
     stats: getStats(layers, index),
   };

--- a/packages/client/src/layers/react/store/createStore.ts
+++ b/packages/client/src/layers/react/store/createStore.ts
@@ -20,6 +20,7 @@ export interface VisibleModals {
   dialogue: boolean;
   inventory: boolean;
   kamiMint: boolean;
+  kamiMintPost: boolean;
   kami: boolean;
   map: boolean;
   merchant: boolean;
@@ -58,6 +59,7 @@ export const dataStore = create<StoreState & StoreActions>((set) => {
       inventory: false,
       kami: false,
       kamiMint: false,
+      kamiMintPost: false,
       map: false,
       merchant: false,
       node: false,

--- a/packages/contracts/src/libraries/LibPet.sol
+++ b/packages/contracts/src/libraries/LibPet.sol
@@ -67,8 +67,17 @@ library LibPet {
     setAccount(components, id, accountID);
     setMediaURI(components, id, uri);
     setLastTs(components, id, block.timestamp);
-    revive(components, id);
+    setState(components, id, "UNREVEALED");
     return id;
+  }
+
+  // called when a pet is revealed
+  // NOTE: most of the reveal logic (generation) is in the PetMetadataSystem itself
+  //       this function is for components that relate directly to the pet
+  function reveal(IUintComp components, uint256 id) internal {
+    setLastTs(components, id, block.timestamp);
+    revive(components, id);
+    setStats(components, id);
   }
 
   // feed the pet with a food item
@@ -271,7 +280,6 @@ library LibPet {
   // SETTERS
 
   // set a pet's stats from its traits
-  // TODO: actually set stats from traits. hardcoded currently
   function setStats(IUintComp components, uint256 id) internal {
     uint256 health;
     uint256 power;
@@ -361,6 +369,10 @@ library LibPet {
   // Get the production of a pet. Return 0 if there are none.
   function getProduction(IUintComp components, uint256 id) internal view returns (uint256) {
     return LibProduction.getForPet(components, id);
+  }
+
+  function getState(IUintComp components, uint256 id) internal view returns (string memory) {
+    return StateComponent(getAddressById(components, StateCompID)).getValue(id);
   }
 
   // Get the traits of a pet, specifically the list of trait registry IDs

--- a/packages/contracts/src/systems/PetMetadataSystem.sol
+++ b/packages/contracts/src/systems/PetMetadataSystem.sol
@@ -120,7 +120,7 @@ contract PetMetadataSystem is System {
       LibString.concat(_baseURI, LibString.toString(packed))
     );
 
-    LibPet.setStats(components, petID);
+    LibPet.reveal(components, petID);
     return "";
   }
 


### PR DESCRIPTION
mostly UI changes, some small SC changes. fixes the bug where reveals get conflicted when many people try to reveal at the same time

Mint flow: `mint` -> `view party` -> `reveal selected`

SC:
- added 'UNREVEALED' state for pets

FE:
- Removed automatic reveals
- Reveal from `party` menu
