### PR TITLE
Environment mode override option (through url params)

### DIFF
--- a/packages/client/src/constants/chains.ts
+++ b/packages/client/src/constants/chains.ts
@@ -62,7 +62,7 @@ const opSepolia: Chain = {
 };
 
 // object mapping between environment MODEs and chain configs
-const chainConfigs: Map<string, Chain> = new Map([
+export const chainConfigs: Map<string, Chain> = new Map([
   ['', localhost],  // default to localhost when no environment mode provided
   ['DEV', localhost],
   ['TEST', opSepolia],
@@ -76,17 +76,7 @@ const getDefaultChainConfig = () => {
   const urlParams = new URLSearchParams(window.location.search);
   const mode = urlParams.get('mode');
   if (!mode) return chainConfigs.get(process.env.MODE ?? '');
-
-  if (chainConfigs.has(mode)) {
-    console.log(`Environment mode override ${mode} detected.`);
-    return chainConfigs.get(mode);
-  } else {
-    console.warn(
-      `No chain config found for mode '${mode}'.\n`,
-      `Must be one of [${Array.from(chainConfigs.keys()).join(' | ')}].\n`,
-      `Defaulting to DEV (localhost).`
-    );
-  }
+  if (chainConfigs.has(mode)) return chainConfigs.get(mode);
   return localhost;
 }
 

--- a/packages/client/src/layers/react/engine/Engine.tsx
+++ b/packages/client/src/layers/react/engine/Engine.tsx
@@ -40,7 +40,7 @@ export const Engine: React.FC<{
   useEffect(() => {
     mountReact.current = (mounted: boolean) => setMounted(mounted);
     setLayers.current = (layers: Layers) => _setLayers(layers);
-    console.log(`LOADED IN ${process.env.MODE ?? "DEV"} MODE (chain ${defaultChain.id})`);
+    console.log(`LOADING (chain ${defaultChain.id})`);
   }, []);
 
   if (!mounted || !layers) return <BootScreen />;


### PR DESCRIPTION
allows us to override the network the client is connected to based on url params. any
options provided by the `chainConfigs` map in our `constants/chains.ts` file are
considered valid (i.e. `kamigotchi.io/?mode=[ DEV | TEST | PROD ]`)

it's a bit messy atm,, as the code relies on both logic found in `chains.ts` as well as
logic found in `network/config.ts` as the "source of truth". this logical flow needs to 
be consolidated down the line, so that the clientside `Validators` strictly rely on info
accessed through the network object

behavior:
- if valid override provided, use override
- if invalid of no override provided, use environment
- if no environment mode, default to DEV env