### PR TITLE
tx bug bandaid

### DIFF
--- a/packages/client/src/layers/network/ActionSystem/createActionSystem.ts
+++ b/packages/client/src/layers/network/ActionSystem/createActionSystem.ts
@@ -162,7 +162,8 @@ export function createActionSystem<M = undefined>(world: World, txReduced$: Obse
       if (tx) {
         // Wait for all tx events to be reduced
         updateComponent(Action, action.entityIndex, { state: ActionState.WaitingForTxEvents, txHash: tx.hash });
-        const txConfirmed = tx.wait().catch((e) => handleError(e, action)); // Also catch the error if not awaiting
+        // console.log(tx);
+        const txConfirmed = tx.wait(1).catch((e) => handleError(e, action)); // Also catch the error if not awaiting
         await awaitStreamValue(txReduced$, (v) => v === tx.hash);
         updateComponent(Action, action.entityIndex, { state: ActionState.TxReduced });
         if (action.awaitConfirmation) await txConfirmed;
@@ -179,7 +180,6 @@ export function createActionSystem<M = undefined>(world: World, txReduced$: Obse
 
   // Set the action's state to ActionState.Failed
   function handleError(error: any, action: ActionData) {
-    // console.log(error.reason);
     updateComponent(Action, action.entityIndex, { metadata: error.reason });
     updateComponent(Action, action.entityIndex, { state: ActionState.Failed });
     remove(action.id);


### PR DESCRIPTION
- bandaid, `tx.wait()` -> `tx.wait(1)` helps a little by forcing a little wait
- will prevent infinite pending bug, but show premature errors