### PR TITLE
longer chat reconnect periods, shorter timeouts

### DIFF
--- a/packages/client/src/layers/react/components/modals/Chat.tsx
+++ b/packages/client/src/layers/react/components/modals/Chat.tsx
@@ -48,7 +48,7 @@ export function registerChatModal() {
         return getComponentValue(Name, index)?.value as string;
       };
 
-      return merge(IsAccount.update$, Name.update$).pipe(
+      return merge(IsAccount.update$).pipe(
         map(() => {
           const accountIndex = Array.from(
             runQuery([
@@ -72,7 +72,12 @@ export function registerChatModal() {
       const [messages, setMessages] = useState<ChatMessage[]>([]);
       const [chatInput, setChatInput] = useState('');
 
-      const relay: mqtt.MqttClient = mqtt.connect(mqttServerUrl);
+      const options = {
+        connectTimeout: 300000,
+        reconnectPeriod: 10000,
+      }
+
+      const relay: mqtt.MqttClient = mqtt.connect(mqttServerUrl, options);
 
       useEffect(() => {
         const botElement = document.getElementById('botElement');


### PR DESCRIPTION
chat server struggles with high loads. I suspect people leaving the kami tab open contributes quite a bit to the load.

pull adds
1) 5 minute chat inactivity timeout
2) 10 second reconnect period
3) removed some update flags

should help with inactivity but server still needs to be scaled up for many people at once