### PR TITLE
feat: add new Kami states

### DIFF
--- a/packages/contracts/src/libraries/LibProduction.sol
+++ b/packages/contracts/src/libraries/LibProduction.sol
@@ -49,6 +49,7 @@ library LibProduction {
 
   // Starts an _existing_ production if not already started.
   function start(IUintComp components, uint256 id) internal {
+    LibPet.setState(components, id, "HARVESTING");
     setState(components, id, "ACTIVE");
     reset(components, id);
     setRate(components, id, calcRate(components, id)); // always last
@@ -56,6 +57,7 @@ library LibProduction {
 
   // Stops an _existing_ production. All potential proceeds will be lost after this point.
   function stop(IUintComp components, uint256 id) internal {
+    LibPet.setState(components, id, "RESTING");
     setState(components, id, "INACTIVE");
     setRate(components, id, 0);
   }

--- a/packages/contracts/src/systems/PetFeedSystem.sol
+++ b/packages/contracts/src/systems/PetFeedSystem.sol
@@ -25,8 +25,6 @@ contract PetFeedSystem is System {
     uint256 registryID = LibRegistryItem.getByFoodIndex(components, foodIndex);
     require(registryID != 0, "RegistryItem: no such food");
 
-    require(LibPet.syncHealth(components, petID) != 0, "Pet: is dead (pls revive)");
-
     uint256 itemIndex = LibRegistryItem.getItemIndex(components, registryID);
     uint256 inventoryID = LibInventory.get(components, accountID, itemIndex);
     require(inventoryID != 0, "Inventory: no bitches, no food");
@@ -34,6 +32,7 @@ contract PetFeedSystem is System {
     LibInventory.dec(components, inventoryID, 1); // inherent check for insufficient balance
 
     uint256 healAmt = LibStat.getHealth(components, registryID);
+    LibPet.syncHealth(components, petID);
     LibPet.heal(components, petID, healAmt);
     LibAccount.updateLastBlock(components, accountID); // gas limit :|
     return "";

--- a/packages/contracts/src/systems/ProductionCollectSystem.sol
+++ b/packages/contracts/src/systems/ProductionCollectSystem.sol
@@ -22,10 +22,10 @@ contract ProductionCollectSystem is System {
     uint256 id = abi.decode(arguments, (uint256));
     uint256 accountID = LibAccount.getByAddress(components, msg.sender);
     uint256 petID = LibProduction.getPet(components, id);
+    LibPet.syncHealth(components, petID);
 
     require(LibPet.getAccount(components, petID) == accountID, "Pet: not urs");
-    require(LibPet.isProducing(components, petID), "Pet: must be producing");
-    require(LibPet.syncHealth(components, petID) != 0, "Pet: is dead (pls revive)");
+    require(LibPet.isHarvesting(components, petID), "Pet: must be harvesting");
 
     uint256 amt = LibProduction.calcOutput(components, id);
     LibCoin.inc(components, accountID, amt);

--- a/packages/contracts/src/systems/ProductionStopSystem.sol
+++ b/packages/contracts/src/systems/ProductionStopSystem.sol
@@ -24,10 +24,10 @@ contract ProductionStopSystem is System {
     uint256 id = abi.decode(arguments, (uint256));
     uint256 accountID = LibAccount.getByAddress(components, msg.sender);
     uint256 petID = LibProduction.getPet(components, id);
+    LibPet.syncHealth(components, petID);
 
     require(LibPet.getAccount(components, petID) == accountID, "Pet: not urs");
-    require(LibPet.isProducing(components, petID), "Pet: must be producing");
-    require(LibPet.syncHealth(components, petID) != 0, "Pet: is dead (pls revive)");
+    require(LibPet.isHarvesting(components, petID), "Pet: must be harvesting");
 
     uint256 amt = LibProduction.calcOutput(components, id);
     LibCoin.inc(components, accountID, amt);

--- a/packages/contracts/src/test/utils/TestSetupImports.sol
+++ b/packages/contracts/src/test/utils/TestSetupImports.sol
@@ -122,11 +122,6 @@ import { ProductionCollectSystem, ID as ProductionCollectSystemID } from "system
 import { ProductionLiquidateSystem, ID as ProductionLiquidateSystemID } from "systems/ProductionLiquidateSystem.sol";
 import { ProductionStartSystem, ID as ProductionStartSystemID } from "systems/ProductionStartSystem.sol";
 import { ProductionStopSystem, ID as ProductionStopSystemID } from "systems/ProductionStopSystem.sol";
-import { TradeAcceptSystem, ID as TradeAcceptSystemID } from "systems/TradeAcceptSystem.sol";
-import { TradeAddToSystem, ID as TradeAddToSystemID } from "systems/TradeAddToSystem.sol";
-import { TradeCancelSystem, ID as TradeCancelSystemID } from "systems/TradeCancelSystem.sol";
-import { TradeConfirmSystem, ID as TradeConfirmSystemID } from "systems/TradeConfirmSystem.sol";
-import { TradeInitiateSystem, ID as TradeInitiateSystemID } from "systems/TradeInitiateSystem.sol";
 
 abstract contract TestSetupImports is MudTest {
 // Components vars
@@ -230,11 +225,6 @@ ProductionCollectSystem _ProductionCollectSystem;
 ProductionLiquidateSystem _ProductionLiquidateSystem;
 ProductionStartSystem _ProductionStartSystem;
 ProductionStopSystem _ProductionStopSystem;
-TradeAcceptSystem _TradeAcceptSystem;
-TradeAddToSystem _TradeAddToSystem;
-TradeCancelSystem _TradeCancelSystem;
-TradeConfirmSystem _TradeConfirmSystem;
-TradeInitiateSystem _TradeInitiateSystem;
 
 function setUp() public virtual override {
 super.setUp();
@@ -338,10 +328,5 @@ _ProductionCollectSystem = ProductionCollectSystem(system(ProductionCollectSyste
 _ProductionLiquidateSystem = ProductionLiquidateSystem(system(ProductionLiquidateSystemID));
 _ProductionStartSystem = ProductionStartSystem(system(ProductionStartSystemID));
 _ProductionStopSystem = ProductionStopSystem(system(ProductionStopSystemID));
-_TradeAcceptSystem = TradeAcceptSystem(system(TradeAcceptSystemID));
-_TradeAddToSystem = TradeAddToSystem(system(TradeAddToSystemID));
-_TradeCancelSystem = TradeCancelSystem(system(TradeCancelSystemID));
-_TradeConfirmSystem = TradeConfirmSystem(system(TradeConfirmSystemID));
-_TradeInitiateSystem = TradeInitiateSystem(system(TradeInitiateSystemID));
 }
 }


### PR DESCRIPTION
This includes DEAD, HARVESTING, RESTING and UNREVEALED. And updates to health syncing logic required to support healing/draining. This also updates the calculation of base stats.