### PR TITLE
fix: room create tests

### DIFF
--- a/packages/contracts/src/test/utils/SetupTemplate.s.sol
+++ b/packages/contracts/src/test/utils/SetupTemplate.s.sol
@@ -227,7 +227,7 @@ abstract contract SetupTemplate is TestSetupImports {
     if (numExits > 2) exits[2] = exit3;
 
     vm.prank(deployer);
-    __RoomCreateSystem.executeTyped(name, location, exits);
+    __RoomCreateSystem.executeTyped(location, name, "", exits);
   }
 
   function _createHarvestingNode(


### PR DESCRIPTION
a minor bug fix from #252, updates `createRoom()` in `testSetupTemplate` to fit the new system