### PR TITLE
update liquidation effect calculations

### DIFF
--- a/packages/client/src/layers/network/api/world.ts
+++ b/packages/client/src/layers/network/api/world.ts
@@ -109,7 +109,7 @@ export function setupWorldAPI(systems: any, provider: any) {
 
     // Liquidation Effects
     await api.config.set.array('KAMI_LIQ_EFFICACY', [0, 500, 500, 3]); // [neut, up, down, prec]
-    await api.config.set.array('KAMI_LIQ_HOSTILITY', [0, 0, 400, 3]); // nontraditional AST node
+    await api.config.set.array('KAMI_LIQ_ANIMOSITY', [0, 0, 400, 3]); // nontraditional AST node
     await api.config.set.array('KAMI_LIQ_THRESHOLD', [0, 3, 1000, 3, 0, 3, 0, 0]);
 
     // Liquidation Bounty

--- a/packages/client/src/layers/network/shapes/Config/kami.ts
+++ b/packages/client/src/layers/network/shapes/Config/kami.ts
@@ -17,7 +17,7 @@ interface HarvestConfig {
 }
 
 interface LiquidationConfig {
-  hostility: AsphoAST;
+  animosity: AsphoAST;
   threshold: AsphoAST;
   // salvage: AsphoAST;
   // spoils: AsphoAST;
@@ -61,7 +61,7 @@ export const getConfig = (world: World, components: Components): Config => {
       efficacy: getEfficacyNode(world, components, 'KAMI_HARV_EFFICACY'),
     },
     liquidation: {
-      hostility: getASTNode(world, components, 'KAMI_LIQ_HOSTILITY'),
+      animosity: getASTNode(world, components, 'KAMI_LIQ_ANIMOSITY'),
       threshold: getASTNode(world, components, 'KAMI_LIQ_THRESHOLD'),
       // salvage: getASTNode(world, components, 'KAMI_LIQ_SALVAGE'),
       // spoils: getASTNode(world, components, 'KAMI_LIQ_SPOILS'),
@@ -72,7 +72,7 @@ export const getConfig = (world: World, components: Components): Config => {
       recovery: getASTNode(world, components, 'KAMI_REST_RECOVERY'),
     },
     general: {
-      strain: getASTNode(world, components, 'KAMI_STRAIN'),
+      strain: getASTNode(world, components, 'KAMI_MUSU_STRAIN'),
       cooldown: getConfigFieldValue(world, components, 'KAMI_COOLDOWN'),
     },
   };

--- a/packages/client/src/layers/network/shapes/Production/functions.ts
+++ b/packages/client/src/layers/network/shapes/Production/functions.ts
@@ -1,4 +1,3 @@
-import { KamiConfig } from '../Config';
 import { Kami } from '../Kami';
 import { Production } from './types';
 
@@ -30,36 +29,29 @@ export const calcBounty = (production: Production): number => {
 };
 
 // calculate the expected output rate from a production
-export const calcRate = (production: Production, kami: Kami, kamiConfig: KamiConfig): number => {
-  const config = kamiConfig.harvest.bounty;
-  const base = calcFertility(production, kami, kamiConfig);
+export const calcRate = (production: Production, kami: Kami): number => {
+  if (production.state !== 'ACTIVE') return 0;
+  const config = kami.config.harvest.bounty;
+  const base = calcFertility(production, kami);
   const nudge = calcDedication();
   const boost = config.boost.value + kami.bonuses.harvest.bounty.boost;
   return (base + nudge) * boost;
 };
 
-export const calcFertility = (
-  production: Production,
-  kami: Kami,
-  kamiConfig: KamiConfig
-): number => {
-  const config = kamiConfig.harvest.fertility;
+export const calcFertility = (production: Production, kami: Kami): number => {
+  const config = kami.config.harvest.fertility;
   const ratio = config.ratio.value;
-  const efficacy = config.boost.value + calcEfficacyShift(production, kami, kamiConfig);
+  const efficacy = config.boost.value + calcEfficacyShift(production, kami);
   return (kami.stats.power.total * ratio * efficacy) / 3600;
 };
 
 export const calcDedication = () => 0;
 
-export const calcEfficacyShift = (
-  production: Production,
-  kami: Kami,
-  kamiConfig: KamiConfig
-): number => {
+export const calcEfficacyShift = (production: Production, kami: Kami): number => {
   const node = production.node;
   if (!node || !kami.affinities || !node.affinity || node.affinity === 'NORMAL') return 0;
 
-  const config = kamiConfig.harvest.efficacy;
+  const config = kami.config.harvest.efficacy;
   const neutShift = config.base;
   const upShift = config.up + kami.bonuses.harvest.fertility.boost;
   const downShift = config.down;

--- a/packages/client/src/layers/network/shapes/Production/types.ts
+++ b/packages/client/src/layers/network/shapes/Production/types.ts
@@ -1,7 +1,6 @@
 import { EntityID, EntityIndex, World, getComponentValue } from '@mud-classic/recs';
 
 import { Components } from 'layers/network';
-import { getKamiConfig } from '../Config';
 import { Kami, getKami } from '../Kami';
 import { Node, getNode } from '../Node';
 import { calcRate } from './functions';
@@ -44,15 +43,6 @@ export const getProduction = (
     },
   };
 
-  // retrieve the kami if it's not passed in
-  if (!kami) {
-    const kamiID = getComponentValue(PetID, index)?.value as EntityID;
-    const kamiEntityIndex = world.entityToIndex.get(kamiID) ?? (0 as EntityIndex);
-    kami = getKami(world, components, kamiEntityIndex, { account: true, traits: true });
-  }
-  const kamiConfig = getKamiConfig(world, components);
-  production.rate = calcRate(production, kami, kamiConfig);
-
   /////////////////
   // OPTIONAL DATA
 
@@ -65,6 +55,15 @@ export const getProduction = (
 
   /////////////////
   // ADJUSTMENTS
+
+  // retrieve the kami if it's not passed in
+  // NOTE: rate calcs only work if the node is set
+  if (!kami) {
+    const kamiID = getComponentValue(PetID, index)?.value as EntityID;
+    const kamiEntityIndex = world.entityToIndex.get(kamiID) ?? (0 as EntityIndex);
+    kami = getKami(world, components, kamiEntityIndex, { account: true, traits: true });
+  }
+  production.rate = calcRate(production, kami);
 
   return production;
 };

--- a/packages/client/src/layers/react/components/modals/kami/skills/Matrix.tsx
+++ b/packages/client/src/layers/react/components/modals/kami/skills/Matrix.tsx
@@ -51,7 +51,7 @@ export const Matrix = (props: Props) => {
     }
     result.push(skillRow[exclusive.length]);
 
-    return <NodeRow>{result}</NodeRow>;
+    return <NodeRow key={skillIndices[0]}>{result}</NodeRow>;
   };
 
   const Node = (skillIndex: number) => {
@@ -66,7 +66,7 @@ export const Matrix = (props: Props) => {
     const titleText = [`${skill.name} [${kSkill?.points.current ?? 0}/${skill.points.max}]`];
 
     return (
-      <NodeWrapper style={{ opacity: acquirable ? '1' : '0.6' }}>
+      <NodeWrapper key={skillIndex} style={{ opacity: acquirable ? '1' : '0.6' }}>
         <ItemIcon
           key={skillIndex}
           item={skill}

--- a/packages/client/src/layers/react/components/modals/node/Kards.tsx
+++ b/packages/client/src/layers/react/components/modals/node/Kards.tsx
@@ -124,16 +124,16 @@ export const Kards = (props: Props) => {
     }
 
     // check what the liquidation threshold is for any kamis that have made it to
-    const valid = available.filter((kami) => canMog(kami, target, kamiConfig));
+    const valid = available.filter((kami) => canMog(kami, target));
     if (valid.length == 0 && reason === '') {
       // get the details of the highest cap liquidation
-      const thresholds = available.map((ally) => calcThreshold(ally, target, kamiConfig));
+      const thresholds = available.map((ally) => calcThreshold(ally, target));
       const [threshold, index] = thresholds.reduce(
         (a, b, i) => (a[0] < b ? [b, i] : a),
         [Number.MIN_VALUE, -1]
       );
       const champion = available[index];
-      reason = `${champion.name} can liquidate at ${Math.round(threshold)} Health`;
+      reason = `${champion.name} can liquidate below ${Math.round(threshold)} Health`;
     }
 
     if (reason === '') reason = 'Liquidate this Kami';
@@ -234,7 +234,7 @@ export const Kards = (props: Props) => {
 
   // button for liquidating production
   const LiquidateButton = (target: Kami, allies: Kami[]) => {
-    const options = allies.filter((ally) => canLiquidate(ally, target, kamiConfig));
+    const options = allies.filter((ally) => canLiquidate(ally, target));
     const actionOptions = options.map((myKami) => {
       return {
         text: `${myKami.name}`,

--- a/packages/contracts/src/libraries/LibKill.sol
+++ b/packages/contracts/src/libraries/LibKill.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import { FixedPointMathLib as LibFPMath } from "solady/utils/FixedPointMathLib.sol";
+import { SafeCastLib } from "solady/utils/SafeCastLib.sol";
 import { IUint256Component as IUintComp } from "solecs/interfaces/IUint256Component.sol";
 import { IWorld } from "solecs/interfaces/IWorld.sol";
 import { getAddressById } from "solecs/utils.sol";
@@ -13,11 +15,24 @@ import { IsKillComponent, ID as IsKillCompID } from "components/IsKillComponent.
 import { BalanceComponent, ID as BalanceCompID } from "components/BalanceComponent.sol";
 import { CoinComponent, ID as CoinCompID } from "components/CoinComponent.sol";
 import { TimeComponent, ID as TimeCompID } from "components/TimeComponent.sol";
-
+import { LibAffinity } from "libraries/LibAffinity.sol";
+import { LibBonus } from "libraries/LibBonus.sol";
+import { LibConfig } from "libraries/LibConfig.sol";
 import { LibNode } from "libraries/LibNode.sol";
+import { LibPet } from "libraries/LibPet.sol";
+import { Gaussian } from "utils/Gaussian.sol";
 
-// a Kill Entity is an event log tracking where, when and with whom a killing took place
+uint256 constant ANIMOSITY_PREC = 6;
+
+// LibKill does maths for liquidation calcs and handles creation of kill logs,
+// which track when, where and with whom a murder took place.
 library LibKill {
+  using LibFPMath for int256;
+  using SafeCastLib for int32;
+  using SafeCastLib for uint32;
+  using SafeCastLib for int256;
+  using SafeCastLib for uint256;
+
   // creates a kill log. pretty sure we don't need to do anything with the library aside from this
   function create(
     IWorld world,
@@ -42,5 +57,105 @@ library LibKill {
     CoinComponent(getAddressById(components, CoinCompID)).set(id, bounty);
     TimeComponent(getAddressById(components, TimeCompID)).set(id, block.timestamp);
     return id;
+  }
+
+  /////////////////
+  // CALCULATIONS
+
+  // Calculate the affinity multiplier for attacks between two kamis.
+  // We really need to overload the word 'base' a bit less..
+  function calcEfficacy(
+    IUintComp components,
+    uint256 sourceID,
+    uint256 targetID,
+    uint256 base
+  ) internal view returns (uint256) {
+    uint32[8] memory config = LibConfig.getArray(components, "KAMI_LIQ_EFFICACY");
+
+    // pull the base efficacy shifts from the config
+    LibAffinity.Shifts memory baseEfficacyShifts = LibAffinity.Shifts({
+      base: config[0].toInt256(),
+      up: config[1].toInt256(),
+      down: config[2].toInt256() * -1
+    });
+
+    // pull the bonus efficacy shifts from the pets
+    int256 attBonus = LibBonus.getRaw(components, sourceID, "ATK_THRESHOLD_RATIO");
+    int256 defBonus = LibBonus.getRaw(components, targetID, "DEF_THRESHOLD_RATIO");
+    LibAffinity.Shifts memory bonusEfficacyShifts = LibAffinity.Shifts({
+      base: int(0),
+      up: attBonus + defBonus,
+      down: int(0)
+    });
+
+    // sum the applied shift with the base efficacy value to get the final value
+    int256 efficacy = base.toInt256();
+    string memory targetAff = LibPet.getAffinities(components, targetID)[0];
+    string memory sourceAff = LibPet.getAffinities(components, sourceID)[1];
+    efficacy += LibAffinity.calcEfficacyShift(
+      LibAffinity.getAttackEffectiveness(sourceAff, targetAff),
+      baseEfficacyShifts,
+      bonusEfficacyShifts
+    );
+
+    return (efficacy > 0) ? uint(efficacy) : 0;
+  }
+
+  // Calculate the base liquidation threshold % for target pet when attacked by source pet.
+  // H = Φ(ln(v_s / h_t)) * ratio  as proportion of total health (1e6 precision).
+  function calcAnimosity(
+    IUintComp components,
+    uint256 sourceID,
+    uint256 targetID
+  ) internal view returns (uint256) {
+    uint32[8] memory config = LibConfig.getArray(components, "KAMI_LIQ_ANIMOSITY");
+
+    uint256 sourceViolence = LibPet.calcTotalViolence(components, sourceID).toUint256();
+    uint256 targetHarmony = LibPet.calcTotalHarmony(components, targetID).toUint256();
+    int256 imbalance = ((1e18 * sourceViolence) / targetHarmony).toInt256();
+    uint256 base = Gaussian.cdf(LibFPMath.lnWad(imbalance)).toUint256();
+    uint256 ratio = config[2]; // core animosity baseline
+
+    // flipped precision as inputs are more precise than output
+    uint256 precision = 10 ** (18 + config[3] - ANIMOSITY_PREC);
+    return (base * ratio) / precision;
+  }
+
+  // Calculate the liquidation HP threshold for target pet, attacked by the source pet.
+  // This is measured as an absolute health value (1e0 precision).
+  function calcThreshold(
+    IUintComp components,
+    uint256 sourceID,
+    uint256 targetID
+  ) internal view returns (uint256) {
+    uint32[8] memory config = LibConfig.getArray(components, "KAMI_LIQ_THRESHOLD");
+    uint256 base = calcAnimosity(components, sourceID, targetID);
+    uint256 ratio = calcEfficacy(components, sourceID, targetID, config[2]);
+
+    // apply attack and defense shifts
+    uint256 shiftPrec = 10 ** (ANIMOSITY_PREC + config[3] - config[5]);
+    int256 shiftAttBonus = LibBonus.getRaw(components, sourceID, "ATK_THRESHOLD_SHIFT");
+    int256 shiftDefBonus = LibBonus.getRaw(components, targetID, "DEF_THRESHOLD_SHIFT");
+    int256 shift = (config[4].toInt256() + shiftAttBonus + shiftDefBonus) * int(shiftPrec);
+
+    int256 postShiftVal = int(base * ratio) + shift;
+    if (postShiftVal < 0) return 0;
+
+    uint256 totalHealth = LibPet.calcTotalHealth(components, targetID).toUint256();
+    uint256 precision = 10 ** (ANIMOSITY_PREC + config[3] + config[7]);
+    return (uint(postShiftVal) * totalHealth) / precision;
+  }
+
+  // Calculate the reward for liquidating a specified Coin balance
+  function calcSpoils(
+    IUintComp components,
+    uint256 id, // unused atm, but will be used for skill multipliers
+    uint256 amt
+  ) internal view returns (uint256) {
+    uint32[8] memory configVals = LibConfig.getArray(components, "LIQ_BOUNTY_BASE");
+
+    uint256 base = configVals[0];
+    uint256 precision = 10 ** uint256(configVals[1]);
+    return (amt * base) / precision;
   }
 }

--- a/packages/contracts/src/systems/ProductionLiquidateSystem.sol
+++ b/packages/contracts/src/systems/ProductionLiquidateSystem.sol
@@ -59,7 +59,7 @@ contract ProductionLiquidateSystem is System {
 
     // collect the money to the production. drain accordingly
     uint256 balance = LibProduction.getBalance(components, targetProductionID);
-    uint256 bounty = LibPet.calcBounty(components, petID, balance);
+    uint256 bounty = LibKill.calcSpoils(components, petID, balance);
     uint256 recoil = LibPet.calcStrain(components, petID, bounty);
     LibCoin.inc(components, productionID, bounty);
     LibPet.drain(components, petID, SafeCastLib.toInt32(recoil));

--- a/packages/contracts/src/test/systems/Murder.t.sol
+++ b/packages/contracts/src/test/systems/Murder.t.sol
@@ -70,7 +70,7 @@ contract MurderTest is SetupTemplate {
     uint health = uint(int(LibStat.getHealth(components, victimID).sync));
     health = (health > drain) ? health - drain : 0;
 
-    uint threshold = LibPet.calcThreshold(components, attackerID, victimID); // 1e18 precision
+    uint threshold = LibKill.calcAnimosity(components, attackerID, victimID); // 1e18 precision
     return threshold * totalHealth > health * 1e18;
   }
 


### PR DESCRIPTION
update liquidation effect calculations

updates calculations for liquidation efficacy and top level shifts.
moves this logic to the LibKill library to declutter LibPet a tad.
also updates the names of liquidation bonuses on the sc side and updates
type conversions for proper handling

hostility -> animosity
