### PR TITLE
theme consistent rainbow buttons

### DIFF
--- a/packages/client/src/layers/react/components/fixtures/Wallet.tsx
+++ b/packages/client/src/layers/react/components/fixtures/Wallet.tsx
@@ -1,7 +1,7 @@
 // src/layers/react/components/buttons/Wallet.tsx
 import React from 'react';
 import { of } from 'rxjs';
-import { ConnectButton } from '@rainbow-me/rainbowkit';
+import { AccountButton } from 'layers/react/components/library/CustomRainbowButton';
 import "@rainbow-me/rainbowkit/styles.css";
 
 import { registerUIComponent } from 'layers/react/engine/store';
@@ -18,14 +18,7 @@ export function registerWalletFixture() {
     (layers) => of(layers),
     () => {
       return (
-        <div style={{ pointerEvents: "all" }}>
-          <ConnectButton
-            label="Connect Wallet"
-            showBalance={false}
-            chainStatus="none"
-            accountStatus="address"
-          />
-        </div>
+        <AccountButton size='menu' />
       );
     },
   );

--- a/packages/client/src/layers/react/components/library/ActionButton.tsx
+++ b/packages/client/src/layers/react/components/library/ActionButton.tsx
@@ -11,7 +11,7 @@ interface Props {
   disabled?: boolean;
   fill?: boolean;
   inverted?: boolean;
-  size?: 'small' | 'medium' | 'large' | 'vending';
+  size?: 'small' | 'medium' | 'large' | 'vending' | 'menu';
 }
 
 // ActionButton is a text button that triggers an Action when clicked
