### PR TITLE
more skill modal cleanups. fix-ish interactions

### DIFF
--- a/packages/client/src/assets/images/skills/index.ts
+++ b/packages/client/src/assets/images/skills/index.ts
@@ -61,7 +61,7 @@ import warmup_exercise from './warmup_exercise.png';
 import wide_portfolio from './wide_portfolio.png';
 import workout_routine from './workout_routine.png';
 
-export const skillImages = {
+export const SkillImages = {
   acquisitiveness,
   advanced_mewing,
   aggression,

--- a/packages/client/src/constants/skills/trees.ts
+++ b/packages/client/src/constants/skills/trees.ts
@@ -36,3 +36,5 @@ export const SkillTrees = new Map([
   ['guardian', GuardianTree],
   ['harvester', HarvesterTree],
 ]);
+
+export const TierRequirements = [0, 0, 5, 15, 25, 40]; // no 0 tier

--- a/packages/client/src/layers/network/utils/waitForActionCompletion.ts
+++ b/packages/client/src/layers/network/utils/waitForActionCompletion.ts
@@ -10,6 +10,7 @@ export async function waitForActionCompletion(
   return waitForComponentValueIn(Action, entity, [
     { state: ActionState.Canceled },
     { state: ActionState.Failed },
+    { state: ActionState.WaitingForTxEvents }, // need to remove this once we have more reliable event update detection
     { state: ActionState.Complete },
   ]);
 }

--- a/packages/client/src/layers/react/components/modals/kami/skills/matrix/Matrix.tsx
+++ b/packages/client/src/layers/react/components/modals/kami/skills/matrix/Matrix.tsx
@@ -12,11 +12,8 @@ interface Props {
   skills: Map<number, Skill>;
   setDisplayed: (skillIndex: number) => void;
   utils: {
-    getSkillUpgradeError: (
-      index: number,
-      kami: Kami,
-      registry: Map<number, Skill>
-    ) => string[] | undefined;
+    getUpgradeError: (index: number) => string[] | undefined;
+    getTreePoints: (tree: string) => number;
   };
 }
 
@@ -43,9 +40,9 @@ export const Matrix = (props: Props) => {
                   key={index}
                   index={index}
                   kami={kami}
-                  skills={skills}
+                  skill={skills.get(index)!}
+                  upgradeError={utils.getUpgradeError(index)}
                   setDisplayed={() => setDisplayed(index)}
-                  utils={utils}
                 />
               ))}
             </Row>

--- a/packages/client/src/layers/react/components/modals/kami/skills/matrix/Node.tsx
+++ b/packages/client/src/layers/react/components/modals/kami/skills/matrix/Node.tsx
@@ -1,36 +1,30 @@
 import styled from 'styled-components';
 
-import { skillImages } from 'assets/images/skills';
+import { SkillImages } from 'assets/images/skills';
 import { Kami } from 'layers/network/shapes/Kami';
 import { Skill, getSkillInstance } from 'layers/network/shapes/Skill';
 import { Tooltip } from 'layers/react/components/library';
 
 interface Props {
   index: number;
-  skills: Map<number, Skill>;
+  skill: Skill;
   kami: Kami;
+  upgradeError: string[] | undefined;
   setDisplayed: () => void;
-  utils: {
-    getSkillUpgradeError: (
-      index: number,
-      kami: Kami,
-      registry: Map<number, Skill>
-    ) => string[] | undefined;
-  };
 }
 
 export const Node = (props: Props) => {
-  const { index, skills, kami, setDisplayed, utils } = props;
-  const skill = skills.get(index);
+  const { index, skill, kami, upgradeError, setDisplayed } = props;
   if (skill == undefined) return <></>;
 
-  const upgradeError = utils.getSkillUpgradeError(index, kami, skills);
   const acquirable = upgradeError == undefined || upgradeError[0].startsWith('Maxed Out');
 
   const kSkill = getSkillInstance(kami, skill);
   const maxedOut = kSkill?.points.current === skill.points.max;
   const titleText = [`${skill.name} [${kSkill?.points.current ?? 0}/${skill.points.max}]`];
-  const image = skillImages[skill.name.toLowerCase() as keyof typeof skillImages] ?? skill.image;
+  const imageKey = skill.name.toLowerCase().replace(' ', '_') as keyof typeof SkillImages;
+  const image = SkillImages[imageKey] ?? skill.image;
+
   return (
     <Tooltip text={titleText}>
       <Container key={index} onClick={setDisplayed} acquirable={acquirable}>

--- a/packages/client/src/utils/misc.ts
+++ b/packages/client/src/utils/misc.ts
@@ -1,0 +1,3 @@
+export const sleep = (delay: number) => {
+  return new Promise((resolve) => setTimeout(resolve, delay));
+};


### PR DESCRIPTION
minimizes the passed data from one layer of the `KamiModal` to the next,
specifically for the Skill DOM tree. this does not yet properly clean up the
Details Component, but it does insure that data on the modal is updated on
demand by modifying `WaitForActionCompletion` to include the pending
action status (since embedded wallets seem to be unreliable at triggering
the final 'complete' state update to actions).

to remedy the update potentially triggering prior to the data being presented
to the FE through our rpc, we hardcode an additional 2s buffer on the wait 
time. this may potentially break the flow for other ui components that rely
on this function, but we can remedy those by baking in a similar buffer.

this is not a long term fix but rather a patch to address similar failures across
the codebase (e.g. with lootbox reveals). what we should do instead is 
unravel our `createActionSystem` code to properly handle the entirety of the
tx event flow without issue

also this fixes the remainder of the broken images on our skill modal