### PR TITLE
add corner coloring to indicate button w dropdown

### DIFF
--- a/packages/client/src/layers/react/components/library/IconListButton.tsx
+++ b/packages/client/src/layers/react/components/library/IconListButton.tsx
@@ -69,6 +69,7 @@ export function IconListButton(props: Props) {
         onClick={handleClick}
         style={setStyles()}
       >
+        <Corner />
         <Image src={props.img} />
       </Button>
       <Popover
@@ -79,9 +80,7 @@ export function IconListButton(props: Props) {
         anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
       >
         <Menu>
-          {props.options.map((option, i) => (
-            element(option, i)
-          ))}
+          {props.options.map((option, i) => element(option, i))}
         </Menu>
       </Popover>
     </div>
@@ -89,6 +88,7 @@ export function IconListButton(props: Props) {
 }
 
 const Button = styled.button`
+  position: relative;
   background-color: #fff;
   border: solid black .12vw;
   border-radius: .4vw;
@@ -112,6 +112,16 @@ const Button = styled.button`
   &:active {
     background-color: #bbb;
   }
+`;
+
+const Corner = styled.div`
+  position: absolute;
+  border: solid black .3vw;
+  border-color: transparent black black transparent;
+  right: 0;
+  bottom: 0;
+  width: 0;
+  height: 0;
 `;
 
 const Image = styled.img`


### PR DESCRIPTION
there is no visual distinction between the two atm until a button is interacted
with. this should make it clear which is which

![Screen Shot 2023-11-16 at 2 13 25 PM](https://github.com/Asphodel-OS/kamigotchi/assets/109483360/88d14754-55e3-4871-b019-58919dfa3ae4)
