### PR TITLE
persist sound settings on refresh

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -53,6 +53,7 @@
     "@protobuf-ts/grpcweb-transport": "^2.7.0",
     "@rainbow-me/rainbowkit": "^1.0.0",
     "@stdlib/stats-base-dists-normal-cdf": "^0.0.7",
+    "@uidotdev/usehooks": "^2.4.1",
     "antd": "^5.4.3",
     "async-mutex": "^0.3.2",
     "ethers": "^5",

--- a/packages/client/src/layers/react/components/modals/settings/Sound.tsx
+++ b/packages/client/src/layers/react/components/modals/settings/Sound.tsx
@@ -1,13 +1,20 @@
+import { useEffect } from "react";
+import { useLocalStorage } from "usehooks-ts";
 import styled from "styled-components";
 
-import mutedSoundImage from 'src/assets/images/icons/sound_muted_native.png';
-import soundImage from 'src/assets/images/icons/sound_native.png';
+import mutedSoundImage from 'assets/images/icons/sound_muted_native.png';
+import soundImage from 'assets/images/icons/sound_native.png';
 import { useSoundSettings } from "layers/react/store/soundSettings";
 import { playClick } from "utils/sounds";
 
 
 export const Sound = () => {
-  const { volumeFX, volumeMusic, setVolumeFX, setVolumeMusic } = useSoundSettings();
+  const [volumeFX, setVolumeFX] = useLocalStorage('volumeFX', .5);
+  const [volumeMusic, setVolumeMusic] = useLocalStorage('volumeMusic', .5);
+
+  useEffect(() => {
+    useSoundSettings.setState({ volumeFX, volumeMusic });
+  }, [volumeFX, volumeMusic]);
 
   const toggleVolume = (type: string) => {
     let volume = (type === 'fx') ? volumeFX : volumeMusic;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3523,6 +3523,11 @@
     "@typescript-eslint/types" "5.51.0"
     eslint-visitor-keys "^3.3.0"
 
+"@uidotdev/usehooks@^2.4.1":
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/@uidotdev/usehooks/-/usehooks-2.4.1.tgz#4b733eaeae09a7be143c6c9ca158b56cc1ea75bf"
+  integrity sha512-1I+RwWyS+kdv3Mv0Vmc+p0dPYH0DTRAo04HLyXReYBL9AeseDWUJyi4THuksBJcu9F0Pih69Ak150VDnqbVnXg==
+
 "@use-gesture/core@10.2.9":
   version "10.2.9"
   resolved "https://registry.yarnpkg.com/@use-gesture/core/-/core-10.2.9.tgz#51eb2a12747c750dd0ac60af48fb7653382cf58a"


### PR DESCRIPTION
we use local storage to persist updates to sound settings between refreshes.
we keep the `SoundSettings` zustand store because it exposes `.getState()`
functions we can use outside of react component declarations (e.g. GameScene)