### PR TITLE
Fix screen overflow issue with feed button and add text to Kami

### DIFF
--- a/packages/client/src/layers/react/components/library/ActionListButton.tsx
+++ b/packages/client/src/layers/react/components/library/ActionListButton.tsx
@@ -21,17 +21,21 @@ export function ActionListButton(props: Props) {
   const toggleRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
-    if (isOpen && toggleRef.current) {
-      const togglePosition = toggleRef.current.getBoundingClientRect();
-      setMenuPosition({ top: togglePosition.bottom, left: togglePosition.left });
-    }
-  }, [isOpen]);
-
-  useEffect(() => {
     setIsOpen(false);
   }, [props.scrollPosition]);
 
-  const toggleMenu = () => {
+  const toggleMenu = (e) => {
+    const togglePosition = toggleRef.current?.getBoundingClientRect();
+    const screenHeight = window.innerHeight;
+    const targetHeight = (e.target as HTMLElement).clientHeight;
+
+    if (togglePosition && togglePosition.bottom + targetHeight > screenHeight * 0.7) {
+      console.log('dadaaa');
+      // Menu should pop up above the toggle
+      setMenuPosition({ top: togglePosition.bottom * 0.85, left: togglePosition.left });
+    } else {
+      setMenuPosition({ top: togglePosition.bottom, left: togglePosition.left });
+    }
     setIsOpen(!isOpen);
   };
 
@@ -46,7 +50,7 @@ export function ActionListButton(props: Props) {
       <Toggle
         ref={toggleRef}
         id={props.id}
-        onClick={!props.disabled ? toggleMenu : () => { }}
+        onClick={!props.disabled ? toggleMenu : () => {}}
         style={setStyles()}
       >
         {props.text + ' ▾'}

--- a/packages/client/src/layers/react/components/modals/Kami.tsx
+++ b/packages/client/src/layers/react/components/modals/Kami.tsx
@@ -145,7 +145,7 @@ export function registerKamiModal() {
           return (
             <TraitBox style={{ gridTemplateColumns: `repeat(${gridColumn}, 1fr)` }}>
               <KamiHeader style={{ gridRow: 1, gridColumn: 1 }}>
-                {dets.traits[key].affinity}
+                {key.charAt(0).toUpperCase() + key.slice(1)}
               </KamiHeader>
               {statBoxes}
             </TraitBox>
@@ -207,7 +207,11 @@ export function registerKamiModal() {
             </div>
           </TopDiv>
           <div>{traitBox()}</div>
-          <div>
+          <div
+            style={{
+              overflowY: 'scroll',
+            }}
+          >
             {Object.keys(dets?.traits ?? {}).map((key: any) => (
               <div key={key}>{traitStats(key)}</div>
             ))}


### PR DESCRIPTION
- Resolved the problem where the feed button was overflowing the screen.
- Adjusted the layout and sizing to ensure the feed button fits within the screen dimensions.
- Implemented a fix to prevent the button from overlapping with other elements.
- Also, included additional text to enhance the functionality and user experience of Kami modal.