### PR TITLE
fix button sizes for validators

### DIFF
--- a/packages/client/src/layers/react/components/validators/AccountRegistrar.tsx
+++ b/packages/client/src/layers/react/components/validators/AccountRegistrar.tsx
@@ -299,6 +299,7 @@ export function registerAccountRegistrar() {
           id='next'
           text='Next'
           onClick={() => setStep(step + 1)}
+          size='vending'
         />
       );
 
@@ -308,6 +309,7 @@ export function registerAccountRegistrar() {
           text='Back'
           disabled={step === 0}
           onClick={() => setStep(step - 1)}
+          size='vending'
         />
       );
 
@@ -349,6 +351,7 @@ export function registerAccountRegistrar() {
               text='Next'
               onClick={() => setStep(step + 1)}
               disabled={addressTaken || name === '' || nameTaken}
+              size='vending'
             />
           );
 
@@ -404,6 +407,7 @@ export function registerAccountRegistrar() {
                   text='Submit'
                   disabled={food === ''}
                   onClick={() => handleAccountCreation(name, food)}
+                  size='vending'
                 />
               </Tooltip>
             </Row>

--- a/packages/client/src/layers/react/components/validators/GasHarasser.tsx
+++ b/packages/client/src/layers/react/components/validators/GasHarasser.tsx
@@ -130,11 +130,11 @@ export function registerGasHarasser() {
         <ValidatorWrapper
           id='gas-harasser'
           divName='gasHarasser'
-          title='Feed Your Operator'
-          errorPrimary='Operator is EMPTY and STARVING'
+          title='Feed Your Avatar'
+          errorPrimary='Avatar is EMPTY and STARVING'
           errorSecondary={`You're lucky we don't report you to the authorities..`}
         >
-          <Description>Account Operator: {account.operatorAddress}</Description>
+          <Description>Account Avatar: {account.operatorAddress}</Description>
           <br />
           <Row>
             <Input

--- a/packages/client/src/layers/react/components/validators/OperatorUpdater.tsx
+++ b/packages/client/src/layers/react/components/validators/OperatorUpdater.tsx
@@ -166,6 +166,7 @@ export function registerOperatorUpdater() {
               id={`generate`}
               text={`I'm feeling Lucky`}
               onClick={() => setValue(generatePrivateKey())}
+              size='vending'
             />
           </Tooltip>
         );
@@ -177,6 +178,7 @@ export function registerOperatorUpdater() {
               text='Use connected one'
               onClick={() => setValue(burner.connected.address)}
               disabled={operatorTaken}
+              size='vending'
             />
           );
           if (operatorTaken) {
@@ -223,7 +225,7 @@ export function registerOperatorUpdater() {
           </InputContainer>
           <Row>
             <SupportButton />
-            <ActionButton id={`submit`} text='Submit' onClick={submit} />
+            <ActionButton id={`submit`} text='Submit' onClick={submit} size='vending' />
           </Row>
         </ValidatorWrapper>
       );


### PR DESCRIPTION
uses the fixed 'vending' size option now so it stays consistent in sizing like the rest of the Fixture elements

![Screen Shot 2023-11-22 at 3 15 21 AM](https://github.com/Asphodel-OS/kamigotchi/assets/109483360/fd3522da-99a9-4d4c-9957-29f5da406c0b)
