### PR TITLE
fix: prematurely pulling node names for party modal

### DIFF
--- a/packages/client/src/layers/react/components/modals/Party.tsx
+++ b/packages/client/src/layers/react/components/modals/Party.tsx
@@ -314,7 +314,7 @@ export function registerPartyModal() {
         } else if (isHarvesting(kami)) {
           if (calcHealth(kami) == 0) {
             description = [`Starving.. `, `on ${kami.production!.node!.name}`];
-          } else {
+          } else if (kami.production?.node != undefined) {
             const harvestRate = getRateDisplay(kami.production?.rate, 2);
             description = [
               `Harvesting`,


### PR DESCRIPTION
premature pulling of node names