### PR TITLE
implement liquidation salvage and update config/calcs

### DIFF
--- a/packages/client/src/layers/network/api/world.ts
+++ b/packages/client/src/layers/network/api/world.ts
@@ -111,9 +111,8 @@ export function setupWorldAPI(systems: any, provider: any) {
     await api.config.set.array('KAMI_LIQ_EFFICACY', [0, 500, 500, 3]); // [neut, up, down, prec]
     await api.config.set.array('KAMI_LIQ_ANIMOSITY', [0, 0, 400, 3]); // nontraditional AST node
     await api.config.set.array('KAMI_LIQ_THRESHOLD', [0, 3, 1000, 3, 0, 3, 0, 0]);
-
-    // Liquidation Bounty
-    await api.config.set.array('LIQ_BOUNTY_BASE', [50, 2]);
+    await api.config.set.array('KAMI_LIQ_SALVAGE', [0, 0, 0, 3, 0, 0, 0, 0]);
+    await api.config.set.array('KAMI_LIQ_SPOILS', [0, 0, 500, 3, 0, 0, 0, 0]);
   }
 
   // local config settings for faster testing

--- a/packages/client/src/layers/network/shapes/Config/kami.ts
+++ b/packages/client/src/layers/network/shapes/Config/kami.ts
@@ -19,8 +19,8 @@ interface HarvestConfig {
 interface LiquidationConfig {
   animosity: AsphoAST;
   threshold: AsphoAST;
-  // salvage: AsphoAST;
-  // spoils: AsphoAST;
+  salvage: AsphoAST;
+  spoils: AsphoAST;
   efficacy: Efficacy;
 }
 
@@ -63,8 +63,8 @@ export const getConfig = (world: World, components: Components): Config => {
     liquidation: {
       animosity: getASTNode(world, components, 'KAMI_LIQ_ANIMOSITY'),
       threshold: getASTNode(world, components, 'KAMI_LIQ_THRESHOLD'),
-      // salvage: getASTNode(world, components, 'KAMI_LIQ_SALVAGE'),
-      // spoils: getASTNode(world, components, 'KAMI_LIQ_SPOILS'),
+      salvage: getASTNode(world, components, 'KAMI_LIQ_SALVAGE'),
+      spoils: getASTNode(world, components, 'KAMI_LIQ_SPOILS'),
       efficacy: getEfficacyNode(world, components, 'KAMI_LIQ_EFFICACY'),
     },
     rest: {

--- a/packages/contracts/src/libraries/LibKill.sol
+++ b/packages/contracts/src/libraries/LibKill.sol
@@ -146,16 +146,28 @@ library LibKill {
     return (uint(postShiftVal) * totalHealth) / precision;
   }
 
+  function calcSalvage(
+    IUintComp components,
+    uint256 id, // unused atm, but will be used for skill multipliers
+    uint256 amt
+  ) internal view returns (uint256) {
+    uint32[8] memory configVals = LibConfig.getArray(components, "KAMI_LIQ_SALVAGE");
+    int256 ratioBonus = LibBonus.getRaw(components, id, "DEF_SALVAGE_RATIO");
+    uint256 ratio = configVals[2] + ratioBonus.toUint256();
+    uint256 precision = 10 ** uint256(configVals[3]);
+    return (amt * ratio) / precision;
+  }
+
   // Calculate the reward for liquidating a specified Coin balance
   function calcSpoils(
     IUintComp components,
     uint256 id, // unused atm, but will be used for skill multipliers
     uint256 amt
   ) internal view returns (uint256) {
-    uint32[8] memory configVals = LibConfig.getArray(components, "LIQ_BOUNTY_BASE");
-
-    uint256 base = configVals[0];
-    uint256 precision = 10 ** uint256(configVals[1]);
-    return (amt * base) / precision;
+    uint32[8] memory configVals = LibConfig.getArray(components, "KAMI_LIQ_SPOILS");
+    int256 ratioBonus = LibBonus.getRaw(components, id, "ATK_SPOILS_RATIO");
+    uint256 ratio = configVals[2] + ratioBonus.toUint256();
+    uint256 precision = 10 ** uint256(configVals[3]);
+    return (amt * ratio) / precision;
   }
 }


### PR DESCRIPTION
liquidation salvage/spoils updates

introduces a new concept of Salvage that determines how much of a harvest
balance that players keep when being liquidated. this is then subtracted from
the harvest bounty before determining how much the liquidator keeps as spoils
from the event
