### PR TITLE
StatComp packed

### DIFF
--- a/packages/client/src/layers/network/components/definitions/NumberComponent.ts
+++ b/packages/client/src/layers/network/components/definitions/NumberComponent.ts
@@ -1,4 +1,4 @@
-import { defineComponent, Metadata, Type, World } from "@mud-classic/recs";
+import { defineComponent, Metadata, Type, World } from '@mud-classic/recs';
 
 export function defineNumberComponent<M extends Metadata>(
   world: World,

--- a/packages/client/src/layers/network/components/definitions/StatComponent.ts
+++ b/packages/client/src/layers/network/components/definitions/StatComponent.ts
@@ -1,4 +1,4 @@
-import { defineComponent, Type, World } from '@mud-classic/recs';
+import { defineComponent, Metadata, Type, World } from '@mud-classic/recs';
 
 export type StatComponent = ReturnType<typeof defineStatComponent>;
 
@@ -6,13 +6,16 @@ export type StatComponent = ReturnType<typeof defineStatComponent>;
 // The given stat's total (on the entity) is calculated as:
 // Total = (1 + boost) * (base + shift)
 export function defineStatComponent(world: World, name: string, contractId: string) {
-  return defineComponent(
+  return defineComponent<{ value: Type.Number }, Metadata>(
     world,
     {
-      base: Type.Number, // base value of the stat
-      shift: Type.Number, // fixed +/- shift on the base stat
-      boost: Type.Number, // % multiplier on post-shifted stat (3 decimals of precision)
-      sync: Type.Number, // the last synced value of stat (optional, for depletable stats)
+      /**
+       * base: base value of the stat
+       * shift: fixed +/- shift on the base stat
+       * boost: % multiplier on post-shifted stat (3 decimals of precision)
+       * sync: the last synced value of stat (optional, for depletable stats)
+       */
+      value: Type.Number, // the current value of the stat
     },
     {
       id: name,

--- a/packages/client/src/layers/network/shapes/Stats.tsx
+++ b/packages/client/src/layers/network/shapes/Stats.tsx
@@ -36,7 +36,19 @@ export const getStats = (components: Components, index: EntityIndex): Stats => {
 };
 
 export const getStat = (index: EntityIndex, type: StatComponent): Stat => {
-  let stat = (getComponentValue(type, index) || {}) as Stat;
-  stat.total = (1 + stat.boost / 1000) * (stat.base + stat.shift);
-  return stat;
+  const raw = BigInt(getComponentValue(type, index)?.value || 0);
+
+  const base = Number((raw >> 192n) & 0xffffffffffffffffn);
+  const shift = Number((raw >> 128n) & 0xffffffffffffffffn);
+  const boost = Number((raw >> 64n) & 0xffffffffffffffffn);
+  const sync = Number(raw & 0xffffffffffffffffn);
+
+  return {
+    base: base,
+    shift: shift,
+    boost: boost,
+    sync: sync,
+    rate: 0,
+    total: (1 + boost / 1000) * (base + shift),
+  };
 };

--- a/packages/contracts/src/components/types/Stat.sol
+++ b/packages/contracts/src/components/types/Stat.sol
@@ -26,6 +26,31 @@ struct Stat {
 // - how overall stats are computed with equipment has yet to be determined
 
 library StatLib {
+  ///////////////
+  // CALCS
+
+  function calcTotal(Stat memory value) internal pure returns (int32) {
+    int32 total = ((1e3 + value.boost) * (value.base + value.shift)) / 1e3;
+    return (total > 0) ? total : int32(0);
+  }
+
+  function shift(Stat memory value, int32 amt) internal pure returns (int32) {
+    return value.shift + amt;
+  }
+
+  function boost(Stat memory value, int32 amt) internal pure returns (int32) {
+    return value.boost + amt;
+  }
+
+  function sync(Stat memory value, int32 amt, int32 max) internal pure returns (int32) {
+    value.sync += amt;
+    if (value.sync < 0) value.sync = 0;
+    if (value.sync > max) value.sync = max;
+    return value.sync;
+  }
+
+  ///////////////
+  // ENCODING
   function encode(Stat memory stat) internal pure returns (bytes memory) {
     return abi.encode(toUint(stat));
   }
@@ -34,6 +59,16 @@ library StatLib {
     bytes[] memory encoded = new bytes[](stats.length);
     for (uint256 i = 0; i < stats.length; i++) encoded[i] = encode(stats[i]);
     return encoded;
+  }
+
+  function decode(bytes memory encoded) internal pure returns (Stat memory) {
+    return toStat(abi.decode(encoded, (uint256)));
+  }
+
+  function decodeBatch(bytes[] memory encoded) internal pure returns (Stat[] memory) {
+    Stat[] memory stats = new Stat[](encoded.length);
+    for (uint256 i = 0; i < encoded.length; i++) stats[i] = decode(encoded[i]);
+    return stats;
   }
 
   function toUint(Stat memory stat) internal pure returns (uint256) {

--- a/packages/contracts/src/test/components/StatComp.t.sol
+++ b/packages/contracts/src/test/components/StatComp.t.sol
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import { console } from "forge-std/Test.sol";
+
+import { Stat, StatLib } from "components/types/Stat.sol";
+import { StatComponent } from "components/base/StatComponent.sol";
+
+import { EmptyWorld } from "test/utils/EmptyWorld.t.sol";
+
+contract StatCompTest is EmptyWorld {
+  StatComponent statComp;
+
+  function setUp() public override {
+    super.setUp();
+
+    vm.startPrank(deployer);
+    statComp = new StatComponent(address(world), uint256(keccak256("test.Stat")));
+    vm.stopPrank();
+  }
+
+  //////////////
+  // COMPONENT
+
+  function testStatComponent() public {
+    uint256 id = 111;
+    uint256[] memory ids = new uint256[](1);
+    ids[0] = id;
+    Stat memory original = Stat(1, 2, 3, 4);
+    Stat[] memory ogBatch = new Stat[](1);
+    ogBatch[0] = original;
+
+    vm.prank(deployer);
+    statComp.set(id, original);
+
+    // test getting
+    assertEq(statComp.get(id), original);
+    vm.expectRevert();
+    statComp.get(1);
+    assertEq(statComp.getBatch(ids), ogBatch);
+
+    // test extract
+    vm.prank(deployer);
+    Stat memory extracted = statComp.extract(id);
+    assertEq(extracted, original);
+    assertTrue(!statComp.has(id));
+    vm.expectRevert();
+    statComp.get(id);
+    vm.prank(deployer);
+    statComp.set(id, original);
+    vm.prank(deployer);
+    assertEq(statComp.extractBatch(ids), ogBatch);
+    assertEq(extracted, original);
+    assertTrue(!statComp.has(id));
+    vm.expectRevert();
+    statComp.get(id);
+
+    // test setting
+    vm.prank(deployer);
+    statComp.set(id, original);
+    assertEq(statComp.get(id), original);
+    ids = new uint256[](3);
+    ids[0] = 1000;
+    ids[1] = 1001;
+    ids[2] = 1002;
+    ogBatch = new Stat[](3);
+    ogBatch[0] = Stat(10, 20, 30, 40);
+    ogBatch[1] = Stat(11, 21, 31, 41);
+    ogBatch[2] = Stat(12, 22, 32, 42);
+    vm.prank(deployer);
+    statComp.setBatch(ids, ogBatch);
+    for (uint256 i = 0; i < ids.length; i++) {
+      assertEq(statComp.get(ids[i]), ogBatch[i]);
+    }
+    assertEq(statComp.getBatch(ids), ogBatch);
+
+    // test setting permissions
+    vm.expectRevert();
+    statComp.set(0, Stat(1, 1, 1, 1));
+    Stat[] memory batch = new Stat[](2);
+    batch[0] = Stat(1, 1, 1, 1);
+    batch[1] = Stat(2, 2, 2, 2);
+    vm.expectRevert();
+    statComp.setBatch(ids, batch);
+
+    // test removing permissions
+    vm.expectRevert();
+    statComp.remove(id);
+    vm.expectRevert();
+    statComp.removeBatch(ids);
+
+    // test extract permissions
+    vm.expectRevert();
+    statComp.extract(id);
+    vm.expectRevert();
+    statComp.extractBatch(ids);
+  }
+
+  function testStatCompFunctions() public {
+    uint256 id = 111;
+    Stat memory stat = Stat(1, 2, 3, 4);
+    vm.prank(deployer);
+    statComp.set(id, stat);
+
+    // test total
+    int32 expTotal = ((1e3 + stat.boost) * (stat.base + stat.shift)) / 1e3;
+    assertEq(statComp.calcTotal(id), expTotal);
+
+    // test sync, 0 amt
+    stat = Stat(10, 0, 0, 5);
+    vm.prank(deployer);
+    statComp.set(id, stat);
+    vm.prank(deployer);
+    int32 synced = statComp.sync(id, 0);
+    assertEq(synced, 5, "sync 0 mismatch");
+    assertEq(statComp.get(id).sync, 5);
+
+    // test sync, positive amt
+    vm.prank(deployer);
+    statComp.set(id, stat);
+    vm.prank(deployer);
+    synced = statComp.sync(id, 11);
+    assertEq(synced, 10, "sync pos mismatch");
+    assertEq(statComp.get(id).sync, 10);
+
+    // test sync, negative amt
+    vm.prank(deployer);
+    statComp.set(id, stat);
+    vm.prank(deployer);
+    synced = statComp.sync(id, -1);
+    assertEq(synced, 4, "sync neg mismatch");
+    assertEq(statComp.get(id).sync, 4);
+
+    // test sync, forced total
+    vm.prank(deployer);
+    statComp.set(id, stat);
+    vm.prank(deployer);
+    synced = statComp.sync(id, 100, 20);
+    assertEq(synced, 20, "sync total mismatch");
+    assertEq(statComp.get(id).sync, 20);
+
+    // // test shift
+    vm.prank(deployer);
+    statComp.set(id, stat);
+    stat.shift += 11;
+    vm.prank(deployer);
+    int32 shifted = statComp.shift(id, 11);
+    assertEq(shifted, stat.shift, "shift mismatch");
+    assertEq(statComp.get(id), stat);
+    vm.expectRevert();
+    statComp.shift(id, 1);
+
+    // test boost
+    vm.prank(deployer);
+    statComp.set(id, stat);
+    stat.boost += 2;
+    vm.prank(deployer);
+    int32 boosted = statComp.boost(id, 2);
+    assertEq(boosted, stat.boost, "boost mismatch");
+    assertEq(statComp.get(id), stat);
+    vm.expectRevert();
+    statComp.boost(id, 1);
+  }
+
+  //////////////
+  // ENCODING
+
+  function testStatLib(int32 base, int32 shift, int32 boost, int32 sync) public {
+    Stat memory original = Stat(base, shift, boost, sync);
+
+    // test uint256 conversion
+    uint256 converted = StatLib.toUint(original);
+    assertEq(StatLib.toStat(converted), original);
+
+    // test abi encoding
+    bytes memory encoded = StatLib.encode(original);
+    assertEq(StatLib.decode(encoded), original);
+  }
+
+  function testStatLibBatch() public {
+    // 0 case
+    Stat[] memory stats = new Stat[](0);
+    assertEq(StatLib.decodeBatch(StatLib.encodeBatch(stats)), stats);
+
+    // 1 case
+    stats = new Stat[](1);
+    stats[0] = Stat(1, 2, 3, 4);
+    assertEq(StatLib.decodeBatch(StatLib.encodeBatch(stats)), stats);
+
+    // regular case
+    stats = new Stat[](5);
+    stats[0] = Stat(1, 2, 3, 4);
+    stats[1] = Stat(5, 6, 7, 8);
+    stats[2] = Stat(9, 10, 11, 12);
+    stats[3] = Stat(13, 14, 15, 16);
+    stats[4] = Stat(17, 18, 19, 20);
+    Stat[] memory decoded = StatLib.decodeBatch(StatLib.encodeBatch(stats));
+    assertEq(decoded[0], stats[0]);
+    assertEq(decoded[1], stats[1]);
+    assertEq(decoded[2], stats[2]);
+    assertEq(decoded[3], stats[3]);
+    assertEq(decoded[4], stats[4]);
+  }
+
+  //////////////
+  // UTILS
+  function assertEq(Stat memory a, Stat memory b) internal view {
+    assertEq(a.base, b.base);
+    assertEq(a.shift, b.shift);
+    assertEq(a.boost, b.boost);
+    assertEq(a.sync, b.sync);
+  }
+
+  function assertEq(Stat[] memory a, Stat[] memory b) internal view {
+    assertEq(a.length, b.length);
+    for (uint256 i = 0; i < a.length; i++) assertEq(a[i], b[i]);
+  }
+}


### PR DESCRIPTION
packed Stat struct into a uint256, updated FE to handle it

an explicit design choice: kept `defineStatComponent()` separate, even though it's effectively a number component. Reasoning is there are many `stat` based comps, so its a little more readable