### PR TITLE
gate level/skill upgrades by kami harvesting status

### DIFF
--- a/packages/client/src/app/components/modals/kami/Kami.tsx
+++ b/packages/client/src/app/components/modals/kami/Kami.tsx
@@ -85,7 +85,7 @@ export function registerKamiModal() {
       };
 
       const levelUp = (kami: Kami) => {
-        actions.add({
+        const actionIndex = actions.add({
           action: 'KamiLevel',
           params: [kami.id],
           description: `Leveling up ${kami.name}`,
@@ -93,6 +93,7 @@ export function registerKamiModal() {
             return api.player.pet.level(kami.id);
           },
         });
+        updateKamiAfterAction(actionIndex);
       };
 
       const upgradeSkill = (kami: Kami, skill: Skill) => {
@@ -104,7 +105,7 @@ export function registerKamiModal() {
             return api.player.skill.upgrade(kami.id, skill.index);
           },
         });
-        return actionIndex;
+        updateKamiAfterAction(actionIndex);
       };
 
       /////////////////
@@ -134,7 +135,6 @@ export function registerKamiModal() {
                 getUpgradeError: (index: number, registry: Map<number, Skill>) =>
                   getSkillUpgradeError(world, components, index, kami, registry),
                 getTreePoints: (tree: string) => getTreePoints(world, components, kami, tree),
-                updateKamiAfterAction,
               }}
             />
           )}

--- a/packages/client/src/app/components/modals/kami/header/Banner.tsx
+++ b/packages/client/src/app/components/modals/kami/header/Banner.tsx
@@ -1,4 +1,4 @@
-import { Kami } from 'layers/network/shapes/Kami';
+import { Kami, isResting } from 'layers/network/shapes/Kami';
 import styled from 'styled-components';
 
 import { ExperienceBar, Tooltip } from 'app/components/library';
