### PR TITLE
fix node modal when no account found

### DIFF
--- a/packages/client/src/layers/network/shapes/Node.tsx
+++ b/packages/client/src/layers/network/shapes/Node.tsx
@@ -99,10 +99,10 @@ export const getNode = (
     // split node kamis between mine and others
     if (kamis && options.accountID) {
       kamisMine = kamis.filter((kami) => {
-        return kami.account!.id === options.accountID;
+        return kami.account?.id === options.accountID;
       });
       kamisOthers = kamis.filter((kami) => {
-        return kami.account!.id !== options.accountID;
+        return kami.account?.id !== options.accountID;
       });
     } else {
       kamisOthers = kamis;

--- a/packages/client/src/layers/react/components/modals/node/Kards.tsx
+++ b/packages/client/src/layers/react/components/modals/node/Kards.tsx
@@ -273,7 +273,7 @@ export const Kards = (props: Props) => {
       <KamiCard
         key={kami.entityIndex}
         kami={kami}
-        subtext={`${kami.account!.name} (\$${calcOutput(kami)})`}
+        subtext={`${kami.account?.name} (\$${calcOutput(kami)})`}
         actions={LiquidateButton(kami, myKamis)}
         description={getDescription(kami)}
         showBattery


### PR DESCRIPTION
we're no longer reliably getting account objects attached to kamis due to duplicate
indices being introduced while deploying the gacha pool kamis. quick fix with a null check