### PR TITLE
auto reveal

### DIFF
--- a/packages/client/src/layers/react/components/modals/Party.tsx
+++ b/packages/client/src/layers/react/components/modals/Party.tsx
@@ -169,7 +169,7 @@ export function registerPartyModal() {
 
       // reveal kami
       const revealKami = async (kami: Kami) => {
-        const actionID = (`Revealing Kami ` + kami.index) as EntityID; // Date.now to have the actions ordered in the component browser
+        const actionID = (`Revealing Kami ` + BigInt(kami.index).toString(10)) as EntityID; // Date.now to have the actions ordered in the component browser
         actions.add({
           id: actionID,
           components: {},

--- a/packages/client/src/layers/react/components/shapes/Account.tsx
+++ b/packages/client/src/layers/react/components/shapes/Account.tsx
@@ -9,7 +9,7 @@ import {
 
 import { Layers } from 'src/types';
 import { getConfigFieldValue } from './Config';
-import { Kami, getKami } from './Kami';
+import { Kami, queryKamisX } from './Kami';
 import {
   Inventory,
   getInventory,
@@ -124,23 +124,11 @@ export const getAccount = (
 
   // populate Kamis
   if (options?.kamis) {
-    let kamis: Kami[] = [];
-
-    const kamiResults = Array.from(
-      runQuery([
-        Has(IsPet),
-        HasValue(AccountID, { value: account.id })
-      ])
+    account.kamis = queryKamisX(
+      layers,
+      { account: account.id },
+      { deaths: true, production: true, traits: true }
     );
-
-    kamis = kamiResults.map(
-      (index): Kami => getKami(
-        layers,
-        index,
-        { deaths: true, production: true, traits: true }
-      )
-    );
-    account.kamis = kamis;
   }
 
   /////////////////

--- a/packages/client/src/layers/react/components/shapes/Kami.tsx
+++ b/packages/client/src/layers/react/components/shapes/Kami.tsx
@@ -1,11 +1,12 @@
 import {
+  Component,
   EntityIndex,
   EntityID,
   Has,
   HasValue,
   getComponentValue,
   runQuery,
-  Component,
+  QueryFragment,
 } from '@latticexyz/recs';
 
 import { Layers } from 'src/types';
@@ -45,6 +46,12 @@ export interface Options {
   production?: boolean;
   traits?: boolean;
   namable?: boolean;
+}
+
+// items to query
+export interface QueryOptions {
+  account?: EntityID;
+  state?: string;
 }
 
 // get a Kami from its EnityIndex. includes options for which data to include
@@ -215,4 +222,42 @@ export const getKami = (
   kami.healthRate = healthRate;
 
   return kami;
+};
+
+export const queryKamisX = (
+  layers: Layers,
+  options: QueryOptions,
+  kamiOptions?: Options
+): Kami[] => {
+  const {
+    network: {
+      components: {
+        AccountID,
+        IsPet,
+        State,
+      },
+    },
+  } = layers;
+
+  const toQuery: QueryFragment[] = [Has(IsPet)];
+
+  if (options?.account) {
+    toQuery.push(HasValue(AccountID, { value: options.account }));
+  }
+
+  if (options?.state) {
+    toQuery.push(HasValue(State, { value: options.state }));
+  }
+
+  const kamiIDs = Array.from(
+    runQuery(toQuery)
+  );
+
+  return kamiIDs.map(
+    (index): Kami => getKami(
+      layers,
+      index,
+      kamiOptions
+    )
+  );;
 };

--- a/packages/contracts/src/libraries/LibRandom.sol
+++ b/packages/contracts/src/libraries/LibRandom.sol
@@ -16,7 +16,7 @@ library LibRandom {
   function getSeedBlockhash(uint256 blocknumber) internal view returns (uint256 result) {
     // require(block.number - blocknumber <= 256, "LibRandom: blockhash too old");
     result = uint256(blockhash(blocknumber));
-    require(result != 0, "LibRandom: blockhash not available");
+    require(result != 0, "LibRandom: blockhash unavailable. Contact admin");
   }
 
   //////////////////


### PR DESCRIPTION
automatically reveals a kami after minting. this solves most situations where kamis get suck as unrevealable because of blockhash

**note:**
- its not foolproof, main edge case here is if a user closes the tab before the transactions are sent and doesn't reveal the kamis via the party window within 8 mins.
- theres no good way on the FE if a kami is revealable or not – it'll attempt to reveal all unrevealed, which gets constant errors if there is a stuck kami (pic) 
<img width="289" alt="Screenshot 2023-06-22 at 8 33 46 PM" src="https://github.com/Asphodel-OS/kamigotchi/assets/40616911/a3065a73-942d-4d25-a0f2-3de983c374d1">
