### PR TITLE
deployment checkpoint

### DIFF
--- a/packages/client/src/layers/network/config.ts
+++ b/packages/client/src/layers/network/config.ts
@@ -138,6 +138,7 @@ function createNetworkConfigLattice(externalProvider?: ExternalProvider): Networ
 
     // checkpointUrl: undefined,
     chainId: 4242,
+    // last depolyment update: 7 Sep 2023
     worldAddress: "0xe29DAb7C4d2ade77e99A57FD0aaFd4d03038e4A3",
     initialBlockNumber: 20740208,
   };


### PR DESCRIPTION
updated the deployment to include new components. world address itself hasn't changed, but using this pull as a checkpoint to more easily compare new component changes in the future