### PR TITLE
fix: burner mismatch false trigger on leading zeroes

### DIFF
--- a/packages/client/src/layers/react/components/validators/BurnerDetector.tsx
+++ b/packages/client/src/layers/react/components/validators/BurnerDetector.tsx
@@ -35,7 +35,7 @@ export function registerBurnerDetector() {
         OwnerAddress.update$
       ).pipe(
         map(() => {
-          const connectedEOA = network.connectedAddress.get();
+          const connectedEOA = network.connectedAddress.get() ?? '';
           return {
             connectedEOA,
             network: layers.network.network,
@@ -62,7 +62,7 @@ export function registerBurnerDetector() {
         const detectedEOA = getAddressFromPrivateKey(detectedPrivateKey);
         setDetectedAddress(detectedEOA);
 
-        const burnerMatches = (connectedEOA === detectedEOA);
+        const burnerMatches = (parseInt(connectedEOA, 16) === parseInt(detectedEOA, 16));
         setBurnerMatches(burnerMatches);
 
         if (!detectedPrivateKey) {
@@ -77,7 +77,7 @@ export function registerBurnerDetector() {
         }
 
         setBurner({
-          connected: { address: connectedEOA ?? '' },
+          connected: { address: connectedEOA },
           detected: {
             address: detectedEOA,
             key: detectedPrivateKey,


### PR DESCRIPTION
when the address has 2 or more leading zeroes we truncate the prefix on the
hex string. this causes issues when comparing the address hex strings to
determine a match between the connected vs detected burner

i'm not going to mine private keys to try and land another double-zero burner,
but i assume converting them to numbers before comparing them would fix it

<img width="802" alt="Screen Shot 2024-01-24 at 1 11 07 AM" src="https://github.com/Asphodel-OS/kamigotchi/assets/109483360/d288bc98-1189-4e05-9c41-9ae31a13e549">
