### PR TITLE
cache kami images

### DIFF
--- a/packages/contracts/src/systems/Pet721RevealSystem.sol
+++ b/packages/contracts/src/systems/Pet721RevealSystem.sol
@@ -56,7 +56,11 @@ contract Pet721RevealSystem is System {
     uint256 packed = LibPet721.reveal(world, components, petID, seed); // uses packed array to generate image off-chain
 
     string memory _baseURI = LibConfig.getValueStringOf(components, "BASE_URI");
-    LibPet.reveal(components, petID, LibString.concat(_baseURI, LibString.toString(packed)));
+    string memory uri = LibString.concat(
+      _baseURI,
+      LibString.concat(LibString.toString(packed), ".gif")
+    );
+    LibPet.reveal(components, petID, uri);
 
     return "";
   }


### PR DESCRIPTION
added `.gif` to kami's `mediaURI`

updated the [image backend server](https://github.com/Asphodel-OS/kamigotchi-backend-metadata/commit/614006e0f8a3c8106d25e2b4cf66cb41fe910393) to serve already generated images as `etag` enabled files, allowing for caching. likely need a proper load balancer and possibly ddos protection soon