### PR TITLE
add account existence check for systems

### DIFF
--- a/packages/contracts/src/systems/AccountMoveSystem.sol
+++ b/packages/contracts/src/systems/AccountMoveSystem.sol
@@ -15,6 +15,7 @@ contract AccountMoveSystem is System {
   function execute(bytes memory arguments) public returns (bytes memory) {
     uint256 to = abi.decode(arguments, (uint256));
     uint256 accountID = LibAccount.getByOperator(components, msg.sender);
+    require(accountID != 0, "AccountMoveSystem: no account");
 
     require(LibAccount.syncStamina(components, accountID) != 0, "Account: out of stamina");
     require(LibAccount.canMoveTo(components, accountID, to), "Account: unreachable location");

--- a/packages/contracts/src/systems/NodeCollectSystem.sol
+++ b/packages/contracts/src/systems/NodeCollectSystem.sol
@@ -23,6 +23,7 @@ contract NodeCollectSystem is System {
   function execute(bytes memory arguments) public returns (bytes memory) {
     uint256 nodeID = abi.decode(arguments, (uint256));
     uint256 accountID = LibAccount.getByOperator(components, msg.sender);
+    require(accountID != 0, "NodeCollectSystem: no account");
     require(
       LibAccount.getLocation(components, accountID) == LibNode.getLocation(components, nodeID),
       "Node: too far"

--- a/packages/contracts/src/systems/Pet721RevealSystem.sol
+++ b/packages/contracts/src/systems/Pet721RevealSystem.sol
@@ -23,6 +23,7 @@ contract Pet721RevealSystem is System {
 
     // checks
     uint256 accountID = LibAccount.getByOperator(components, msg.sender);
+    require(accountID != 0, "PetRevealSystem: no account");
     require(LibPet.getAccount(components, petID) == accountID, "Pet: not urs");
     require(LibPet.isUnrevealed(components, petID), "already revealed!");
 

--- a/packages/contracts/src/systems/PetFeedSystem.sol
+++ b/packages/contracts/src/systems/PetFeedSystem.sol
@@ -22,6 +22,7 @@ contract PetFeedSystem is System {
     uint256 accountID = LibAccount.getByOperator(components, msg.sender);
 
     // standard checks (ownership, cooldown, state)
+    require(accountID != 0, "PetFeed: no account");
     require(LibPet.isPet(components, id), "Pet: not a pet");
     require(LibPet.getAccount(components, id) == accountID, "Pet: not urs");
     require(LibPet.canAct(components, id), "Pet: on cooldown");

--- a/packages/contracts/src/systems/PetLevelSystem.sol
+++ b/packages/contracts/src/systems/PetLevelSystem.sol
@@ -21,6 +21,7 @@ contract PetLevelSystem is System {
     uint256 accountID = LibAccount.getByOperator(components, msg.sender);
 
     // standard checks (type check, ownership, location)
+    require(accountID != 0, "PetLevel: no account");
     require(LibPet.isPet(components, id), "PetLevel: not a pet");
     require(LibPet.getAccount(components, id) == accountID, "PetLevel: not urs");
     require(

--- a/packages/contracts/src/systems/PetNameSystem.sol
+++ b/packages/contracts/src/systems/PetNameSystem.sol
@@ -20,6 +20,7 @@ contract PetNameSystem is System {
     (uint256 id, string memory name) = abi.decode(arguments, (uint256, string));
     uint256 accountID = LibAccount.getByOperator(components, msg.sender);
 
+    require(accountID != 0, "PetName: no account");
     require(LibPet.isPet(components, id), "PetName: not a pet");
     require(LibPet.canName(components, id), "PetName: cannot named");
     require(LibPet.getAccount(components, id) == accountID, "PetName: not urs");

--- a/packages/contracts/src/systems/PetReviveSystem.sol
+++ b/packages/contracts/src/systems/PetReviveSystem.sol
@@ -21,6 +21,7 @@ contract PetReviveSystem is System {
     uint256 accountID = LibAccount.getByOperator(components, msg.sender);
 
     // standard checks (ownership, cooldown, state)
+    require(accountID != 0, "PetRevive: no account");
     require(LibPet.getAccount(components, id) == accountID, "Pet: not urs");
     require(LibPet.canAct(components, id), "Pet: on cooldown");
     require(LibPet.isDead(components, id), "Pet: must be dead");

--- a/packages/contracts/src/systems/PetSetAccountSystem.sol
+++ b/packages/contracts/src/systems/PetSetAccountSystem.sol
@@ -20,6 +20,7 @@ contract PetSetAccountSystem is System {
     (uint256 id, address to) = abi.decode(arguments, (uint256, address));
     uint256 accountID = LibAccount.getByOwner(components, msg.sender);
 
+    require(accountID != 0, "PetSetAccount: no account");
     require(LibPet.isPet(components, id), "Pet: not a pet");
     require(LibPet.getAccount(components, id) == accountID, "Pet: not urs");
 

--- a/packages/contracts/src/systems/ProductionCollectSystem.sol
+++ b/packages/contracts/src/systems/ProductionCollectSystem.sol
@@ -24,6 +24,7 @@ contract ProductionCollectSystem is System {
     uint256 petID = LibProduction.getPet(components, id);
 
     // standard checks (ownership, cooldown, state)
+    require(accountID != 0, "ProductionCollect: no account");
     require(LibPet.getAccount(components, petID) == accountID, "Pet: not urs");
     require(LibPet.canAct(components, petID), "Pet: on cooldown");
     require(LibPet.isHarvesting(components, petID), "Pet: must be harvesting");

--- a/packages/contracts/src/systems/ProductionLiquidateSystem.sol
+++ b/packages/contracts/src/systems/ProductionLiquidateSystem.sol
@@ -25,6 +25,7 @@ contract ProductionLiquidateSystem is System {
     uint256 accountID = LibAccount.getByOperator(components, msg.sender);
 
     // standard checks (ownership, cooldown, state)
+    require(accountID != 0, "ProductionLiquidate: no account");
     require(LibPet.getAccount(components, petID) == accountID, "Pet: not urs");
     require(LibPet.canAct(components, petID), "Pet: on cooldown");
     require(LibPet.isHarvesting(components, petID), "Pet: must be harvesting");

--- a/packages/contracts/src/systems/ProductionStartSystem.sol
+++ b/packages/contracts/src/systems/ProductionStartSystem.sol
@@ -24,6 +24,7 @@ contract ProductionStartSystem is System {
     uint256 accountID = LibAccount.getByOperator(components, msg.sender);
 
     // standard checks (ownership, cooldown, state)
+    require(accountID != 0, "ProductionStart: no account");
     require(LibPet.getAccount(components, petID) == accountID, "Pet: not urs");
     require(LibPet.canAct(components, petID), "Pet: on cooldown");
     require(LibPet.isResting(components, petID), "Pet: must be resting");

--- a/packages/contracts/src/systems/ProductionStopSystem.sol
+++ b/packages/contracts/src/systems/ProductionStopSystem.sol
@@ -27,6 +27,7 @@ contract ProductionStopSystem is System {
     uint256 petID = LibProduction.getPet(components, id);
 
     // standard checks (ownership, cooldown, state)
+    require(accountID != 0, "ProductionStop: no account");
     require(LibPet.getAccount(components, petID) == accountID, "Pet: not urs");
     require(LibPet.canAct(components, petID), "Pet: on cooldown");
     require(LibPet.isHarvesting(components, petID), "Pet: must be harvesting");

--- a/packages/contracts/src/systems/QuestAcceptSystem.sol
+++ b/packages/contracts/src/systems/QuestAcceptSystem.sol
@@ -19,6 +19,7 @@ contract QuestAcceptSystem is System {
     require(questID != 0, "Quest not found");
 
     uint256 accountID = LibAccount.getByOperator(components, msg.sender);
+    require(accountID != 0, "QuestAccept: no account");
 
     require(
       LibQuests.checkRequirements(components, questID, accountID),

--- a/packages/contracts/src/systems/QuestCompleteSystem.sol
+++ b/packages/contracts/src/systems/QuestCompleteSystem.sol
@@ -16,6 +16,7 @@ contract QuestCompleteSystem is System {
     uint256 questID = abi.decode(arguments, (uint256));
     uint256 accountID = LibAccount.getByOperator(components, msg.sender);
 
+    require(accountID != 0, "QuestComplete: no account");
     require(accountID == LibQuests.getAccountId(components, questID), "QuestComplete: not account");
     require(LibQuests.isQuest(components, questID), "QuestComplete: not a quest");
     require(

--- a/packages/contracts/src/systems/TradeAcceptSystem.sol
+++ b/packages/contracts/src/systems/TradeAcceptSystem.sol
@@ -16,6 +16,7 @@ contract TradeAcceptSystem is System {
   function execute(bytes memory arguments) public returns (bytes memory) {
     uint256 tradeID = abi.decode(arguments, (uint256));
     uint256 accountID = LibAccount.getByOperator(components, msg.sender);
+    require(accountID != 0, "TradeAccept: no account");
 
     // requirements
     // TODO: add same room check once disabling of room switching enforced on FE

--- a/packages/contracts/src/systems/TradeAddToSystem.sol
+++ b/packages/contracts/src/systems/TradeAddToSystem.sol
@@ -20,6 +20,7 @@ contract TradeAddToSystem is System {
       (uint256, uint256, uint256)
     );
     uint256 accountID = LibAccount.getByOperator(components, msg.sender);
+    require(accountID != 0, "TradeAddTo: no account");
 
     // requirements
     // TODO: add same room check once disabling of room switching enforced on FE

--- a/packages/contracts/src/systems/TradeCancelSystem.sol
+++ b/packages/contracts/src/systems/TradeCancelSystem.sol
@@ -19,6 +19,7 @@ contract TradeCancelSystem is System {
 
     // requirements
     // TODO: add same room check once disabling of room switching enforced on FE
+    require(accountID != 0, "TradeCancel: no account");
     require(LibTrade.isTrade(components, tradeID), "Trade: not a trade");
     require(LibTrade.hasParticipant(components, tradeID, accountID), "Trade: must be participant");
     require(!LibTrade.hasState(components, tradeID, "CANCELED"), "Trade: already canceled");

--- a/packages/contracts/src/systems/TradeConfirmSystem.sol
+++ b/packages/contracts/src/systems/TradeConfirmSystem.sol
@@ -20,6 +20,7 @@ contract TradeConfirmSystem is System {
 
     // requirements
     // TODO: add same room check once disabling of room switching enforced on FE
+    require(accountID != 0, "TradeConfirm: no account");
     require(LibTrade.isTrade(components, tradeID), "Trade: not a trade");
     require(LibTrade.hasParticipant(components, tradeID, accountID), "Trade: must be participant");
     require(LibTrade.hasState(components, tradeID, "ACCEPTED"), "Trade: must be accepted");

--- a/packages/contracts/src/systems/TradeInitiateSystem.sol
+++ b/packages/contracts/src/systems/TradeInitiateSystem.sol
@@ -18,6 +18,7 @@ contract TradeInitiateSystem is System {
     uint256 accountID = LibAccount.getByOperator(components, msg.sender);
 
     // requirements
+    require(accountID != 0, "TradeInitiate: no account");
     require(accountID != toID, "Trade: no self-trade !!");
     require(LibTrade.canTrade(components, accountID, toID), "Trade: must be in same room");
     require(LibTrade.getRequest(components, accountID, toID) == 0, "Trade: request exists");


### PR DESCRIPTION
requires accounts to exist for systems. we missed this check for many systems, and its quite crucial – wondering if its worth implementing this in the library directly