### PR TITLE
Convert isLiquidatableBy() to External

### DIFF
--- a/packages/client/abi/PetFeedSystem.json
+++ b/packages/client/abi/PetFeedSystem.json
@@ -28,6 +28,11 @@
     },
     {
       "inputs": [],
+      "name": "invalidFood",
+      "type": "error"
+    },
+    {
+      "inputs": [],
       "name": "notFungibleInstance",
       "type": "error"
     },

--- a/packages/client/abi/ProductionLiquidateSystem.json
+++ b/packages/client/abi/ProductionLiquidateSystem.json
@@ -18,11 +18,6 @@
     },
     {
       "inputs": [],
-      "name": "Min",
-      "type": "error"
-    },
-    {
-      "inputs": [],
       "name": "Ownable__NotOwner",
       "type": "error"
     },

--- a/packages/contracts/src/libraries/LibProduction.sol
+++ b/packages/contracts/src/libraries/LibProduction.sol
@@ -126,7 +126,7 @@ library LibProduction {
     IUintComp components,
     uint256 id,
     uint256 sourcePetID
-  ) internal view returns (bool) {
+  ) external view returns (bool) {
     uint256 targetPetID = getPet(components, id);
     uint256 targetHealth = LibPet.getCurrHealth(components, targetPetID);
     uint256 targetTotalHealth = LibPet.calcTotalHealth(components, targetPetID);

--- a/packages/contracts/src/systems/ProductionCollectSystem.sol
+++ b/packages/contracts/src/systems/ProductionCollectSystem.sol
@@ -9,7 +9,6 @@ import { LibCoin } from "libraries/LibCoin.sol";
 import { LibAccount } from "libraries/LibAccount.sol";
 import { LibPet } from "libraries/LibPet.sol";
 import { LibProduction } from "libraries/LibProduction.sol";
-import { Strings } from "utils/Strings.sol";
 
 uint256 constant ID = uint256(keccak256("system.Production.Collect"));
 

--- a/packages/contracts/src/systems/ProductionLiquidateSystem.sol
+++ b/packages/contracts/src/systems/ProductionLiquidateSystem.sol
@@ -47,9 +47,9 @@ contract ProductionLiquidateSystem is System {
     // kill the target and shut off the production
     LibPet.kill(components, targetPetID);
     LibProduction.stop(components, targetProductionID);
-    // LibKill.create(world, components, petID, targetPetID, nodeID);
+    LibKill.create(world, components, petID, targetPetID, nodeID);
 
-    // LibAccount.updateLastBlock(components, accountID);
+    LibAccount.updateLastBlock(components, accountID);
     return "";
   }
 

--- a/packages/contracts/src/systems/ProductionStopSystem.sol
+++ b/packages/contracts/src/systems/ProductionStopSystem.sol
@@ -9,7 +9,6 @@ import { LibCoin } from "libraries/LibCoin.sol";
 import { LibAccount } from "libraries/LibAccount.sol";
 import { LibPet } from "libraries/LibPet.sol";
 import { LibProduction } from "libraries/LibProduction.sol";
-import { Strings } from "utils/Strings.sol";
 
 uint256 constant ID = uint256(keccak256("system.Production.Stop"));
 

--- a/packages/contracts/src/test/systems/Load.t.sol
+++ b/packages/contracts/src/test/systems/Load.t.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+import "test/utils/SetupTemplate.s.sol";
+
+/*
+ * This is a load bearing test. Yes. A load bearing test.
+ * This test is used to force a compilation error during the build step to
+ * circumvent an incorrectly surfaced error by foundry during deployment. This
+ * error is only present when compiling/deploying externalized library functions
+ * and unavoidable otherwise.
+ *
+ * See for yourself. Remove this file and 'yarn dev' from the packages/contracts.
+ * Witness the cognito-hazard for yourself. Just know that I bear no responsibility
+ * for any resulting aneurysms. 
+ */
+contract LoadBearingTest is SetupTemplate {
+  __waddafakSystem.executeTyped();
+}

--- a/packages/contracts/src/test/utils/SetupTemplate.s.sol
+++ b/packages/contracts/src/test/utils/SetupTemplate.s.sol
@@ -58,11 +58,7 @@ abstract contract SetupTemplate is TestSetupImports {
     vm.stopPrank();
   }
 
-  function _transferPetNFT(
-    address from,
-    address to,
-    uint256 nftID
-  ) internal {
+  function _transferPetNFT(address from, address to, uint256 nftID) internal {
     vm.prank(from);
     _ERC721PetSystem.transferFrom(from, to, nftID);
   }
@@ -70,11 +66,7 @@ abstract contract SetupTemplate is TestSetupImports {
   /***********************
    *   room create
    ************************/
-  function _roomCreate(
-    string memory name,
-    uint256 location,
-    uint256[] memory exits
-  ) internal {
+  function _roomCreate(string memory name, uint256 location, uint256[] memory exits) internal {
     vm.prank(deployer);
     __RoomCreateSystem.executeTyped(name, location, exits);
   }


### PR DESCRIPTION
We are converting this function to external to free up significant space on our contract size limitations. This should unlock the ability to do so for other library functions are `view` only.

This includes a "load bearing" test contract now to force a compilation error during deployment. This is the only way to avoid the critical foundry error that causes the whole deployment to fail.. don't ask me why, just trust the process