### PR TITLE
enable foundry gas reports

### DIFF
--- a/packages/contracts/foundry.toml
+++ b/packages/contracts/foundry.toml
@@ -8,3 +8,4 @@ out = "out"
 solc = "0.8.17"
 src = "src"
 verbosity = 1
+gas_reports = ["*"]


### PR DESCRIPTION
a tiny, tiny one line change. allows us to look at gas report estimates with `yarn mud test --forgeOpts=--gas-report`