### PR TITLE
fix random roll shift

### DIFF
--- a/packages/contracts/src/libraries/LibRandom.sol
+++ b/packages/contracts/src/libraries/LibRandom.sol
@@ -62,9 +62,6 @@ library LibRandom {
     }
 
     return keys[_positionFromWeighted(weights, totalWeight, randN)];
-
-    // should never get here
-    revert("LibRandom: no item found");
   }
 
   // @notice picks multiple results from weighted array
@@ -116,7 +113,7 @@ library LibRandom {
     uint256 currentWeight;
     for (uint256 i; i < weights.length; i++) {
       currentWeight += weights[i];
-      if (roll <= currentWeight) {
+      if (roll < currentWeight) {
         return (i);
       }
     }


### PR DESCRIPTION
fixes the shifted-by-one random rolling issue
also clears out some unreachable code

will require an update of any systems using random rolling:
- `Pet721RevealSystem`
- `LootboxExecuteRevealSystem`

these redeployments aren't urgent as this only becomes an issue after launch 