### PR TITLE
map modal hiding consistency

### DIFF
--- a/packages/client/src/layers/react/components/fixtures/buttons/Map.tsx
+++ b/packages/client/src/layers/react/components/fixtures/buttons/Map.tsx
@@ -18,17 +18,6 @@ export function registerMapButton() {
     (layers) => of(layers),
     () => {
       const { visibleButtons } = dataStore();
-      const modalsToHide: Partial<VisibleModals> = {
-        bridgeERC20: false,
-        bridgeERC721: false,
-        dialogue: false,
-        kami: false,
-        kamisNaming: false,
-        nameKami: false,
-        node: false,
-        merchant: false,
-        leaderboard: false,
-      };
 
       return (
         <MenuButton
@@ -36,7 +25,6 @@ export function registerMapButton() {
           targetDiv='map'
           text='Map'
           visible={visibleButtons.map}
-          hideModal={modalsToHide}
         >
           <img style={{ height: '100%', width: 'auto' }} src={mapImage} alt='map_icon' />
         </MenuButton>


### PR DESCRIPTION
small design change that gets `map` into a consistent overlay pattern with the rest of the menu modals

**Before (hides other modals on screen)**

https://github.com/Asphodel-OS/kamigotchi/assets/40616911/67c171b2-afaa-4d63-af9d-8e4b087cef80

**After (layers on top of)**

https://github.com/Asphodel-OS/kamigotchi/assets/40616911/928afa4a-d514-4454-b8ab-8d8ff41c84d7

added this because it was bothering me but open to feedback on it


