### PR TITLE
premature error fix

### DIFF
--- a/packages/client/src/layers/network/ActionSystem/createActionSystem.ts
+++ b/packages/client/src/layers/network/ActionSystem/createActionSystem.ts
@@ -157,19 +157,19 @@ export function createActionSystem<M = undefined>(world: World, txReduced$: Obse
     try {
       // Execute the action
       const tx = await action.execute(requirementResult);
-
-      // If the result includes a hash key (single tx) or hashes (multiple tx) key, wait for the transactions to complete before removing the pending actions
+      console.log("trying")
       if (tx) {
+        console.log("has tx reciept")
         // Wait for all tx events to be reduced
         updateComponent(Action, action.entityIndex, { state: ActionState.WaitingForTxEvents, txHash: tx.hash });
-        const txConfirmed = tx.wait().catch((e) => handleError(e, action)); // Also catch the error if not awaiting
         await awaitStreamValue(txReduced$, (v) => v === tx.hash);
         updateComponent(Action, action.entityIndex, { state: ActionState.TxReduced });
-        if (action.awaitConfirmation) await txConfirmed;
+        if (action.awaitConfirmation) await tx.wait();
       }
 
       updateComponent(Action, action.entityIndex, { state: ActionState.Complete });
     } catch (e) {
+      console.log("catching")
       handleError(e, action);
     }
 
@@ -179,6 +179,7 @@ export function createActionSystem<M = undefined>(world: World, txReduced$: Obse
 
   // Set the action's state to ActionState.Failed
   function handleError(error: any, action: ActionData) {
+    console.log('handle error')
     // console.log(error.reason);
     updateComponent(Action, action.entityIndex, { metadata: error.reason });
     updateComponent(Action, action.entityIndex, { state: ActionState.Failed });


### PR DESCRIPTION
one of the more cursed fixes, unfortunately. one of those _removed error by removing the check_

`tx.wait()` looks bugged on certain chains. refer to https://github.com/ethers-io/ethers.js/issues/945 – there are multiple issues in this thread, but all kind of lumped together. The issue we're facing is where the tx is mined, but `tx.wait()` doesn't still resolve/doesn't exist. i suspect this is likely some low level interaction betweeen ethersjs, the rpc, and possibly made worse with a testnet chain. 

opting to remove it because 
1. its an unfixable bug on our end imo
2. it doesn't actually do anything – we already wait for the `tx.hash` to resolve, which is basically what `tx.wait()` is for. 