### PR TITLE
Fix Skill Tests

### DIFF
--- a/packages/contracts/src/libraries/LibSkill.sol
+++ b/packages/contracts/src/libraries/LibSkill.sol
@@ -42,7 +42,7 @@ library LibSkill {
     return id;
   }
 
-  // increase skill points by a specified value
+  // increase skill points of a skill by a specified value
   function inc(IUintComp components, uint256 id, uint256 value) internal {
     uint256 curr = getPoints(components, id);
     setPoints(components, id, curr + value);
@@ -55,14 +55,39 @@ library LibSkill {
     setPoints(components, id, curr - value);
   }
 
-  // process the upgrade of a generic skill inc/dec effect
+  // process the upgrade of a skill (can be generic or stat skill)
   function processEffectUpgrade(
+    IWorld world,
     IUintComp components,
     uint256 holderID,
-    uint256 effectID,
-    string memory type_
+    uint256 effectID
   ) internal {
-    uint256 bonusID = LibBonus.get(components, holderID, type_);
+    if (LibString.eq("STAT", LibRegistrySkill.getType(components, effectID))) {
+      processStatEffectUpgrade(world, components, holderID, effectID);
+    } else {
+      processGeneralEffectUpgrade(world, components, holderID, effectID);
+    }
+  }
+
+  // process the upgrade of a generic skill inc/dec effect
+  function processGeneralEffectUpgrade(
+    IWorld world,
+    IUintComp components,
+    uint256 holderID,
+    uint256 effectID
+  ) internal {
+    string memory type_ = LibRegistrySkill.getType(components, effectID);
+    string memory subtype = LibRegistrySkill.getSubtype(components, effectID);
+    string memory bonusType = LibString.concat(LibString.concat(type_, "_"), subtype);
+
+    // get the bonus entity or create one if it doesnt exist
+    // default the initial value to 0 if Cooldown type (otherwise 1000 implicitly)
+    uint256 bonusID = LibBonus.get(components, holderID, bonusType);
+    if (bonusID == 0) {
+      bonusID = LibBonus.create(world, components, holderID, bonusType);
+      if (LibString.eq("COOLDOWN", subtype)) LibBonus.setValue(components, bonusID, 0);
+    }
+
     string memory logicType = LibRegistrySkill.getLogicType(components, effectID);
     uint256 value = LibRegistrySkill.getValue(components, effectID);
 
@@ -73,11 +98,14 @@ library LibSkill {
   // processes the upgrade of a stat increment/decrement effect
   // assume the holder's bonus entity exists
   function processStatEffectUpgrade(
+    IWorld world,
     IUintComp components,
     uint256 holderID,
     uint256 effectID
   ) internal {
     uint256 bonusID = LibBonus.get(components, holderID, "STAT");
+    if (bonusID == 0) bonusID = LibBonus.create(world, components, holderID, "STAT");
+
     string memory subtype = LibRegistrySkill.getSubtype(components, effectID);
     string memory logicType = LibRegistrySkill.getLogicType(components, effectID);
     uint256 value = LibRegistrySkill.getValue(components, effectID);

--- a/packages/contracts/src/systems/SkillUpgradeSystem.sol
+++ b/packages/contracts/src/systems/SkillUpgradeSystem.sol
@@ -18,7 +18,7 @@ contract SkillUpgradeSystem is System {
   constructor(IWorld _world, address _components) System(_world, _components) {}
 
   function execute(bytes memory arguments) public returns (bytes memory) {
-    (uint256 id, uint256 skillIndex) = abi.decode(arguments, (uint256, uint256));
+    (uint256 holderID, uint256 skillIndex) = abi.decode(arguments, (uint256, uint256));
     uint256 accountID = LibAccount.getByOperator(components, msg.sender);
 
     // check that the skill exists
@@ -26,79 +26,55 @@ contract SkillUpgradeSystem is System {
     require(registryID != 0, "SkillUpgrade: skill not found");
 
     // entity type check
-    bool isPet = LibPet.isPet(components, id);
-    bool isAccount = LibAccount.isAccount(components, id);
+    bool isPet = LibPet.isPet(components, holderID);
+    bool isAccount = LibAccount.isAccount(components, holderID);
     require(isPet || isAccount, "SkillUpgrade: invalid target");
 
     // generic requirements
     if (isAccount) {
-      require(accountID == id, "SkillUpgrade: not ur account");
+      require(accountID == holderID, "SkillUpgrade: not ur account");
     } else if (isPet) {
-      require(accountID == LibPet.getAccount(components, id), "SkillUpgrade: not ur pet");
+      require(accountID == LibPet.getAccount(components, holderID), "SkillUpgrade: not ur pet");
       require(
-        LibPet.getLocation(components, id) == LibAccount.getLocation(components, accountID),
+        LibPet.getLocation(components, holderID) == LibAccount.getLocation(components, accountID),
         "SkillUpgrade: must be in same room"
       );
 
       // NOTE: we don't block skill upgrading by cooldown time or pet status
       // but we need to sync in advance to get accurate historical output
-      LibPet.sync(components, id);
+      LibPet.sync(components, holderID);
     }
 
     // points are decremented when checking prerequisites
     require(
-      LibSkill.meetsPrerequisites(components, id, registryID),
+      LibSkill.meetsPrerequisites(components, holderID, registryID),
       "SkillUpgrade: unmet prerequisites"
     );
 
     // decrement the skill cost
     uint256 cost = LibRegistrySkill.getCost(components, registryID);
-    LibSkill.dec(components, id, cost);
+    LibSkill.dec(components, holderID, cost);
 
     // create the skill if it doesnt exist and increment it
-    uint256 skillID = LibSkill.get(components, id, skillIndex);
-    if (skillID == 0) skillID = LibSkill.create(world, components, id, skillIndex);
+    uint256 skillID = LibSkill.get(components, holderID, skillIndex);
+    if (skillID == 0) skillID = LibSkill.create(world, components, holderID, skillIndex);
     LibSkill.inc(components, skillID, 1);
 
-    // get the skill's effects. for any stat effects update the holder's bonus
-    uint256 bonusID;
-    string memory type_;
-    string memory subtype;
+    // get the skill's effects and update the holder's bonuses accordingly
     uint256[] memory effectIDs = LibRegistrySkill.getEffectsByIndex(components, skillIndex);
     for (uint256 i = 0; i < effectIDs.length; i++) {
-      // determine the type of the Bonus entity to be affected
-      type_ = LibRegistrySkill.getType(components, effectIDs[i]);
-      subtype = LibRegistrySkill.getSubtype(components, effectIDs[i]);
-      if (!LibString.eq("STAT", type_)) {
-        type_ = LibString.concat(type_, "_");
-        type_ = LibString.concat(type_, subtype);
-      }
-
-      // get the bonus entity or create one if it doesnt exist
-      // default the initial value of new Bonus to 0 if Cooldown type
-      bonusID = LibBonus.get(components, id, type_);
-      if (bonusID == 0) {
-        bonusID = LibBonus.create(world, components, id, type_);
-        if (LibString.eq("COOLDOWN", subtype)) LibBonus.setValue(components, bonusID, 0);
-      }
-
-      // update the appropriate bonus entity
-      if (LibString.eq("STAT", type_)) {
-        LibSkill.processStatEffectUpgrade(components, id, effectIDs[i]);
-      } else {
-        LibSkill.processEffectUpgrade(components, id, effectIDs[i], type_);
-      }
+      LibSkill.processEffectUpgrade(world, components, holderID, effectIDs[i]);
     }
 
     // NOTE: we sync the pet a second time here, because the updated Production Rate
     // informs the FE. it's gas inefficient, but it keeps the code sane up there.
     // Can consider wiping once the calculations are mirrored on the FE.
-    LibPet.sync(components, id);
+    if (isPet) LibPet.sync(components, holderID);
     LibAccount.updateLastBlock(components, accountID);
     return "";
   }
 
-  function executeTyped(uint256 id, uint256 skillIndex) public returns (bytes memory) {
-    return execute(abi.encode(id, skillIndex));
+  function executeTyped(uint256 holderID, uint256 skillIndex) public returns (bytes memory) {
+    return execute(abi.encode(holderID, skillIndex));
   }
 }

--- a/packages/contracts/src/test/systems/Skill.t.sol
+++ b/packages/contracts/src/test/systems/Skill.t.sol
@@ -6,30 +6,23 @@ import "test/utils/SetupTemplate.s.sol";
 contract SkillTest is SetupTemplate {
   function setUp() public override {
     super.setUp();
+    _registerAccount(0);
   }
 
+  // test whether skill upgrades are properly gated by skill point availability
   function testSkillBasicAccount() public {
-    // create skill
-    _createSkill(1, "ACCOUNT", "PASSIVE", "TEST_SKILL", 0, 1, "test skill description");
-
-    // register the account
-    _registerAccount(0);
     uint256 accountID = _getAccount(0);
+    _createSkill(1, "ACCOUNT", "PASSIVE", "TEST_SKILL", 0, 1, "test skill description");
 
     // select skill
     _upgradeSkill(0, accountID, 1);
-
-    // check if skills are added
     assertTrue(LibSkill.get(components, accountID, 1) != 0);
   }
 
-  function testUseSkillPoints() public {
-    // create skill
-    _createSkill(1, "ACCOUNT", "PASSIVE", "TEST_SKILL", 1, 1, "test skill description");
-
-    // register the account
-    _registerAccount(0);
+  // test whether skill upgrades are properly gated by skill point availability
+  function testSkillPoints() public {
     uint256 accountID = _getAccount(0);
+    _createSkill(1, "ACCOUNT", "PASSIVE", "TEST_SKILL", 1, 1, "test skill description");
 
     // select skill (fail - no points)
     vm.prank(_getOperator(0));
@@ -45,18 +38,12 @@ contract SkillTest is SetupTemplate {
     assertEq(LibSkill.getPoints(components, accountID), 0);
   }
 
+  // test whether skill upgrades are properly gated by skill cap
   function testSkillMax() public {
-    // create skill
+    uint256 accountID = _getAccount(0);
     _createSkill(1, "ACCOUNT", "PASSIVE", "TEST_SKILL", 0, 2, "test skill description");
 
-    // register the account
-    _registerAccount(0);
-    uint256 accountID = _getAccount(0);
-
-    // accept x1
     _upgradeSkill(0, accountID, 1);
-
-    // accept x2
     _upgradeSkill(0, accountID, 1);
 
     // accept x3 (expect fail)

--- a/packages/contracts/src/test/utils/SetupTemplate.s.sol
+++ b/packages/contracts/src/test/utils/SetupTemplate.s.sol
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import { Deploy } from "test/Deploy.sol";
+import "forge-std/console.sol";
+import { LibString } from "solady/utils/LibString.sol";
 import "std-contracts/test/MudTest.t.sol";
 
-import "forge-std/console.sol";
-
-import { LibString } from "solady/utils/LibString.sol";
+import { Deploy } from "test/Deploy.sol";
 import "./TestSetupImports.sol";
 
 abstract contract SetupTemplate is TestSetupImports {


### PR DESCRIPTION
Includes a refactoring of the logic found in
`SkillUpgradeSystem` for a cleaner abstraction of logic.
We should probably split this system into two down the line
(one for Account, one for Pet) as the two appreciate
different sets of logic, even if similar.
