### PR TITLE
redeploy some systems

### DIFF
--- a/packages/contracts/deploy-archive/deployHistory.json
+++ b/packages/contracts/deploy-archive/deployHistory.json
@@ -1,5 +1,8 @@
 {
-  "last deployed": "31st October 2023",
+  "last deployed": "7th November 2023",
+  "undeployed": [
+    "TimelockComponent"
+  ],
   "components": [
     "AddressOperatorComponent",
     "AddressOwnerComponent",
@@ -674,14 +677,14 @@
       "writeAccess": []
     },
     {
-      "last deployed": "20th October 2023",
+      "last deployed": "7th November 2023",
       "name": "Pet721MintSystem",
       "writeAccess": [
         "*"
       ]
     },
     {
-      "last deployed": "20th October 2023",
+      "last deployed": "7th November 2023",
       "name": "Pet721RevealSystem",
       "writeAccess": [
         "*"
@@ -735,7 +738,7 @@
       ]
     },
     {
-      "last deployed": "20th October 2023",
+      "last deployed": "7th November 2023",
       "name": "PetFeedSystem",
       "writeAccess": [
         "BalanceComponent",
@@ -754,7 +757,7 @@
       ]
     },
     {
-      "last deployed": "28th October 2023",
+      "last deployed": "7th November 2023",
       "name": "PetLevelSystem",
       "writeAccess": [
         "BlockLastComponent",
@@ -769,7 +772,7 @@
       ]
     },
     {
-      "last deployed": "20th October 2023",
+      "last deployed": "7th November 2023",
       "name": "PetNameSystem",
       "writeAccess": [
         "BlockLastComponent",
@@ -801,7 +804,7 @@
       ]
     },
     {
-      "last deployed": "20th October 2023",
+      "last deployed": "7th November 2023",
       "name": "ProductionCollectSystem",
       "writeAccess": [
         "BalanceComponent",
@@ -821,7 +824,7 @@
       ]
     },
     {
-      "last deployed": "20th October 2023",
+      "last deployed": "7th November 2023",
       "name": "ProductionLiquidateSystem",
       "writeAccess": [
         "BalanceComponent",
@@ -846,7 +849,7 @@
       ]
     },
     {
-      "last deployed": "20th October 2023",
+      "last deployed": "7th November 2023",
       "name": "ProductionStartSystem",
       "writeAccess": [
         "IsProductionComponent",
@@ -861,7 +864,7 @@
       ]
     },
     {
-      "last deployed": "20th October 2023",
+      "last deployed": "7th November 2023",
       "name": "ProductionStopSystem",
       "writeAccess": [
         "BalanceComponent",
@@ -935,7 +938,7 @@
       ]
     },
     {
-      "last deployed": "28th October 2023",
+      "last deployed": "7th November 2023",
       "name": "SkillUpgradeSystem",
       "writeAccess": [
         "BlockLastComponent",

--- a/packages/contracts/src/libraries/LibProduction.sol
+++ b/packages/contracts/src/libraries/LibProduction.sol
@@ -90,7 +90,12 @@ library LibProduction {
 
   // Calculate the duration since a production last started, measured in seconds.
   function calcDuration(IUintComp components, uint256 id) internal view returns (uint256) {
-    return block.timestamp - getStartTime(components, id);
+    uint256 startTime = getStartTime(components, id);
+    if (startTime == 0) {
+      uint256 petID = getPet(components, id);
+      startTime = LibPet.getLastTs(components, petID);
+    }
+    return block.timestamp - startTime;
   }
 
   // Calculate the accrued output of the production since the pet's last snapshot
@@ -226,6 +231,7 @@ library LibProduction {
   }
 
   function getStartTime(IUintComp components, uint256 id) internal view returns (uint256) {
+    if (!TimeStartComponent(getAddressById(components, TimeStartCompID)).has(id)) return 0;
     return TimeStartComponent(getAddressById(components, TimeStartCompID)).getValue(id);
   }
 


### PR DESCRIPTION
redeployment of the following systems:
- PetFeedSystem
- PetLevelSystem
- PetNameSystem
- ProductionCollectSystem
- ProductionLiquidateSystem
- ProductionStartSystem
- ProductionStopSystem
- SkillUpgradeSystem
- Pet721MintSystem
- Pet721RevealSysem
- LootboxExecuteRevealSystem

following bug fixes and refinements:
- don't heal kamis to full on level up 
- separate kami ts and production ts
- resync kami/production on skill upgrades
- fix off-by-1 random rolling

this also introduces some workaround logic to prevent currently active productions from
breaking upon interaction. this occurs because currently active productions rely on the kami's
ts and don't maintain a timestamp of their own. as a result, this causes an contract-level
breakage whenever a user attempts to sync the kami, while a production is already active.
we'll want to remove this logic at a later date.

this also introduces a new field on `deployHistory.json` to track unregistered components as
they're challenging to identify from simply scanning the list of 100+ components we currently
have actively registered with the world

[postmortem](https://www.notion.so/System-Deployment-November-7th-05c2f1af2fd24b0c982d085d55cab363?pvs=4)