### PR TITLE
Refine KamiCard image/title clicking

### DIFF
--- a/packages/client/src/layers/react/components/library/KamiCard.tsx
+++ b/packages/client/src/layers/react/components/library/KamiCard.tsx
@@ -8,14 +8,10 @@ import { dataStore } from 'layers/react/store/createStore';
 
 interface Props {
   kami: Kami;
-  title: string;
-  image: string;
-  subtext: string;
   description: string[];
-  action: React.ReactNode;
+  subtext?: string;
+  action?: React.ReactNode;
   cornerContent?: React.ReactNode;
-  imageOnClick?: Function;
-  titleOnClick?: Function;
 }
 
 // KamiCard is a card that displays information about a Kami. It is designed to display
@@ -29,9 +25,15 @@ export const KamiCard = (props: Props) => {
     sound: { volume },
   } = dataStore();
 
+  // layer on a sound effect
+  const playClickAudio = async () => {
+    const clickSound = new Audio(clickSoundUrl);
+    clickSound.volume = volume * 0.6;
+    clickSound.play();
+  };
+
   // toggle the kami modal settings depending on current its current state
   const kamiOnClick = () => {
-    playClickAudio();
     const modalIsOpen = visibleModals.kami;
     const sameKami = selectedEntities.kami === props.kami.entityIndex;
     if (modalIsOpen) {
@@ -44,14 +46,8 @@ export const KamiCard = (props: Props) => {
       setSelectedEntities({ ...selectedEntities, kami: props.kami.entityIndex });
       setVisibleModals({ ...visibleModals, kami: true });
     }
+    playClickAudio();
   }
-
-  // layer on a sound effect
-  const playClickAudio = async () => {
-    const clickSound = new Audio(clickSoundUrl);
-    clickSound.volume = volume * 0.6;
-    clickSound.play();
-  };
 
   // generate the styled text divs for the description
   const Description = () => {
@@ -65,10 +61,10 @@ export const KamiCard = (props: Props) => {
 
   return (
     <Card key={props.kami.id}>
-      <Image onClick={() => kamiOnClick()} src={props.image} />
+      <Image onClick={() => kamiOnClick()} src={props.kami.uri} />
       <Container>
         <TitleBar>
-          <TitleText onClick={() => kamiOnClick()}>{props.title}</TitleText>
+          <TitleText onClick={() => kamiOnClick()}>{props.kami.name}</TitleText>
           <TitleCorner>{props.cornerContent}</TitleCorner>
         </TitleBar>
         <Content>

--- a/packages/client/src/layers/react/components/modals/Node.tsx
+++ b/packages/client/src/layers/react/components/modals/Node.tsx
@@ -361,8 +361,8 @@ export function registerNodeModal() {
       // DISPLAY
 
       // button for adding Kami to node
-      const AddButton = (node: Node, restingKamis: Kami[]) => {
-        const options: ActionListOption[] = restingKamis.map((kami) => {
+      const AddButton = (node: Node, kamis: Kami[]) => {
+        const options: ActionListOption[] = kamis.map((kami) => {
           return { text: `${kami.name}`, onClick: () => start(kami, node) };
         });
         return (
@@ -373,29 +373,34 @@ export function registerNodeModal() {
             hidden={true}
             scrollPosition={scrollPosition}
             options={options}
-            disabled={restingKamis.length == 0}
+            disabled={kamis.length == 0}
           />
         );
       };
 
       // button for collecting on production
-      const CollectButton = (myKami: Kami) => (
+      const CollectButton = (kami: Kami) => (
         <ActionButton
-          id={`harvest-collect`}
-          key={`harvest-collect`}
-          onClick={() => collect(myKami.production!)}
+          id={`harvest-collect-${kami.id}`}
+          key={`harvest-collect-${kami.id}`}
+          onClick={() => collect(kami.production!)}
           text='Collect'
         />
       );
 
       // button for stopping production
-      const StopButton = (myKami: Kami) => (
-        <ActionButton id={`harvest-stop`} onClick={() => stop(myKami.production!)} text='Stop' />
+      const StopButton = (kami: Kami) => (
+        <ActionButton
+          id={`harvest-stop-${kami.id}`}
+          key={`harvest-stop-${kami.id}`}
+          text='Stop'
+          onClick={() => stop(kami.production!)}
+        />
       );
 
       // button for liquidating production
-      const LiquidateButton = (target: Kami, soldiers: Kami[]) => {
-        const options: ActionListOption[] = soldiers.map((myKami) => {
+      const LiquidateButton = (target: Kami, allies: Kami[]) => {
+        const options: ActionListOption[] = allies.map((myKami) => {
           return { text: `${myKami.name}`, onClick: () => liquidate(myKami, target) };
         });
 
@@ -407,7 +412,7 @@ export function registerNodeModal() {
             hidden={true}
             scrollPosition={scrollPosition}
             options={options}
-            disabled={soldiers.length == 0}
+            disabled={allies.length == 0}
           />
         );
       };
@@ -429,8 +434,6 @@ export function registerNodeModal() {
           <KamiCard
             key={kami.id}
             kami={kami}
-            title={kami.name}
-            image={kami.uri}
             subtext={`yours (\$${output})`}
             action={[CollectButton(kami), StopButton(kami)]}
             cornerContent={<BatteryComponent level={healthPercent} />}
@@ -460,8 +463,6 @@ export function registerNodeModal() {
           <KamiCard
             key={kami.id}
             kami={kami}
-            title={kami.name}
-            image={kami.uri}
             subtext={`${kami.account!.name} (\$${output})`}
             action={LiquidateButton(kami, validLiquidators)}
             cornerContent={<BatteryComponent level={healthPercent} />}

--- a/packages/client/src/layers/react/components/modals/Party.tsx
+++ b/packages/client/src/layers/react/components/modals/Party.tsx
@@ -491,15 +491,11 @@ export function registerPartyModal() {
           return (
             <KamiCard
               key={kami.id}
-              image={kami.uri}
-              title={kami.name}
               kami={kami}
               description={description}
               subtext={`${calcOutput(kami)} $KAMI`}
               action={action}
               cornerContent={healthString}
-              imageOnClick={() => openKamiModal(kami.entityIndex)}
-              titleOnClick={() => openKamiModal(kami.entityIndex)}
             />
           );
         });


### PR DESCRIPTION
makes it so clicking on any use of the KamiCard toggles the Kami Details Modal.
this change also alters the KamiCard to use the input kami data in favor of using
the additional title/image props. the goal here is to generalize this as much as
possible so it can be used in other places. to that end, the `subtext` and `action`
props have both been made optional