### PR TITLE
fix loading bug for missing mint20-proxy

### DIFF
--- a/packages/client/src/layers/react/components/fixtures/AccountInfo.tsx
+++ b/packages/client/src/layers/react/components/fixtures/AccountInfo.tsx
@@ -79,7 +79,7 @@ export function registerAccountInfoFixture() {
 
       // $KAMI Balance
       const { data: mint20Addy } = useContractRead({
-        address: network.systems['system.Mint20.Proxy'].address as `0x${string}`,
+        address: network.systems['system.Mint20.Proxy']?.address as `0x${string}`,
         abi: Pet721ProxySystemABI,
         functionName: 'getTokenAddy',
       });


### PR DESCRIPTION
loading bug similar to the one we found on the gacha modal. `AccountInfo`
has a similar subscription 