### PR TITLE
fixed undefined names

### DIFF
--- a/packages/client/src/layers/react/components/modals/Chat.tsx
+++ b/packages/client/src/layers/react/components/modals/Chat.tsx
@@ -48,7 +48,7 @@ export function registerChatModal() {
         return getComponentValue(Name, index)?.value as string;
       };
 
-      return merge(IsAccount.update$).pipe(
+      return merge(IsAccount.update$, Name.update$).pipe(
         map(() => {
           const accountIndex = Array.from(
             runQuery([


### PR DESCRIPTION
apparently the previous pull broke the account chat name

putting the update on name hook back

i suspect this is a result of how RECS handles states internally