@@ -47,6 +47,13 @@ export const ActionButton = (props: Props) => {
       styles.fontSize = '12px';
       styles.margin = '3px';
       styles.padding = '8px 24px';
+    } else if (size === 'menu') {
+      styles.fontSize = '10px';
+      styles.margin = '0px';
+      styles.padding = '3px 6px';
+      styles.borderRadius = '10px';
+      styles.borderWidth = '1px';
+      styles.height = '36px';
     }
 
     if (props.inverted) {

--- a/packages/client/src/layers/react/components/library/CustomRainbowButton.tsx
+++ b/packages/client/src/layers/react/components/library/CustomRainbowButton.tsx
@@ -1,0 +1,176 @@
+
+import { ConnectButton } from '@rainbow-me/rainbowkit';
+import { ActionButton } from 'layers/react/components/library/ActionButton';
+
+/*
+  * Modifies rainbowkit's ConnectButton to be use ActionButton instead
+  * copies some props from action button to allow pass through
+*/
+
+interface Props {
+  size: 'small' | 'medium' | 'large' | 'vending' | 'menu';
+  disabled?: boolean;
+  fill?: boolean;
+  inverted?: boolean;
+}
+
+export const AccountButton = (props: Props) => {
+  return (
+    <ConnectButton.Custom>
+      {({
+        account,
+        chain,
+        openAccountModal,
+        openChainModal,
+        openConnectModal,
+        authenticationStatus,
+        mounted,
+      }) => {
+        const ready = mounted && authenticationStatus !== 'loading';
+        const connected =
+          ready &&
+          account &&
+          chain &&
+          (!authenticationStatus ||
+            authenticationStatus === 'authenticated');
+
+        return (
+          <div
+            {...(!ready && {
+              'aria-hidden': true,
+              'style': {
+                opacity: 0,
+                pointerEvents: 'none',
+                userSelect: 'none',
+              },
+            })}
+          >
+            {(() => {
+              if (!connected) {
+                return (
+                  <ActionButton
+                    id='connect-button'
+                    onClick={openConnectModal}
+                    text='Connect Wallet'
+                    size={props.size}
+                    disabled={props.disabled}
+                    fill={props.fill}
+                    inverted={props.inverted}
+                  />
+                );
+              }
+
+              if (chain.unsupported) {
+                return (
+                  <ActionButton
+                    id='unsupported-chain-button'
+                    onClick={openChainModal}
+                    text="Wrong Chain"
+                    size={props.size}
+                    disabled={props.disabled}
+                    fill={props.fill}
+                    inverted={props.inverted}
+                  />
+                );
+              }
+
+              return (
+                <div style={{ display: 'flex' }}>
+                  <ActionButton
+                    id='chain-button'
+                    onClick={openAccountModal}
+                    text={account.address.substring(0, 4) + '...' + account.address.substring(38, 42)}
+                    size={props.size}
+                    disabled={props.disabled}
+                    fill={props.fill}
+                    inverted={props.inverted}
+                  />
+                </div>
+              );
+            })()}
+          </div>
+        );
+      }}
+    </ConnectButton.Custom>
+  );
+};
+
+export const ChainButton = (props: Props) => {
+  return (
+    <ConnectButton.Custom>
+      {({
+        account,
+        chain,
+        openChainModal,
+        openConnectModal,
+        authenticationStatus,
+        mounted,
+      }) => {
+        const ready = mounted && authenticationStatus !== 'loading';
+        const connected =
+          ready &&
+          account &&
+          chain &&
+          (!authenticationStatus ||
+            authenticationStatus === 'authenticated');
+
+        return (
+          <div
+            {...(!ready && {
+              'aria-hidden': true,
+              'style': {
+                opacity: 0,
+                pointerEvents: 'none',
+                userSelect: 'none',
+              },
+            })}
+          >
+            {(() => {
+              if (!connected) {
+                return (
+                  <ActionButton
+                    id='connect-button'
+                    onClick={openConnectModal}
+                    text='Wallet Disconnected'
+                    size={props.size}
+                    disabled={props.disabled}
+                    fill={props.fill}
+                    inverted={props.inverted}
+                  />
+                );
+              }
+
+              if (chain.unsupported) {
+                return (
+                  <ActionButton
+                    id='unsupported-chain-button'
+                    onClick={openChainModal}
+                    text="Change Chain"
+                    size={props.size}
+                    disabled={props.disabled}
+                    fill={props.fill}
+                    inverted={props.inverted}
+                  />
+                );
+              }
+
+              return (
+                <div style={{ display: 'flex' }}>
+                  <ActionButton
+                    id='chain-button'
+                    onClick={openChainModal}
+                    text='Change Chain'
+                    size={props.size}
+                    disabled={props.disabled}
+                    fill={props.fill}
+                    inverted={props.inverted}
+                  />
+                </div>
+              );
+            })()}
+          </div>
+        );
+      }}
+    </ConnectButton.Custom>
+  );
+};

--- a/packages/client/src/layers/react/components/validators/WalletConnector.tsx
+++ b/packages/client/src/layers/react/components/validators/WalletConnector.tsx
@@ -3,6 +3,8 @@ import { of } from 'rxjs';
 import styled, { keyframes } from 'styled-components';
 import { useAccount, useNetwork, Connector } from 'wagmi';
 
+import { ChainButton } from 'layers/react/components/library/CustomRainbowButton';
+
 import { defaultChainConfig } from 'constants/chains';
 import { createNetworkConfig } from 'layers/network/config';
 import { createNetworkLayer } from 'layers/network/createNetworkLayer';
@@ -93,6 +95,16 @@ export function registerWalletConnecter() {
         }
       };
 
+      /////////////////
+      // DISPLAY
+
+      const BottomButton = () => {
+        if (!isCorrectNetwork && isConnected) {
+          return (
+            <ChainButton size="medium" />
+          );
+        }
+      };
 
       /////////////////
       // RENDER
@@ -108,6 +120,9 @@ export function registerWalletConnecter() {
             <Title>{title}</Title>
             <Description>({status})</Description>
             <Description>{description}</Description>
+            <div style={{ display: 'flex', justifyContent: 'center' }}>
+              {BottomButton()}
+            </div>
           </ModalContent>
         </ModalWrapper>
       );


### PR DESCRIPTION
Overrides RainbowKits's `connect button` fit in the theme 

**Before**
![image](https://github.com/Asphodel-OS/kamigotchi/assets/40616911/07f78b15-1c82-41ae-9af1-6f75166c97f9)

**After**
![image](https://github.com/Asphodel-OS/kamigotchi/assets/40616911/d85c0aea-ee8e-4dc4-8fd5-0a086bf78ea7)

Also adds a button to change network when network is wrong