@@ -66,6 +66,7 @@ export const Banner = (props: Props) => {
 
   const getLevelUpDisabledReason = () => {
     if (!isMine(kami)) return 'not ur kami';
+    if (!isResting(kami)) return 'kami must be resting';
   };
 
   const handleAccountClick = () => {

--- a/packages/client/src/app/components/modals/kami/skills/Details.tsx
+++ b/packages/client/src/app/components/modals/kami/skills/Details.tsx
@@ -1,4 +1,3 @@
-import { EntityIndex } from '@mud-classic/recs';
 import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
@@ -19,13 +18,10 @@ interface Props {
   index: number;
   skills: Map<number, Skill>; // registry skills
   upgradeError: string[] | undefined;
-  actions: {
-    upgrade: (skill: Skill) => EntityIndex;
-  };
+  actions: { upgrade: (skill: Skill) => void };
   utils: {
     getSkillImage: (skill: Skill) => string;
     getTreePoints: (tree: string) => number;
-    updateKamiAfterAction: (actionIndex: EntityIndex) => void;
   };
 }
 
@@ -50,8 +46,7 @@ export const Details = (props: Props) => {
   // trigger an upgrade of the skill
   const triggerUpgrade = (skill: Skill) => {
     playClick();
-    const actionIndex = actions.upgrade(skill);
-    utils.updateKamiAfterAction(actionIndex);
+    actions.upgrade(skill);
   };
 
   ////////////////////

--- a/packages/client/src/app/components/modals/kami/skills/Skills.tsx
+++ b/packages/client/src/app/components/modals/kami/skills/Skills.tsx
@@ -1,4 +1,3 @@
-import { EntityIndex } from '@mud-classic/recs';
 import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
@@ -14,12 +13,11 @@ interface Props {
   kami: Kami;
   skills: Skill[]; // registry skills
   actions: {
-    upgrade: (skill: Skill) => EntityIndex;
+    upgrade: (skill: Skill) => void;
   };
   utils: {
     getUpgradeError: (index: number, registry: Map<number, Skill>) => string[] | undefined;
     getTreePoints: (tree: string) => number;
-    updateKamiAfterAction: (actionIndex: EntityIndex) => void;
   };
 }
 
@@ -61,7 +59,6 @@ export const Skills = (props: Props) => {
         utils={{
           getSkillImage,
           getTreePoints: utils.getTreePoints,
-          updateKamiAfterAction: utils.updateKamiAfterAction,
         }}
       />
       <Matrix

--- a/packages/client/src/layers/network/shapes/Skill/functions.ts
+++ b/packages/client/src/layers/network/shapes/Skill/functions.ts
@@ -2,7 +2,7 @@ import { World } from '@mud-classic/recs';
 import { Components } from 'layers/network';
 import { Account } from '../Account';
 import { getData } from '../Data';
-import { Kami, isDead, isOffWorld, isStarving, isWithAccount } from '../Kami';
+import { Kami, isDead, isHarvesting, isOffWorld, isStarving } from '../Kami';
 import { checkCondition } from '../utils/Conditionals';
 import { Effect, Requirement, Skill } from './types';
 
@@ -33,8 +33,8 @@ export const getUpgradeError = (
   // status/roomIndex check
   if (isDead(kami)) return [`${kami.name} is Dead`];
   if (isOffWorld(kami)) return [`${kami.name} is Off World`];
-  if (isStarving(kami)) return [`${kami.name} is Starving`];
-  if (!isWithAccount(kami)) return [`${kami.name} is too far away.`];
+  if (isStarving(kami)) return [`${kami.name} is busy Starving`];
+  if (isHarvesting(kami)) return [`${kami.name} is busy Harvesting`];
 
   // tree check
   if (rSkill.treeTier > 0) {

--- a/packages/contracts/src/systems/PetLevelSystem.sol
+++ b/packages/contracts/src/systems/PetLevelSystem.sol
@@ -23,10 +23,7 @@ contract PetLevelSystem is System {
     // standard checks (type check, ownership, roomIndex)
     require(LibPet.isPet(components, id), "PetLevel: not a pet");
     require(LibPet.getAccount(components, id) == accountID, "PetLevel: not urs");
-    require(
-      LibPet.getRoom(components, id) == LibAccount.getRoom(components, accountID),
-      "PetLevel: must be in same room"
-    );
+    require(LibPet.isResting(components, id), "PetLevel: pet not resting");
 
     // check that the pet meets the experience requirement
     uint256 levelCost = LibExperience.calcLevelCost(components, id);

--- a/packages/contracts/src/systems/SkillUpgradeSystem.sol
+++ b/packages/contracts/src/systems/SkillUpgradeSystem.sol
@@ -35,13 +35,7 @@ contract SkillUpgradeSystem is System {
       require(accountID == holderID, "SkillUpgrade: not ur account");
     } else if (isPet) {
       require(accountID == LibPet.getAccount(components, holderID), "SkillUpgrade: not ur pet");
-      require(
-        LibPet.getRoom(components, holderID) == LibAccount.getRoom(components, accountID),
-        "SkillUpgrade: must be in same room"
-      );
-
-      // NOTE: we don't block skill upgrading by cooldown time or pet status
-      // but we need to sync in advance to get accurate historical output
+      require(LibPet.isResting(components, holderID), "SkillUpgrade: pet not resting");
       LibPet.sync(components, holderID);
     }
 
@@ -65,11 +59,6 @@ contract SkillUpgradeSystem is System {
     for (uint256 i = 0; i < effectIDs.length; i++) {
       LibSkill.processEffectUpgrade(components, holderID, effectIDs[i]);
     }
-
-    // NOTE: we sync the pet a second time here, because the updated Production Rate
-    // informs the FE. it's gas inefficient, but it keeps the code sane up there.
-    // Can consider wiping once the calculations are mirrored on the FE.
-    if (isPet) LibPet.sync(components, holderID);
 
     // standard logging and tracking
     LibSkill.logUsePoint(components, accountID);


### PR DESCRIPTION
kami must be resting. fixes sc/fe to mirror this gating and also fixes data 
propagation in the kami modal upon level-up.

this has absolutely zero testing