### PR TITLE
remove getSchema() from components 

### DIFF
--- a/packages/client/abi/AddressBareComponent.json
+++ b/packages/client/abi/AddressBareComponent.json
@@ -215,24 +215,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -507,7 +489,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/AddressComponent.json
+++ b/packages/client/abi/AddressComponent.json
@@ -258,24 +258,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -571,7 +553,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/AddressOperatorComponent.json
+++ b/packages/client/abi/AddressOperatorComponent.json
@@ -253,24 +253,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -566,7 +548,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/AddressOwnerComponent.json
+++ b/packages/client/abi/AddressOwnerComponent.json
@@ -253,24 +253,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -566,7 +548,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/AffinityComponent.json
+++ b/packages/client/abi/AffinityComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -526,7 +508,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "hasValue(uint256,string)": "9d72b0e1",
     "id()": "af640d0f",

--- a/packages/client/abi/BlacklistComponent.json
+++ b/packages/client/abi/BlacklistComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/BlockRevealComponent.json
+++ b/packages/client/abi/BlockRevealComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/BoolBareComponent.json
+++ b/packages/client/abi/BoolBareComponent.json
@@ -215,24 +215,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -497,7 +479,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/BoolComponent.json
+++ b/packages/client/abi/BoolComponent.json
@@ -258,24 +258,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -561,7 +543,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/CacheOperatorComponent.json
+++ b/packages/client/abi/CacheOperatorComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/CanNameComponent.json
+++ b/packages/client/abi/CanNameComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/CoordComponent.json
+++ b/packages/client/abi/CoordComponent.json
@@ -343,24 +343,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -690,7 +672,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/CostComponent.json
+++ b/packages/client/abi/CostComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/DamageComponent.json
+++ b/packages/client/abi/DamageComponent.json
@@ -177,24 +177,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "getValue",
       "inputs": [
         {
@@ -487,7 +469,6 @@
     "getEntitiesWithValue(uint256)": "fbdfa1ea",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "getValue(uint256)": "0ff4c916",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",

--- a/packages/client/abi/DescriptionAltComponent.json
+++ b/packages/client/abi/DescriptionAltComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -526,7 +508,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "hasValue(uint256,string)": "9d72b0e1",
     "id()": "af640d0f",

--- a/packages/client/abi/DescriptionComponent.json
+++ b/packages/client/abi/DescriptionComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -526,7 +508,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "hasValue(uint256,string)": "9d72b0e1",
     "id()": "af640d0f",

--- a/packages/client/abi/ExitsComponent.json
+++ b/packages/client/abi/ExitsComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/ExperienceComponent.json
+++ b/packages/client/abi/ExperienceComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/FarcasterIndexComponent.json
+++ b/packages/client/abi/FarcasterIndexComponent.json
@@ -253,24 +253,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -566,7 +548,6 @@
     "getEntitiesWithValue(uint32)": "447e2bd2",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/ForComponent.json
+++ b/packages/client/abi/ForComponent.json
@@ -253,24 +253,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -566,7 +548,6 @@
     "getEntitiesWithValue(uint256)": "fbdfa1ea",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/FromPrototypeComponent.json
+++ b/packages/client/abi/FromPrototypeComponent.json
@@ -190,24 +190,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "getValue",
       "inputs": [
         {
@@ -501,7 +483,6 @@
     "getEntitiesWithValue(uint256)": "fbdfa1ea",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "getValue(uint256)": "0ff4c916",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",

--- a/packages/client/abi/HarmonyComponent.json
+++ b/packages/client/abi/HarmonyComponent.json
@@ -341,24 +341,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -756,7 +738,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/HashComponent.json
+++ b/packages/client/abi/HashComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -520,7 +502,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/HealthComponent.json
+++ b/packages/client/abi/HealthComponent.json
@@ -341,24 +341,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -756,7 +738,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IDOwnsInventoryComponent.json
+++ b/packages/client/abi/IDOwnsInventoryComponent.json
@@ -253,24 +253,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -566,7 +548,6 @@
     "getEntitiesWithValue(uint256)": "fbdfa1ea",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IDOwnsPetComponent.json
+++ b/packages/client/abi/IDOwnsPetComponent.json
@@ -253,24 +253,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -566,7 +548,6 @@
     "getEntitiesWithValue(uint256)": "fbdfa1ea",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IDOwnsQuestComponent.json
+++ b/packages/client/abi/IDOwnsQuestComponent.json
@@ -253,24 +253,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -566,7 +548,6 @@
     "getEntitiesWithValue(uint256)": "fbdfa1ea",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IDOwnsRelationshipComponent.json
+++ b/packages/client/abi/IDOwnsRelationshipComponent.json
@@ -253,24 +253,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -566,7 +548,6 @@
     "getEntitiesWithValue(uint256)": "fbdfa1ea",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IDPointerComponent.json
+++ b/packages/client/abi/IDPointerComponent.json
@@ -253,24 +253,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -566,7 +548,6 @@
     "getEntitiesWithValue(uint256)": "fbdfa1ea",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IDRoomComponent.json
+++ b/packages/client/abi/IDRoomComponent.json
@@ -253,24 +253,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -566,7 +548,6 @@
     "getEntitiesWithValue(uint256)": "fbdfa1ea",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IDScoreTypeComponent.json
+++ b/packages/client/abi/IDScoreTypeComponent.json
@@ -253,24 +253,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -566,7 +548,6 @@
     "getEntitiesWithValue(uint256)": "fbdfa1ea",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IdAccountComponent.json
+++ b/packages/client/abi/IdAccountComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IdDelegateeComponent.json
+++ b/packages/client/abi/IdDelegateeComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IdDelegatorComponent.json
+++ b/packages/client/abi/IdDelegatorComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IdHolderComponent.json
+++ b/packages/client/abi/IdHolderComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IdNodeComponent.json
+++ b/packages/client/abi/IdNodeComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IdPetComponent.json
+++ b/packages/client/abi/IdPetComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IdRequesteeComponent.json
+++ b/packages/client/abi/IdRequesteeComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IdRequesterComponent.json
+++ b/packages/client/abi/IdRequesterComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IdSourceComponent.json
+++ b/packages/client/abi/IdSourceComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IdTargetComponent.json
+++ b/packages/client/abi/IdTargetComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IndexAccountComponent.json
+++ b/packages/client/abi/IndexAccountComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IndexBackgroundComponent.json
+++ b/packages/client/abi/IndexBackgroundComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IndexBodyComponent.json
+++ b/packages/client/abi/IndexBodyComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IndexColorComponent.json
+++ b/packages/client/abi/IndexColorComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IndexComponent.json
+++ b/packages/client/abi/IndexComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IndexFaceComponent.json
+++ b/packages/client/abi/IndexFaceComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IndexHandComponent.json
+++ b/packages/client/abi/IndexHandComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IndexItemComponent.json
+++ b/packages/client/abi/IndexItemComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IndexNPCComponent.json
+++ b/packages/client/abi/IndexNPCComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IndexNodeComponent.json
+++ b/packages/client/abi/IndexNodeComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IndexPetComponent.json
+++ b/packages/client/abi/IndexPetComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IndexQuestComponent.json
+++ b/packages/client/abi/IndexQuestComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IndexRelationshipComponent.json
+++ b/packages/client/abi/IndexRelationshipComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IndexRoomComponent.json
+++ b/packages/client/abi/IndexRoomComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IndexSkillComponent.json
+++ b/packages/client/abi/IndexSkillComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/Int256BareComponent.json
+++ b/packages/client/abi/Int256BareComponent.json
@@ -215,24 +215,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -507,7 +489,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/Int32BareComponent.json
+++ b/packages/client/abi/Int32BareComponent.json
@@ -215,24 +215,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -507,7 +489,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/Int32Component.json
+++ b/packages/client/abi/Int32Component.json
@@ -258,24 +258,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -571,7 +553,6 @@
     "getEntitiesWithValue(int32)": "926cbc9f",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IsAccountComponent.json
+++ b/packages/client/abi/IsAccountComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IsBonusComponent.json
+++ b/packages/client/abi/IsBonusComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IsCompleteComponent.json
+++ b/packages/client/abi/IsCompleteComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IsConditionComponent.json
+++ b/packages/client/abi/IsConditionComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IsConsumableComponent.json
+++ b/packages/client/abi/IsConsumableComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IsEffectComponent.json
+++ b/packages/client/abi/IsEffectComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IsEquippedComponent.json
+++ b/packages/client/abi/IsEquippedComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IsFriendshipComponent.json
+++ b/packages/client/abi/IsFriendshipComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IsGoalComponent.json
+++ b/packages/client/abi/IsGoalComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IsInventoryComponent.json
+++ b/packages/client/abi/IsInventoryComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IsKillComponent.json
+++ b/packages/client/abi/IsKillComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IsListingComponent.json
+++ b/packages/client/abi/IsListingComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IsLogComponent.json
+++ b/packages/client/abi/IsLogComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IsLootboxComponent.json
+++ b/packages/client/abi/IsLootboxComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IsNPCComponent.json
+++ b/packages/client/abi/IsNPCComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IsNodeComponent.json
+++ b/packages/client/abi/IsNodeComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IsObjectiveComponent.json
+++ b/packages/client/abi/IsObjectiveComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IsPetComponent.json
+++ b/packages/client/abi/IsPetComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IsProductionComponent.json
+++ b/packages/client/abi/IsProductionComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IsQuestComponent.json
+++ b/packages/client/abi/IsQuestComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IsRegisterComponent.json
+++ b/packages/client/abi/IsRegisterComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IsRegistryComponent.json
+++ b/packages/client/abi/IsRegistryComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IsRelationshipComponent.json
+++ b/packages/client/abi/IsRelationshipComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IsRepeatableComponent.json
+++ b/packages/client/abi/IsRepeatableComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IsRequestComponent.json
+++ b/packages/client/abi/IsRequestComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IsRequirementComponent.json
+++ b/packages/client/abi/IsRequirementComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IsRewardComponent.json
+++ b/packages/client/abi/IsRewardComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IsRoomComponent.json
+++ b/packages/client/abi/IsRoomComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IsSkillComponent.json
+++ b/packages/client/abi/IsSkillComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/IsTradeComponent.json
+++ b/packages/client/abi/IsTradeComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/KeysComponent.json
+++ b/packages/client/abi/KeysComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/LevelComponent.json
+++ b/packages/client/abi/LevelComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/LocationComponent.json
+++ b/packages/client/abi/LocationComponent.json
@@ -338,24 +338,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -685,7 +667,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/LogicTypeComponent.json
+++ b/packages/client/abi/LogicTypeComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -526,7 +508,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "hasValue(uint256,string)": "9d72b0e1",
     "id()": "af640d0f",

--- a/packages/client/abi/MaxComponent.json
+++ b/packages/client/abi/MaxComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/MediaURIComponent.json
+++ b/packages/client/abi/MediaURIComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/NameComponent.json
+++ b/packages/client/abi/NameComponent.json
@@ -253,24 +253,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -590,7 +572,6 @@
     "getEntitiesWithValue(string)": "f94655da",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "hasValue(uint256,string)": "9d72b0e1",
     "id()": "af640d0f",

--- a/packages/client/abi/OwnedByEntityComponent.json
+++ b/packages/client/abi/OwnedByEntityComponent.json
@@ -190,24 +190,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "getValue",
       "inputs": [
         {
@@ -501,7 +483,6 @@
     "getEntitiesWithValue(uint256)": "fbdfa1ea",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "getValue(uint256)": "0ff4c916",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",

--- a/packages/client/abi/PositionComponent.json
+++ b/packages/client/abi/PositionComponent.json
@@ -189,24 +189,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "getValue",
       "inputs": [
         {
@@ -523,7 +505,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "getValue(uint256)": "0ff4c916",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",

--- a/packages/client/abi/PowerComponent.json
+++ b/packages/client/abi/PowerComponent.json
@@ -341,24 +341,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -756,7 +738,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/PriceBuyComponent.json
+++ b/packages/client/abi/PriceBuyComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/PriceSellComponent.json
+++ b/packages/client/abi/PriceSellComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/PrototypeTagComponent.json
+++ b/packages/client/abi/PrototypeTagComponent.json
@@ -190,24 +190,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "getValue",
       "inputs": [
         {
@@ -501,7 +483,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "getValue(uint256)": "0ff4c916",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",

--- a/packages/client/abi/ProxyPermissionsERC721Component.json
+++ b/packages/client/abi/ProxyPermissionsERC721Component.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/ProxyPermissionsFarm20Component.json
+++ b/packages/client/abi/ProxyPermissionsFarm20Component.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/ProxyPermissionsMint20Component.json
+++ b/packages/client/abi/ProxyPermissionsMint20Component.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -492,7 +474,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/RarityComponent.json
+++ b/packages/client/abi/RarityComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/RateComponent.json
+++ b/packages/client/abi/RateComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/RerollComponent.json
+++ b/packages/client/abi/RerollComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/SkillPointComponent.json
+++ b/packages/client/abi/SkillPointComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/SlotsComponent.json
+++ b/packages/client/abi/SlotsComponent.json
@@ -341,24 +341,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -756,7 +738,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/StaminaComponent.json
+++ b/packages/client/abi/StaminaComponent.json
@@ -341,24 +341,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -756,7 +738,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/StatComponent.json
+++ b/packages/client/abi/StatComponent.json
@@ -346,24 +346,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -761,7 +743,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/StateComponent.json
+++ b/packages/client/abi/StateComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -526,7 +508,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "hasValue(uint256,string)": "9d72b0e1",
     "id()": "af640d0f",

--- a/packages/client/abi/StringBareComponent.json
+++ b/packages/client/abi/StringBareComponent.json
@@ -215,24 +215,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -507,7 +489,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/StringComponent.json
+++ b/packages/client/abi/StringComponent.json
@@ -258,24 +258,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -571,7 +553,6 @@
     "getEntitiesWithValue(string)": "f94655da",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/SubtypeComponent.json
+++ b/packages/client/abi/SubtypeComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -526,7 +508,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "hasValue(uint256,string)": "9d72b0e1",
     "id()": "af640d0f",

--- a/packages/client/abi/TestComponent.json
+++ b/packages/client/abi/TestComponent.json
@@ -171,24 +171,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -444,7 +426,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/TestComponent1.json
+++ b/packages/client/abi/TestComponent1.json
@@ -171,24 +171,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -444,7 +426,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/TestComponent2.json
+++ b/packages/client/abi/TestComponent2.json
@@ -171,24 +171,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -444,7 +426,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/TestComponent3.json
+++ b/packages/client/abi/TestComponent3.json
@@ -171,24 +171,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -444,7 +426,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/TestComponent4.json
+++ b/packages/client/abi/TestComponent4.json
@@ -171,24 +171,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -444,7 +426,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/TimeComponent.json
+++ b/packages/client/abi/TimeComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/TimeLastActionComponent.json
+++ b/packages/client/abi/TimeLastActionComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/TimeLastComponent.json
+++ b/packages/client/abi/TimeLastComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/TimeResetComponent.json
+++ b/packages/client/abi/TimeResetComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/TimeStartComponent.json
+++ b/packages/client/abi/TimeStartComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/TimelockComponent.json
+++ b/packages/client/abi/TimelockComponent.json
@@ -230,24 +230,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -539,7 +521,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/TypeComponent.json
+++ b/packages/client/abi/TypeComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -526,7 +508,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "hasValue(uint256,string)": "9d72b0e1",
     "id()": "af640d0f",

--- a/packages/client/abi/Uint256ArrayBareComponent.json
+++ b/packages/client/abi/Uint256ArrayBareComponent.json
@@ -215,24 +215,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -507,7 +489,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/Uint256ArrayComponent.json
+++ b/packages/client/abi/Uint256ArrayComponent.json
@@ -258,24 +258,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -571,7 +553,6 @@
     "getEntitiesWithValue(uint256[])": "963e9eb0",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/Uint256BareComponent.json
+++ b/packages/client/abi/Uint256BareComponent.json
@@ -215,24 +215,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -507,7 +489,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/Uint32ArrayBareComponent.json
+++ b/packages/client/abi/Uint32ArrayBareComponent.json
@@ -215,24 +215,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -507,7 +489,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/Uint32ArrayComponent.json
+++ b/packages/client/abi/Uint32ArrayComponent.json
@@ -258,24 +258,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -571,7 +553,6 @@
     "getEntitiesWithValue(uint32[])": "bd2746e7",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/Uint32BareComponent.json
+++ b/packages/client/abi/Uint32BareComponent.json
@@ -215,24 +215,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -507,7 +489,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/Uint32Component.json
+++ b/packages/client/abi/Uint32Component.json
@@ -258,24 +258,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -571,7 +553,6 @@
     "getEntitiesWithValue(uint32)": "447e2bd2",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/ValueComponent.json
+++ b/packages/client/abi/ValueComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/ValueSignedComponent.json
+++ b/packages/client/abi/ValueSignedComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/ValuesComponent.json
+++ b/packages/client/abi/ValuesComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/ViolenceComponent.json
+++ b/packages/client/abi/ViolenceComponent.json
@@ -341,24 +341,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -756,7 +738,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/WeightsComponent.json
+++ b/packages/client/abi/WeightsComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/abi/WhitelistComponent.json
+++ b/packages/client/abi/WhitelistComponent.json
@@ -210,24 +210,6 @@
     },
     {
       "type": "function",
-      "name": "getSchema",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "keys",
-          "type": "string[]",
-          "internalType": "string[]"
-        },
-        {
-          "name": "values",
-          "type": "uint8[]",
-          "internalType": "enum LibTypes.SchemaValue[]"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
       "name": "has",
       "inputs": [
         {
@@ -502,7 +484,6 @@
     "getEntitiesWithValue(bytes)": "b361be46",
     "getRaw(uint256)": "dd98e3c9",
     "getRawBatch(uint256[])": "4323c4ef",
-    "getSchema()": "6b122fe0",
     "has(uint256)": "cccf7a8e",
     "id()": "af640d0f",
     "owner()": "8da5cb5b",

--- a/packages/client/types/ethers-contracts/AddressBareComponent.ts
+++ b/packages/client/types/ethers-contracts/AddressBareComponent.ts
@@ -40,7 +40,6 @@ export interface AddressBareComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface AddressBareComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface AddressBareComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface AddressBareComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface AddressBareComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface AddressBareComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface AddressBareComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface AddressBareComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface AddressBareComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/AddressComponent.ts
+++ b/packages/client/types/ethers-contracts/AddressComponent.ts
@@ -42,7 +42,6 @@ export interface AddressComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -75,7 +74,6 @@ export interface AddressComponentInterface extends utils.Interface {
       | "getEntitiesWithValue(bytes)"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -145,7 +143,6 @@ export interface AddressComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -232,7 +229,6 @@ export interface AddressComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -385,10 +381,6 @@ export interface AddressComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -523,10 +515,6 @@ export interface AddressComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -660,10 +648,6 @@ export interface AddressComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -811,8 +795,6 @@ export interface AddressComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -947,8 +929,6 @@ export interface AddressComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/AddressOperatorComponent.ts
+++ b/packages/client/types/ethers-contracts/AddressOperatorComponent.ts
@@ -42,7 +42,6 @@ export interface AddressOperatorComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -75,7 +74,6 @@ export interface AddressOperatorComponentInterface extends utils.Interface {
       | "getEntitiesWithValue(bytes)"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -145,7 +143,6 @@ export interface AddressOperatorComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -232,7 +229,6 @@ export interface AddressOperatorComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -385,10 +381,6 @@ export interface AddressOperatorComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -523,10 +515,6 @@ export interface AddressOperatorComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -660,10 +648,6 @@ export interface AddressOperatorComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -811,8 +795,6 @@ export interface AddressOperatorComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -947,8 +929,6 @@ export interface AddressOperatorComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/AddressOwnerComponent.ts
+++ b/packages/client/types/ethers-contracts/AddressOwnerComponent.ts
@@ -42,7 +42,6 @@ export interface AddressOwnerComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -75,7 +74,6 @@ export interface AddressOwnerComponentInterface extends utils.Interface {
       | "getEntitiesWithValue(bytes)"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -145,7 +143,6 @@ export interface AddressOwnerComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -232,7 +229,6 @@ export interface AddressOwnerComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -385,10 +381,6 @@ export interface AddressOwnerComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -523,10 +515,6 @@ export interface AddressOwnerComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -660,10 +648,6 @@ export interface AddressOwnerComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -811,8 +795,6 @@ export interface AddressOwnerComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -947,8 +929,6 @@ export interface AddressOwnerComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/AffinityComponent.ts
+++ b/packages/client/types/ethers-contracts/AffinityComponent.ts
@@ -40,7 +40,6 @@ export interface AffinityComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "hasValue(uint256,string)": FunctionFragment;
     "id()": FunctionFragment;
@@ -71,7 +70,6 @@ export interface AffinityComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "hasValue"
       | "id"
@@ -133,7 +131,6 @@ export interface AffinityComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -215,7 +212,6 @@ export interface AffinityComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "hasValue", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
@@ -357,10 +353,6 @@ export interface AffinityComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -485,10 +477,6 @@ export interface AffinityComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -612,10 +600,6 @@ export interface AffinityComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -753,8 +737,6 @@ export interface AffinityComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -879,8 +861,6 @@ export interface AffinityComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/BlacklistComponent.ts
+++ b/packages/client/types/ethers-contracts/BlacklistComponent.ts
@@ -40,7 +40,6 @@ export interface BlacklistComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface BlacklistComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface BlacklistComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface BlacklistComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface BlacklistComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface BlacklistComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface BlacklistComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface BlacklistComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface BlacklistComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/BlockRevealComponent.ts
+++ b/packages/client/types/ethers-contracts/BlockRevealComponent.ts
@@ -40,7 +40,6 @@ export interface BlockRevealComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface BlockRevealComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface BlockRevealComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface BlockRevealComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface BlockRevealComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface BlockRevealComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface BlockRevealComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface BlockRevealComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface BlockRevealComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/BoolBareComponent.ts
+++ b/packages/client/types/ethers-contracts/BoolBareComponent.ts
@@ -40,7 +40,6 @@ export interface BoolBareComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface BoolBareComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface BoolBareComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface BoolBareComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface BoolBareComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface BoolBareComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface BoolBareComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface BoolBareComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface BoolBareComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/BoolComponent.ts
+++ b/packages/client/types/ethers-contracts/BoolComponent.ts
@@ -42,7 +42,6 @@ export interface BoolComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -75,7 +74,6 @@ export interface BoolComponentInterface extends utils.Interface {
       | "getEntitiesWithValue(bytes)"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -145,7 +143,6 @@ export interface BoolComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -232,7 +229,6 @@ export interface BoolComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -385,10 +381,6 @@ export interface BoolComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -521,10 +513,6 @@ export interface BoolComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -656,10 +644,6 @@ export interface BoolComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -805,8 +789,6 @@ export interface BoolComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -939,8 +921,6 @@ export interface BoolComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/CacheOperatorComponent.ts
+++ b/packages/client/types/ethers-contracts/CacheOperatorComponent.ts
@@ -40,7 +40,6 @@ export interface CacheOperatorComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface CacheOperatorComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface CacheOperatorComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface CacheOperatorComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface CacheOperatorComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface CacheOperatorComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface CacheOperatorComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface CacheOperatorComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface CacheOperatorComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/CanNameComponent.ts
+++ b/packages/client/types/ethers-contracts/CanNameComponent.ts
@@ -40,7 +40,6 @@ export interface CanNameComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface CanNameComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface CanNameComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface CanNameComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface CanNameComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface CanNameComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface CanNameComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface CanNameComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface CanNameComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/CoordComponent.ts
+++ b/packages/client/types/ethers-contracts/CoordComponent.ts
@@ -54,7 +54,6 @@ export interface CoordComponentInterface extends utils.Interface {
     "getEntitiesWithValue((int32,int32,int32))": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -87,7 +86,6 @@ export interface CoordComponentInterface extends utils.Interface {
       | "getEntitiesWithValue((int32,int32,int32))"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -157,7 +155,6 @@ export interface CoordComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -244,7 +241,6 @@ export interface CoordComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -397,10 +393,6 @@ export interface CoordComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -535,10 +527,6 @@ export interface CoordComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -672,10 +660,6 @@ export interface CoordComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -823,8 +807,6 @@ export interface CoordComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -959,8 +941,6 @@ export interface CoordComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/CostComponent.ts
+++ b/packages/client/types/ethers-contracts/CostComponent.ts
@@ -40,7 +40,6 @@ export interface CostComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface CostComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface CostComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface CostComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface CostComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface CostComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface CostComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface CostComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface CostComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/DamageComponent.ts
+++ b/packages/client/types/ethers-contracts/DamageComponent.ts
@@ -38,7 +38,6 @@ export interface DamageComponentInterface extends utils.Interface {
     "getEntitiesWithValue(uint256)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "getValue(uint256)": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
@@ -67,7 +66,6 @@ export interface DamageComponentInterface extends utils.Interface {
       | "getEntitiesWithValue(uint256)"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "getValue"
       | "has"
       | "id"
@@ -121,7 +119,6 @@ export interface DamageComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "getValue",
     values: [PromiseOrValue<BigNumberish>]
@@ -201,7 +198,6 @@ export interface DamageComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "getValue", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
@@ -328,10 +324,6 @@ export interface DamageComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     getValue(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -445,10 +437,6 @@ export interface DamageComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   getValue(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -561,10 +549,6 @@ export interface DamageComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     getValue(
       entity: PromiseOrValue<BigNumberish>,
@@ -691,8 +675,6 @@ export interface DamageComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     getValue(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -806,8 +788,6 @@ export interface DamageComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     getValue(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/DescriptionAltComponent.ts
+++ b/packages/client/types/ethers-contracts/DescriptionAltComponent.ts
@@ -40,7 +40,6 @@ export interface DescriptionAltComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "hasValue(uint256,string)": FunctionFragment;
     "id()": FunctionFragment;
@@ -71,7 +70,6 @@ export interface DescriptionAltComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "hasValue"
       | "id"
@@ -133,7 +131,6 @@ export interface DescriptionAltComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -215,7 +212,6 @@ export interface DescriptionAltComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "hasValue", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
@@ -357,10 +353,6 @@ export interface DescriptionAltComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -485,10 +477,6 @@ export interface DescriptionAltComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -612,10 +600,6 @@ export interface DescriptionAltComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -753,8 +737,6 @@ export interface DescriptionAltComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -879,8 +861,6 @@ export interface DescriptionAltComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/DescriptionComponent.ts
+++ b/packages/client/types/ethers-contracts/DescriptionComponent.ts
@@ -40,7 +40,6 @@ export interface DescriptionComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "hasValue(uint256,string)": FunctionFragment;
     "id()": FunctionFragment;
@@ -71,7 +70,6 @@ export interface DescriptionComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "hasValue"
       | "id"
@@ -133,7 +131,6 @@ export interface DescriptionComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -215,7 +212,6 @@ export interface DescriptionComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "hasValue", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
@@ -357,10 +353,6 @@ export interface DescriptionComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -485,10 +477,6 @@ export interface DescriptionComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -612,10 +600,6 @@ export interface DescriptionComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -753,8 +737,6 @@ export interface DescriptionComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -879,8 +861,6 @@ export interface DescriptionComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/ExitsComponent.ts
+++ b/packages/client/types/ethers-contracts/ExitsComponent.ts
@@ -40,7 +40,6 @@ export interface ExitsComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface ExitsComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface ExitsComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface ExitsComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface ExitsComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface ExitsComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface ExitsComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface ExitsComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface ExitsComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/ExperienceComponent.ts
+++ b/packages/client/types/ethers-contracts/ExperienceComponent.ts
@@ -40,7 +40,6 @@ export interface ExperienceComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface ExperienceComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface ExperienceComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface ExperienceComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface ExperienceComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface ExperienceComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface ExperienceComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface ExperienceComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface ExperienceComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/FarcasterIndexComponent.ts
+++ b/packages/client/types/ethers-contracts/FarcasterIndexComponent.ts
@@ -42,7 +42,6 @@ export interface FarcasterIndexComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -75,7 +74,6 @@ export interface FarcasterIndexComponentInterface extends utils.Interface {
       | "getEntitiesWithValue(bytes)"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -145,7 +143,6 @@ export interface FarcasterIndexComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -232,7 +229,6 @@ export interface FarcasterIndexComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -385,10 +381,6 @@ export interface FarcasterIndexComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -523,10 +515,6 @@ export interface FarcasterIndexComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -660,10 +648,6 @@ export interface FarcasterIndexComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -811,8 +795,6 @@ export interface FarcasterIndexComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -947,8 +929,6 @@ export interface FarcasterIndexComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/ForComponent.ts
+++ b/packages/client/types/ethers-contracts/ForComponent.ts
@@ -42,7 +42,6 @@ export interface ForComponentInterface extends utils.Interface {
     "getEntitiesWithValue(uint256)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -75,7 +74,6 @@ export interface ForComponentInterface extends utils.Interface {
       | "getEntitiesWithValue(uint256)"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -145,7 +143,6 @@ export interface ForComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -232,7 +229,6 @@ export interface ForComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -385,10 +381,6 @@ export interface ForComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -523,10 +515,6 @@ export interface ForComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -660,10 +648,6 @@ export interface ForComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -811,8 +795,6 @@ export interface ForComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -947,8 +929,6 @@ export interface ForComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/FromPrototypeComponent.ts
+++ b/packages/client/types/ethers-contracts/FromPrototypeComponent.ts
@@ -39,7 +39,6 @@ export interface FromPrototypeComponentInterface extends utils.Interface {
     "getEntitiesWithValue(uint256)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "getValue(uint256)": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
@@ -69,7 +68,6 @@ export interface FromPrototypeComponentInterface extends utils.Interface {
       | "getEntitiesWithValue(uint256)"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "getValue"
       | "has"
       | "id"
@@ -124,7 +122,6 @@ export interface FromPrototypeComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "getValue",
     values: [PromiseOrValue<BigNumberish>]
@@ -205,7 +202,6 @@ export interface FromPrototypeComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "getValue", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
@@ -334,10 +330,6 @@ export interface FromPrototypeComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     getValue(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -453,10 +445,6 @@ export interface FromPrototypeComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   getValue(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -571,10 +559,6 @@ export interface FromPrototypeComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     getValue(
       entity: PromiseOrValue<BigNumberish>,
@@ -703,8 +687,6 @@ export interface FromPrototypeComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     getValue(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -820,8 +802,6 @@ export interface FromPrototypeComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     getValue(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/HarmonyComponent.ts
+++ b/packages/client/types/ethers-contracts/HarmonyComponent.ts
@@ -56,7 +56,6 @@ export interface HarmonyComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -91,7 +90,6 @@ export interface HarmonyComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -163,7 +161,6 @@ export interface HarmonyComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -259,7 +256,6 @@ export interface HarmonyComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -420,10 +416,6 @@ export interface HarmonyComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -572,10 +564,6 @@ export interface HarmonyComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -723,10 +711,6 @@ export interface HarmonyComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -888,8 +872,6 @@ export interface HarmonyComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -1038,8 +1020,6 @@ export interface HarmonyComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/HashComponent.ts
+++ b/packages/client/types/ethers-contracts/HashComponent.ts
@@ -40,7 +40,6 @@ export interface HashComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -71,7 +70,6 @@ export interface HashComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -133,7 +131,6 @@ export interface HashComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -215,7 +212,6 @@ export interface HashComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -360,10 +356,6 @@ export interface HashComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -488,10 +480,6 @@ export interface HashComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -615,10 +603,6 @@ export interface HashComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -756,8 +740,6 @@ export interface HashComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -882,8 +864,6 @@ export interface HashComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/HealthComponent.ts
+++ b/packages/client/types/ethers-contracts/HealthComponent.ts
@@ -56,7 +56,6 @@ export interface HealthComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -91,7 +90,6 @@ export interface HealthComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -163,7 +161,6 @@ export interface HealthComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -259,7 +256,6 @@ export interface HealthComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -420,10 +416,6 @@ export interface HealthComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -572,10 +564,6 @@ export interface HealthComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -723,10 +711,6 @@ export interface HealthComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -888,8 +872,6 @@ export interface HealthComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -1038,8 +1020,6 @@ export interface HealthComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IDOwnsInventoryComponent.ts
+++ b/packages/client/types/ethers-contracts/IDOwnsInventoryComponent.ts
@@ -42,7 +42,6 @@ export interface IDOwnsInventoryComponentInterface extends utils.Interface {
     "getEntitiesWithValue(uint256)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -75,7 +74,6 @@ export interface IDOwnsInventoryComponentInterface extends utils.Interface {
       | "getEntitiesWithValue(uint256)"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -145,7 +143,6 @@ export interface IDOwnsInventoryComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -232,7 +229,6 @@ export interface IDOwnsInventoryComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -385,10 +381,6 @@ export interface IDOwnsInventoryComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -523,10 +515,6 @@ export interface IDOwnsInventoryComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -660,10 +648,6 @@ export interface IDOwnsInventoryComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -811,8 +795,6 @@ export interface IDOwnsInventoryComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -947,8 +929,6 @@ export interface IDOwnsInventoryComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IDOwnsPetComponent.ts
+++ b/packages/client/types/ethers-contracts/IDOwnsPetComponent.ts
@@ -42,7 +42,6 @@ export interface IDOwnsPetComponentInterface extends utils.Interface {
     "getEntitiesWithValue(uint256)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -75,7 +74,6 @@ export interface IDOwnsPetComponentInterface extends utils.Interface {
       | "getEntitiesWithValue(uint256)"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -145,7 +143,6 @@ export interface IDOwnsPetComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -232,7 +229,6 @@ export interface IDOwnsPetComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -385,10 +381,6 @@ export interface IDOwnsPetComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -523,10 +515,6 @@ export interface IDOwnsPetComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -660,10 +648,6 @@ export interface IDOwnsPetComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -811,8 +795,6 @@ export interface IDOwnsPetComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -947,8 +929,6 @@ export interface IDOwnsPetComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IDOwnsQuestComponent.ts
+++ b/packages/client/types/ethers-contracts/IDOwnsQuestComponent.ts
@@ -42,7 +42,6 @@ export interface IDOwnsQuestComponentInterface extends utils.Interface {
     "getEntitiesWithValue(uint256)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -75,7 +74,6 @@ export interface IDOwnsQuestComponentInterface extends utils.Interface {
       | "getEntitiesWithValue(uint256)"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -145,7 +143,6 @@ export interface IDOwnsQuestComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -232,7 +229,6 @@ export interface IDOwnsQuestComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -385,10 +381,6 @@ export interface IDOwnsQuestComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -523,10 +515,6 @@ export interface IDOwnsQuestComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -660,10 +648,6 @@ export interface IDOwnsQuestComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -811,8 +795,6 @@ export interface IDOwnsQuestComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -947,8 +929,6 @@ export interface IDOwnsQuestComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IDOwnsRelationshipComponent.ts
+++ b/packages/client/types/ethers-contracts/IDOwnsRelationshipComponent.ts
@@ -42,7 +42,6 @@ export interface IDOwnsRelationshipComponentInterface extends utils.Interface {
     "getEntitiesWithValue(uint256)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -75,7 +74,6 @@ export interface IDOwnsRelationshipComponentInterface extends utils.Interface {
       | "getEntitiesWithValue(uint256)"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -145,7 +143,6 @@ export interface IDOwnsRelationshipComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -232,7 +229,6 @@ export interface IDOwnsRelationshipComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -385,10 +381,6 @@ export interface IDOwnsRelationshipComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -523,10 +515,6 @@ export interface IDOwnsRelationshipComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -660,10 +648,6 @@ export interface IDOwnsRelationshipComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -811,8 +795,6 @@ export interface IDOwnsRelationshipComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -947,8 +929,6 @@ export interface IDOwnsRelationshipComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IDPointerComponent.ts
+++ b/packages/client/types/ethers-contracts/IDPointerComponent.ts
@@ -42,7 +42,6 @@ export interface IDPointerComponentInterface extends utils.Interface {
     "getEntitiesWithValue(uint256)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -75,7 +74,6 @@ export interface IDPointerComponentInterface extends utils.Interface {
       | "getEntitiesWithValue(uint256)"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -145,7 +143,6 @@ export interface IDPointerComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -232,7 +229,6 @@ export interface IDPointerComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -385,10 +381,6 @@ export interface IDPointerComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -523,10 +515,6 @@ export interface IDPointerComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -660,10 +648,6 @@ export interface IDPointerComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -811,8 +795,6 @@ export interface IDPointerComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -947,8 +929,6 @@ export interface IDPointerComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IDRoomComponent.ts
+++ b/packages/client/types/ethers-contracts/IDRoomComponent.ts
@@ -42,7 +42,6 @@ export interface IDRoomComponentInterface extends utils.Interface {
     "getEntitiesWithValue(uint256)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -75,7 +74,6 @@ export interface IDRoomComponentInterface extends utils.Interface {
       | "getEntitiesWithValue(uint256)"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -145,7 +143,6 @@ export interface IDRoomComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -232,7 +229,6 @@ export interface IDRoomComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -385,10 +381,6 @@ export interface IDRoomComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -523,10 +515,6 @@ export interface IDRoomComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -660,10 +648,6 @@ export interface IDRoomComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -811,8 +795,6 @@ export interface IDRoomComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -947,8 +929,6 @@ export interface IDRoomComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IDScoreTypeComponent.ts
+++ b/packages/client/types/ethers-contracts/IDScoreTypeComponent.ts
@@ -42,7 +42,6 @@ export interface IDScoreTypeComponentInterface extends utils.Interface {
     "getEntitiesWithValue(uint256)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -75,7 +74,6 @@ export interface IDScoreTypeComponentInterface extends utils.Interface {
       | "getEntitiesWithValue(uint256)"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -145,7 +143,6 @@ export interface IDScoreTypeComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -232,7 +229,6 @@ export interface IDScoreTypeComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -385,10 +381,6 @@ export interface IDScoreTypeComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -523,10 +515,6 @@ export interface IDScoreTypeComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -660,10 +648,6 @@ export interface IDScoreTypeComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -811,8 +795,6 @@ export interface IDScoreTypeComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -947,8 +929,6 @@ export interface IDScoreTypeComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IdAccountComponent.ts
+++ b/packages/client/types/ethers-contracts/IdAccountComponent.ts
@@ -40,7 +40,6 @@ export interface IdAccountComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IdAccountComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IdAccountComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IdAccountComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IdAccountComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface IdAccountComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface IdAccountComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface IdAccountComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface IdAccountComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IdDelegateeComponent.ts
+++ b/packages/client/types/ethers-contracts/IdDelegateeComponent.ts
@@ -40,7 +40,6 @@ export interface IdDelegateeComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IdDelegateeComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IdDelegateeComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IdDelegateeComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IdDelegateeComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface IdDelegateeComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface IdDelegateeComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface IdDelegateeComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface IdDelegateeComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IdDelegatorComponent.ts
+++ b/packages/client/types/ethers-contracts/IdDelegatorComponent.ts
@@ -40,7 +40,6 @@ export interface IdDelegatorComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IdDelegatorComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IdDelegatorComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IdDelegatorComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IdDelegatorComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface IdDelegatorComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface IdDelegatorComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface IdDelegatorComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface IdDelegatorComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IdHolderComponent.ts
+++ b/packages/client/types/ethers-contracts/IdHolderComponent.ts
@@ -40,7 +40,6 @@ export interface IdHolderComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IdHolderComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IdHolderComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IdHolderComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IdHolderComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface IdHolderComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface IdHolderComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface IdHolderComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface IdHolderComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IdNodeComponent.ts
+++ b/packages/client/types/ethers-contracts/IdNodeComponent.ts
@@ -40,7 +40,6 @@ export interface IdNodeComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IdNodeComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IdNodeComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IdNodeComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IdNodeComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface IdNodeComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface IdNodeComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface IdNodeComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface IdNodeComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IdPetComponent.ts
+++ b/packages/client/types/ethers-contracts/IdPetComponent.ts
@@ -40,7 +40,6 @@ export interface IdPetComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IdPetComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IdPetComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IdPetComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IdPetComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface IdPetComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface IdPetComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface IdPetComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface IdPetComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IdRequesteeComponent.ts
+++ b/packages/client/types/ethers-contracts/IdRequesteeComponent.ts
@@ -40,7 +40,6 @@ export interface IdRequesteeComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IdRequesteeComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IdRequesteeComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IdRequesteeComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IdRequesteeComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface IdRequesteeComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface IdRequesteeComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface IdRequesteeComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface IdRequesteeComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IdRequesterComponent.ts
+++ b/packages/client/types/ethers-contracts/IdRequesterComponent.ts
@@ -40,7 +40,6 @@ export interface IdRequesterComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IdRequesterComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IdRequesterComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IdRequesterComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IdRequesterComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface IdRequesterComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface IdRequesterComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface IdRequesterComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface IdRequesterComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IdSourceComponent.ts
+++ b/packages/client/types/ethers-contracts/IdSourceComponent.ts
@@ -40,7 +40,6 @@ export interface IdSourceComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IdSourceComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IdSourceComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IdSourceComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IdSourceComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface IdSourceComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface IdSourceComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface IdSourceComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface IdSourceComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IdTargetComponent.ts
+++ b/packages/client/types/ethers-contracts/IdTargetComponent.ts
@@ -40,7 +40,6 @@ export interface IdTargetComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IdTargetComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IdTargetComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IdTargetComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IdTargetComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface IdTargetComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface IdTargetComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface IdTargetComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface IdTargetComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IndexAccountComponent.ts
+++ b/packages/client/types/ethers-contracts/IndexAccountComponent.ts
@@ -40,7 +40,6 @@ export interface IndexAccountComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IndexAccountComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IndexAccountComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IndexAccountComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IndexAccountComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface IndexAccountComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface IndexAccountComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface IndexAccountComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface IndexAccountComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IndexBackgroundComponent.ts
+++ b/packages/client/types/ethers-contracts/IndexBackgroundComponent.ts
@@ -40,7 +40,6 @@ export interface IndexBackgroundComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IndexBackgroundComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IndexBackgroundComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IndexBackgroundComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IndexBackgroundComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface IndexBackgroundComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface IndexBackgroundComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface IndexBackgroundComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface IndexBackgroundComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IndexBodyComponent.ts
+++ b/packages/client/types/ethers-contracts/IndexBodyComponent.ts
@@ -40,7 +40,6 @@ export interface IndexBodyComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IndexBodyComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IndexBodyComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IndexBodyComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IndexBodyComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface IndexBodyComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface IndexBodyComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface IndexBodyComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface IndexBodyComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IndexColorComponent.ts
+++ b/packages/client/types/ethers-contracts/IndexColorComponent.ts
@@ -40,7 +40,6 @@ export interface IndexColorComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IndexColorComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IndexColorComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IndexColorComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IndexColorComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface IndexColorComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface IndexColorComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface IndexColorComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface IndexColorComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IndexComponent.ts
+++ b/packages/client/types/ethers-contracts/IndexComponent.ts
@@ -40,7 +40,6 @@ export interface IndexComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IndexComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IndexComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IndexComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IndexComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface IndexComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface IndexComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface IndexComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface IndexComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IndexFaceComponent.ts
+++ b/packages/client/types/ethers-contracts/IndexFaceComponent.ts
@@ -40,7 +40,6 @@ export interface IndexFaceComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IndexFaceComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IndexFaceComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IndexFaceComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IndexFaceComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface IndexFaceComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface IndexFaceComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface IndexFaceComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface IndexFaceComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IndexHandComponent.ts
+++ b/packages/client/types/ethers-contracts/IndexHandComponent.ts
@@ -40,7 +40,6 @@ export interface IndexHandComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IndexHandComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IndexHandComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IndexHandComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IndexHandComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface IndexHandComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface IndexHandComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface IndexHandComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface IndexHandComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IndexItemComponent.ts
+++ b/packages/client/types/ethers-contracts/IndexItemComponent.ts
@@ -40,7 +40,6 @@ export interface IndexItemComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IndexItemComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IndexItemComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IndexItemComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IndexItemComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface IndexItemComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface IndexItemComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface IndexItemComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface IndexItemComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IndexNPCComponent.ts
+++ b/packages/client/types/ethers-contracts/IndexNPCComponent.ts
@@ -40,7 +40,6 @@ export interface IndexNPCComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IndexNPCComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IndexNPCComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IndexNPCComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IndexNPCComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface IndexNPCComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface IndexNPCComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface IndexNPCComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface IndexNPCComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IndexNodeComponent.ts
+++ b/packages/client/types/ethers-contracts/IndexNodeComponent.ts
@@ -40,7 +40,6 @@ export interface IndexNodeComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IndexNodeComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IndexNodeComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IndexNodeComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IndexNodeComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface IndexNodeComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface IndexNodeComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface IndexNodeComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface IndexNodeComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IndexPetComponent.ts
+++ b/packages/client/types/ethers-contracts/IndexPetComponent.ts
@@ -40,7 +40,6 @@ export interface IndexPetComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IndexPetComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IndexPetComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IndexPetComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IndexPetComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface IndexPetComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface IndexPetComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface IndexPetComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface IndexPetComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IndexQuestComponent.ts
+++ b/packages/client/types/ethers-contracts/IndexQuestComponent.ts
@@ -40,7 +40,6 @@ export interface IndexQuestComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IndexQuestComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IndexQuestComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IndexQuestComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IndexQuestComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface IndexQuestComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface IndexQuestComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface IndexQuestComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface IndexQuestComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IndexRelationshipComponent.ts
+++ b/packages/client/types/ethers-contracts/IndexRelationshipComponent.ts
@@ -40,7 +40,6 @@ export interface IndexRelationshipComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IndexRelationshipComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IndexRelationshipComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IndexRelationshipComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IndexRelationshipComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface IndexRelationshipComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface IndexRelationshipComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface IndexRelationshipComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface IndexRelationshipComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IndexRoomComponent.ts
+++ b/packages/client/types/ethers-contracts/IndexRoomComponent.ts
@@ -40,7 +40,6 @@ export interface IndexRoomComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IndexRoomComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IndexRoomComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IndexRoomComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IndexRoomComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface IndexRoomComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface IndexRoomComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface IndexRoomComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface IndexRoomComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IndexSkillComponent.ts
+++ b/packages/client/types/ethers-contracts/IndexSkillComponent.ts
@@ -40,7 +40,6 @@ export interface IndexSkillComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IndexSkillComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IndexSkillComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IndexSkillComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IndexSkillComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface IndexSkillComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface IndexSkillComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface IndexSkillComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface IndexSkillComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/Int256BareComponent.ts
+++ b/packages/client/types/ethers-contracts/Int256BareComponent.ts
@@ -40,7 +40,6 @@ export interface Int256BareComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface Int256BareComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface Int256BareComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface Int256BareComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface Int256BareComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface Int256BareComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface Int256BareComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface Int256BareComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface Int256BareComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/Int32BareComponent.ts
+++ b/packages/client/types/ethers-contracts/Int32BareComponent.ts
@@ -40,7 +40,6 @@ export interface Int32BareComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface Int32BareComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface Int32BareComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface Int32BareComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface Int32BareComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface Int32BareComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface Int32BareComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface Int32BareComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface Int32BareComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/Int32Component.ts
+++ b/packages/client/types/ethers-contracts/Int32Component.ts
@@ -42,7 +42,6 @@ export interface Int32ComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -75,7 +74,6 @@ export interface Int32ComponentInterface extends utils.Interface {
       | "getEntitiesWithValue(bytes)"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -145,7 +143,6 @@ export interface Int32ComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -232,7 +229,6 @@ export interface Int32ComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -385,10 +381,6 @@ export interface Int32Component extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -523,10 +515,6 @@ export interface Int32Component extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -660,10 +648,6 @@ export interface Int32Component extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -811,8 +795,6 @@ export interface Int32Component extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -947,8 +929,6 @@ export interface Int32Component extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IsAccountComponent.ts
+++ b/packages/client/types/ethers-contracts/IsAccountComponent.ts
@@ -40,7 +40,6 @@ export interface IsAccountComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IsAccountComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IsAccountComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IsAccountComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IsAccountComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface IsAccountComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface IsAccountComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface IsAccountComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface IsAccountComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IsBonusComponent.ts
+++ b/packages/client/types/ethers-contracts/IsBonusComponent.ts
@@ -40,7 +40,6 @@ export interface IsBonusComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IsBonusComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IsBonusComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IsBonusComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IsBonusComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface IsBonusComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface IsBonusComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface IsBonusComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface IsBonusComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IsCompleteComponent.ts
+++ b/packages/client/types/ethers-contracts/IsCompleteComponent.ts
@@ -40,7 +40,6 @@ export interface IsCompleteComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IsCompleteComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IsCompleteComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IsCompleteComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IsCompleteComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface IsCompleteComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface IsCompleteComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface IsCompleteComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface IsCompleteComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IsConditionComponent.ts
+++ b/packages/client/types/ethers-contracts/IsConditionComponent.ts
@@ -40,7 +40,6 @@ export interface IsConditionComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IsConditionComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IsConditionComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IsConditionComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IsConditionComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface IsConditionComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface IsConditionComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface IsConditionComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface IsConditionComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IsConsumableComponent.ts
+++ b/packages/client/types/ethers-contracts/IsConsumableComponent.ts
@@ -40,7 +40,6 @@ export interface IsConsumableComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IsConsumableComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IsConsumableComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IsConsumableComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IsConsumableComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface IsConsumableComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface IsConsumableComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface IsConsumableComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface IsConsumableComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IsEffectComponent.ts
+++ b/packages/client/types/ethers-contracts/IsEffectComponent.ts
@@ -40,7 +40,6 @@ export interface IsEffectComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IsEffectComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IsEffectComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IsEffectComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IsEffectComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface IsEffectComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface IsEffectComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface IsEffectComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface IsEffectComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IsEquippedComponent.ts
+++ b/packages/client/types/ethers-contracts/IsEquippedComponent.ts
@@ -40,7 +40,6 @@ export interface IsEquippedComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IsEquippedComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IsEquippedComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IsEquippedComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IsEquippedComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface IsEquippedComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface IsEquippedComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface IsEquippedComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface IsEquippedComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IsFriendshipComponent.ts
+++ b/packages/client/types/ethers-contracts/IsFriendshipComponent.ts
@@ -40,7 +40,6 @@ export interface IsFriendshipComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IsFriendshipComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IsFriendshipComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IsFriendshipComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IsFriendshipComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface IsFriendshipComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface IsFriendshipComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface IsFriendshipComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface IsFriendshipComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IsGoalComponent.ts
+++ b/packages/client/types/ethers-contracts/IsGoalComponent.ts
@@ -40,7 +40,6 @@ export interface IsGoalComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IsGoalComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IsGoalComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IsGoalComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IsGoalComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface IsGoalComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface IsGoalComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface IsGoalComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface IsGoalComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IsInventoryComponent.ts
+++ b/packages/client/types/ethers-contracts/IsInventoryComponent.ts
@@ -40,7 +40,6 @@ export interface IsInventoryComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IsInventoryComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IsInventoryComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IsInventoryComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IsInventoryComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface IsInventoryComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface IsInventoryComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface IsInventoryComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface IsInventoryComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IsKillComponent.ts
+++ b/packages/client/types/ethers-contracts/IsKillComponent.ts
@@ -40,7 +40,6 @@ export interface IsKillComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IsKillComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IsKillComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IsKillComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IsKillComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface IsKillComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface IsKillComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface IsKillComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface IsKillComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IsListingComponent.ts
+++ b/packages/client/types/ethers-contracts/IsListingComponent.ts
@@ -40,7 +40,6 @@ export interface IsListingComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IsListingComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IsListingComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IsListingComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IsListingComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface IsListingComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface IsListingComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface IsListingComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface IsListingComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IsLogComponent.ts
+++ b/packages/client/types/ethers-contracts/IsLogComponent.ts
@@ -40,7 +40,6 @@ export interface IsLogComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IsLogComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IsLogComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IsLogComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IsLogComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface IsLogComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface IsLogComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface IsLogComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface IsLogComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IsLootboxComponent.ts
+++ b/packages/client/types/ethers-contracts/IsLootboxComponent.ts
@@ -40,7 +40,6 @@ export interface IsLootboxComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IsLootboxComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IsLootboxComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IsLootboxComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IsLootboxComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface IsLootboxComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface IsLootboxComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface IsLootboxComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface IsLootboxComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IsNPCComponent.ts
+++ b/packages/client/types/ethers-contracts/IsNPCComponent.ts
@@ -40,7 +40,6 @@ export interface IsNPCComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IsNPCComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IsNPCComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IsNPCComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IsNPCComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface IsNPCComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface IsNPCComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface IsNPCComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface IsNPCComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IsNodeComponent.ts
+++ b/packages/client/types/ethers-contracts/IsNodeComponent.ts
@@ -40,7 +40,6 @@ export interface IsNodeComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IsNodeComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IsNodeComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IsNodeComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IsNodeComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface IsNodeComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface IsNodeComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface IsNodeComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface IsNodeComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IsObjectiveComponent.ts
+++ b/packages/client/types/ethers-contracts/IsObjectiveComponent.ts
@@ -40,7 +40,6 @@ export interface IsObjectiveComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IsObjectiveComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IsObjectiveComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IsObjectiveComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IsObjectiveComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface IsObjectiveComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface IsObjectiveComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface IsObjectiveComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface IsObjectiveComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IsPetComponent.ts
+++ b/packages/client/types/ethers-contracts/IsPetComponent.ts
@@ -40,7 +40,6 @@ export interface IsPetComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IsPetComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IsPetComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IsPetComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IsPetComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface IsPetComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface IsPetComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface IsPetComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface IsPetComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IsProductionComponent.ts
+++ b/packages/client/types/ethers-contracts/IsProductionComponent.ts
@@ -40,7 +40,6 @@ export interface IsProductionComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IsProductionComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IsProductionComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IsProductionComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IsProductionComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface IsProductionComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface IsProductionComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface IsProductionComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface IsProductionComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IsQuestComponent.ts
+++ b/packages/client/types/ethers-contracts/IsQuestComponent.ts
@@ -40,7 +40,6 @@ export interface IsQuestComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IsQuestComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IsQuestComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IsQuestComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IsQuestComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface IsQuestComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface IsQuestComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface IsQuestComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface IsQuestComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IsRegisterComponent.ts
+++ b/packages/client/types/ethers-contracts/IsRegisterComponent.ts
@@ -40,7 +40,6 @@ export interface IsRegisterComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IsRegisterComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IsRegisterComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IsRegisterComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IsRegisterComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface IsRegisterComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface IsRegisterComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface IsRegisterComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface IsRegisterComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IsRegistryComponent.ts
+++ b/packages/client/types/ethers-contracts/IsRegistryComponent.ts
@@ -40,7 +40,6 @@ export interface IsRegistryComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IsRegistryComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IsRegistryComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IsRegistryComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IsRegistryComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface IsRegistryComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface IsRegistryComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface IsRegistryComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface IsRegistryComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IsRelationshipComponent.ts
+++ b/packages/client/types/ethers-contracts/IsRelationshipComponent.ts
@@ -40,7 +40,6 @@ export interface IsRelationshipComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IsRelationshipComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IsRelationshipComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IsRelationshipComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IsRelationshipComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface IsRelationshipComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface IsRelationshipComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface IsRelationshipComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface IsRelationshipComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IsRepeatableComponent.ts
+++ b/packages/client/types/ethers-contracts/IsRepeatableComponent.ts
@@ -40,7 +40,6 @@ export interface IsRepeatableComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IsRepeatableComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IsRepeatableComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IsRepeatableComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IsRepeatableComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface IsRepeatableComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface IsRepeatableComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface IsRepeatableComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface IsRepeatableComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IsRequestComponent.ts
+++ b/packages/client/types/ethers-contracts/IsRequestComponent.ts
@@ -40,7 +40,6 @@ export interface IsRequestComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IsRequestComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IsRequestComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IsRequestComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IsRequestComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface IsRequestComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface IsRequestComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface IsRequestComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface IsRequestComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IsRequirementComponent.ts
+++ b/packages/client/types/ethers-contracts/IsRequirementComponent.ts
@@ -40,7 +40,6 @@ export interface IsRequirementComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IsRequirementComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IsRequirementComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IsRequirementComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IsRequirementComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface IsRequirementComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface IsRequirementComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface IsRequirementComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface IsRequirementComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IsRewardComponent.ts
+++ b/packages/client/types/ethers-contracts/IsRewardComponent.ts
@@ -40,7 +40,6 @@ export interface IsRewardComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IsRewardComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IsRewardComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IsRewardComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IsRewardComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface IsRewardComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface IsRewardComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface IsRewardComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface IsRewardComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IsRoomComponent.ts
+++ b/packages/client/types/ethers-contracts/IsRoomComponent.ts
@@ -40,7 +40,6 @@ export interface IsRoomComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IsRoomComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IsRoomComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IsRoomComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IsRoomComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface IsRoomComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface IsRoomComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface IsRoomComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface IsRoomComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IsSkillComponent.ts
+++ b/packages/client/types/ethers-contracts/IsSkillComponent.ts
@@ -40,7 +40,6 @@ export interface IsSkillComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IsSkillComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IsSkillComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IsSkillComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IsSkillComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface IsSkillComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface IsSkillComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface IsSkillComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface IsSkillComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/IsTradeComponent.ts
+++ b/packages/client/types/ethers-contracts/IsTradeComponent.ts
@@ -40,7 +40,6 @@ export interface IsTradeComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface IsTradeComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface IsTradeComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface IsTradeComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface IsTradeComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -470,10 +462,6 @@ export interface IsTradeComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -589,10 +577,6 @@ export interface IsTradeComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -722,8 +706,6 @@ export interface IsTradeComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -840,8 +822,6 @@ export interface IsTradeComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/KeysComponent.ts
+++ b/packages/client/types/ethers-contracts/KeysComponent.ts
@@ -40,7 +40,6 @@ export interface KeysComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface KeysComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface KeysComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface KeysComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface KeysComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface KeysComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface KeysComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface KeysComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface KeysComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/LevelComponent.ts
+++ b/packages/client/types/ethers-contracts/LevelComponent.ts
@@ -40,7 +40,6 @@ export interface LevelComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface LevelComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface LevelComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface LevelComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface LevelComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface LevelComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface LevelComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface LevelComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface LevelComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/LocationComponent.ts
+++ b/packages/client/types/ethers-contracts/LocationComponent.ts
@@ -54,7 +54,6 @@ export interface LocationComponentInterface extends utils.Interface {
     "getEntitiesWithValue((int32,int32,int32))": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -87,7 +86,6 @@ export interface LocationComponentInterface extends utils.Interface {
       | "getEntitiesWithValue((int32,int32,int32))"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -157,7 +155,6 @@ export interface LocationComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -244,7 +241,6 @@ export interface LocationComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -397,10 +393,6 @@ export interface LocationComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -535,10 +527,6 @@ export interface LocationComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -672,10 +660,6 @@ export interface LocationComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -823,8 +807,6 @@ export interface LocationComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -959,8 +941,6 @@ export interface LocationComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/LogicTypeComponent.ts
+++ b/packages/client/types/ethers-contracts/LogicTypeComponent.ts
@@ -40,7 +40,6 @@ export interface LogicTypeComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "hasValue(uint256,string)": FunctionFragment;
     "id()": FunctionFragment;
@@ -71,7 +70,6 @@ export interface LogicTypeComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "hasValue"
       | "id"
@@ -133,7 +131,6 @@ export interface LogicTypeComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -215,7 +212,6 @@ export interface LogicTypeComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "hasValue", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
@@ -357,10 +353,6 @@ export interface LogicTypeComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -485,10 +477,6 @@ export interface LogicTypeComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -612,10 +600,6 @@ export interface LogicTypeComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -753,8 +737,6 @@ export interface LogicTypeComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -879,8 +861,6 @@ export interface LogicTypeComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/MaxComponent.ts
+++ b/packages/client/types/ethers-contracts/MaxComponent.ts
@@ -40,7 +40,6 @@ export interface MaxComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface MaxComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface MaxComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface MaxComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface MaxComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface MaxComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface MaxComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface MaxComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface MaxComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/MediaURIComponent.ts
+++ b/packages/client/types/ethers-contracts/MediaURIComponent.ts
@@ -40,7 +40,6 @@ export interface MediaURIComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface MediaURIComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface MediaURIComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface MediaURIComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface MediaURIComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface MediaURIComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface MediaURIComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface MediaURIComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface MediaURIComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/NameComponent.ts
+++ b/packages/client/types/ethers-contracts/NameComponent.ts
@@ -42,7 +42,6 @@ export interface NameComponentInterface extends utils.Interface {
     "getEntitiesWithValue(string)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "hasValue(uint256,string)": FunctionFragment;
     "id()": FunctionFragment;
@@ -76,7 +75,6 @@ export interface NameComponentInterface extends utils.Interface {
       | "getEntitiesWithValue(string)"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "hasValue"
       | "id"
@@ -147,7 +145,6 @@ export interface NameComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -238,7 +235,6 @@ export interface NameComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "hasValue", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
@@ -392,10 +388,6 @@ export interface NameComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -536,10 +528,6 @@ export interface NameComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -679,10 +667,6 @@ export interface NameComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -836,8 +820,6 @@ export interface NameComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -978,8 +960,6 @@ export interface NameComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/OwnedByEntityComponent.ts
+++ b/packages/client/types/ethers-contracts/OwnedByEntityComponent.ts
@@ -39,7 +39,6 @@ export interface OwnedByEntityComponentInterface extends utils.Interface {
     "getEntitiesWithValue(uint256)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "getValue(uint256)": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
@@ -69,7 +68,6 @@ export interface OwnedByEntityComponentInterface extends utils.Interface {
       | "getEntitiesWithValue(uint256)"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "getValue"
       | "has"
       | "id"
@@ -124,7 +122,6 @@ export interface OwnedByEntityComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "getValue",
     values: [PromiseOrValue<BigNumberish>]
@@ -205,7 +202,6 @@ export interface OwnedByEntityComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "getValue", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
@@ -334,10 +330,6 @@ export interface OwnedByEntityComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     getValue(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -453,10 +445,6 @@ export interface OwnedByEntityComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   getValue(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -571,10 +559,6 @@ export interface OwnedByEntityComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     getValue(
       entity: PromiseOrValue<BigNumberish>,
@@ -703,8 +687,6 @@ export interface OwnedByEntityComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     getValue(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -820,8 +802,6 @@ export interface OwnedByEntityComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     getValue(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/PositionComponent.ts
+++ b/packages/client/types/ethers-contracts/PositionComponent.ts
@@ -48,7 +48,6 @@ export interface PositionComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "getValue(uint256)": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
@@ -77,7 +76,6 @@ export interface PositionComponentInterface extends utils.Interface {
       | "getEntitiesWithValue(bytes)"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "getValue"
       | "has"
       | "id"
@@ -131,7 +129,6 @@ export interface PositionComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "getValue",
     values: [PromiseOrValue<BigNumberish>]
@@ -211,7 +208,6 @@ export interface PositionComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "getValue", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
@@ -338,10 +334,6 @@ export interface PositionComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     getValue(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -455,10 +447,6 @@ export interface PositionComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   getValue(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -571,10 +559,6 @@ export interface PositionComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     getValue(
       entity: PromiseOrValue<BigNumberish>,
@@ -701,8 +685,6 @@ export interface PositionComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     getValue(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -816,8 +798,6 @@ export interface PositionComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     getValue(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/PowerComponent.ts
+++ b/packages/client/types/ethers-contracts/PowerComponent.ts
@@ -56,7 +56,6 @@ export interface PowerComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -91,7 +90,6 @@ export interface PowerComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -163,7 +161,6 @@ export interface PowerComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -259,7 +256,6 @@ export interface PowerComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -420,10 +416,6 @@ export interface PowerComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -572,10 +564,6 @@ export interface PowerComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -723,10 +711,6 @@ export interface PowerComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -888,8 +872,6 @@ export interface PowerComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -1038,8 +1020,6 @@ export interface PowerComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/PriceBuyComponent.ts
+++ b/packages/client/types/ethers-contracts/PriceBuyComponent.ts
@@ -40,7 +40,6 @@ export interface PriceBuyComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface PriceBuyComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface PriceBuyComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface PriceBuyComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface PriceBuyComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface PriceBuyComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface PriceBuyComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface PriceBuyComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface PriceBuyComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/PriceSellComponent.ts
+++ b/packages/client/types/ethers-contracts/PriceSellComponent.ts
@@ -40,7 +40,6 @@ export interface PriceSellComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface PriceSellComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface PriceSellComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface PriceSellComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface PriceSellComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface PriceSellComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface PriceSellComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface PriceSellComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface PriceSellComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/PrototypeTagComponent.ts
+++ b/packages/client/types/ethers-contracts/PrototypeTagComponent.ts
@@ -39,7 +39,6 @@ export interface PrototypeTagComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "getValue(uint256)": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
@@ -69,7 +68,6 @@ export interface PrototypeTagComponentInterface extends utils.Interface {
       | "getEntitiesWithValue(bytes)"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "getValue"
       | "has"
       | "id"
@@ -124,7 +122,6 @@ export interface PrototypeTagComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "getValue",
     values: [PromiseOrValue<BigNumberish>]
@@ -205,7 +202,6 @@ export interface PrototypeTagComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "getValue", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
@@ -334,10 +330,6 @@ export interface PrototypeTagComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     getValue(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -453,10 +445,6 @@ export interface PrototypeTagComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   getValue(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -571,10 +559,6 @@ export interface PrototypeTagComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     getValue(
       entity: PromiseOrValue<BigNumberish>,
@@ -703,8 +687,6 @@ export interface PrototypeTagComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     getValue(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -820,8 +802,6 @@ export interface PrototypeTagComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     getValue(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/ProxyPermissionsERC721Component.ts
+++ b/packages/client/types/ethers-contracts/ProxyPermissionsERC721Component.ts
@@ -41,7 +41,6 @@ export interface ProxyPermissionsERC721ComponentInterface
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -71,7 +70,6 @@ export interface ProxyPermissionsERC721ComponentInterface
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -132,7 +130,6 @@ export interface ProxyPermissionsERC721ComponentInterface
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -210,7 +207,6 @@ export interface ProxyPermissionsERC721ComponentInterface
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -351,10 +347,6 @@ export interface ProxyPermissionsERC721Component extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -471,10 +463,6 @@ export interface ProxyPermissionsERC721Component extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -590,10 +578,6 @@ export interface ProxyPermissionsERC721Component extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -723,8 +707,6 @@ export interface ProxyPermissionsERC721Component extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -841,8 +823,6 @@ export interface ProxyPermissionsERC721Component extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/ProxyPermissionsFarm20Component.ts
+++ b/packages/client/types/ethers-contracts/ProxyPermissionsFarm20Component.ts
@@ -41,7 +41,6 @@ export interface ProxyPermissionsFarm20ComponentInterface
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -71,7 +70,6 @@ export interface ProxyPermissionsFarm20ComponentInterface
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -132,7 +130,6 @@ export interface ProxyPermissionsFarm20ComponentInterface
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -210,7 +207,6 @@ export interface ProxyPermissionsFarm20ComponentInterface
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -351,10 +347,6 @@ export interface ProxyPermissionsFarm20Component extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -471,10 +463,6 @@ export interface ProxyPermissionsFarm20Component extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -590,10 +578,6 @@ export interface ProxyPermissionsFarm20Component extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -723,8 +707,6 @@ export interface ProxyPermissionsFarm20Component extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -841,8 +823,6 @@ export interface ProxyPermissionsFarm20Component extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/ProxyPermissionsMint20Component.ts
+++ b/packages/client/types/ethers-contracts/ProxyPermissionsMint20Component.ts
@@ -41,7 +41,6 @@ export interface ProxyPermissionsMint20ComponentInterface
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -71,7 +70,6 @@ export interface ProxyPermissionsMint20ComponentInterface
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -132,7 +130,6 @@ export interface ProxyPermissionsMint20ComponentInterface
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -210,7 +207,6 @@ export interface ProxyPermissionsMint20ComponentInterface
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -351,10 +347,6 @@ export interface ProxyPermissionsMint20Component extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -471,10 +463,6 @@ export interface ProxyPermissionsMint20Component extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -590,10 +578,6 @@ export interface ProxyPermissionsMint20Component extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -723,8 +707,6 @@ export interface ProxyPermissionsMint20Component extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -841,8 +823,6 @@ export interface ProxyPermissionsMint20Component extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/RarityComponent.ts
+++ b/packages/client/types/ethers-contracts/RarityComponent.ts
@@ -40,7 +40,6 @@ export interface RarityComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface RarityComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface RarityComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface RarityComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface RarityComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface RarityComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface RarityComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface RarityComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface RarityComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/RateComponent.ts
+++ b/packages/client/types/ethers-contracts/RateComponent.ts
@@ -40,7 +40,6 @@ export interface RateComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface RateComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface RateComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface RateComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface RateComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface RateComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface RateComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface RateComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface RateComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/RerollComponent.ts
+++ b/packages/client/types/ethers-contracts/RerollComponent.ts
@@ -40,7 +40,6 @@ export interface RerollComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface RerollComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface RerollComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface RerollComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface RerollComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface RerollComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface RerollComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface RerollComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface RerollComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/SkillPointComponent.ts
+++ b/packages/client/types/ethers-contracts/SkillPointComponent.ts
@@ -40,7 +40,6 @@ export interface SkillPointComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface SkillPointComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface SkillPointComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface SkillPointComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface SkillPointComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface SkillPointComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface SkillPointComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface SkillPointComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface SkillPointComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/SlotsComponent.ts
+++ b/packages/client/types/ethers-contracts/SlotsComponent.ts
@@ -56,7 +56,6 @@ export interface SlotsComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -91,7 +90,6 @@ export interface SlotsComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -163,7 +161,6 @@ export interface SlotsComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -259,7 +256,6 @@ export interface SlotsComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -420,10 +416,6 @@ export interface SlotsComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -572,10 +564,6 @@ export interface SlotsComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -723,10 +711,6 @@ export interface SlotsComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -888,8 +872,6 @@ export interface SlotsComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -1038,8 +1020,6 @@ export interface SlotsComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/StaminaComponent.ts
+++ b/packages/client/types/ethers-contracts/StaminaComponent.ts
@@ -56,7 +56,6 @@ export interface StaminaComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -91,7 +90,6 @@ export interface StaminaComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -163,7 +161,6 @@ export interface StaminaComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -259,7 +256,6 @@ export interface StaminaComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -420,10 +416,6 @@ export interface StaminaComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -572,10 +564,6 @@ export interface StaminaComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -723,10 +711,6 @@ export interface StaminaComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -888,8 +872,6 @@ export interface StaminaComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -1038,8 +1020,6 @@ export interface StaminaComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/StatComponent.ts
+++ b/packages/client/types/ethers-contracts/StatComponent.ts
@@ -56,7 +56,6 @@ export interface StatComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -91,7 +90,6 @@ export interface StatComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -163,7 +161,6 @@ export interface StatComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -259,7 +256,6 @@ export interface StatComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -420,10 +416,6 @@ export interface StatComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -572,10 +564,6 @@ export interface StatComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -723,10 +711,6 @@ export interface StatComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -888,8 +872,6 @@ export interface StatComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -1038,8 +1020,6 @@ export interface StatComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/StateComponent.ts
+++ b/packages/client/types/ethers-contracts/StateComponent.ts
@@ -40,7 +40,6 @@ export interface StateComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "hasValue(uint256,string)": FunctionFragment;
     "id()": FunctionFragment;
@@ -71,7 +70,6 @@ export interface StateComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "hasValue"
       | "id"
@@ -133,7 +131,6 @@ export interface StateComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -215,7 +212,6 @@ export interface StateComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "hasValue", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
@@ -357,10 +353,6 @@ export interface StateComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -485,10 +477,6 @@ export interface StateComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -612,10 +600,6 @@ export interface StateComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -753,8 +737,6 @@ export interface StateComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -879,8 +861,6 @@ export interface StateComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/StringBareComponent.ts
+++ b/packages/client/types/ethers-contracts/StringBareComponent.ts
@@ -40,7 +40,6 @@ export interface StringBareComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface StringBareComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface StringBareComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface StringBareComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface StringBareComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface StringBareComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface StringBareComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface StringBareComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface StringBareComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/StringComponent.ts
+++ b/packages/client/types/ethers-contracts/StringComponent.ts
@@ -42,7 +42,6 @@ export interface StringComponentInterface extends utils.Interface {
     "getEntitiesWithValue(string)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -75,7 +74,6 @@ export interface StringComponentInterface extends utils.Interface {
       | "getEntitiesWithValue(string)"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -145,7 +143,6 @@ export interface StringComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -232,7 +229,6 @@ export interface StringComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -385,10 +381,6 @@ export interface StringComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -523,10 +515,6 @@ export interface StringComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -660,10 +648,6 @@ export interface StringComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -811,8 +795,6 @@ export interface StringComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -947,8 +929,6 @@ export interface StringComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/SubtypeComponent.ts
+++ b/packages/client/types/ethers-contracts/SubtypeComponent.ts
@@ -40,7 +40,6 @@ export interface SubtypeComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "hasValue(uint256,string)": FunctionFragment;
     "id()": FunctionFragment;
@@ -71,7 +70,6 @@ export interface SubtypeComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "hasValue"
       | "id"
@@ -133,7 +131,6 @@ export interface SubtypeComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -215,7 +212,6 @@ export interface SubtypeComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "hasValue", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
@@ -357,10 +353,6 @@ export interface SubtypeComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -485,10 +477,6 @@ export interface SubtypeComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -612,10 +600,6 @@ export interface SubtypeComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -753,8 +737,6 @@ export interface SubtypeComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -879,8 +861,6 @@ export interface SubtypeComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/TestComponent.ts
+++ b/packages/client/types/ethers-contracts/TestComponent.ts
@@ -38,7 +38,6 @@ export interface TestComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -65,7 +64,6 @@ export interface TestComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -114,7 +112,6 @@ export interface TestComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -183,7 +180,6 @@ export interface TestComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -299,10 +295,6 @@ export interface TestComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -402,10 +394,6 @@ export interface TestComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -504,10 +492,6 @@ export interface TestComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -620,8 +604,6 @@ export interface TestComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -721,8 +703,6 @@ export interface TestComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/TestComponent1.ts
+++ b/packages/client/types/ethers-contracts/TestComponent1.ts
@@ -38,7 +38,6 @@ export interface TestComponent1Interface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -65,7 +64,6 @@ export interface TestComponent1Interface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -114,7 +112,6 @@ export interface TestComponent1Interface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -183,7 +180,6 @@ export interface TestComponent1Interface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -299,10 +295,6 @@ export interface TestComponent1 extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -402,10 +394,6 @@ export interface TestComponent1 extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -504,10 +492,6 @@ export interface TestComponent1 extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -620,8 +604,6 @@ export interface TestComponent1 extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -721,8 +703,6 @@ export interface TestComponent1 extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/TestComponent2.ts
+++ b/packages/client/types/ethers-contracts/TestComponent2.ts
@@ -38,7 +38,6 @@ export interface TestComponent2Interface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -65,7 +64,6 @@ export interface TestComponent2Interface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -114,7 +112,6 @@ export interface TestComponent2Interface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -183,7 +180,6 @@ export interface TestComponent2Interface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -299,10 +295,6 @@ export interface TestComponent2 extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -402,10 +394,6 @@ export interface TestComponent2 extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -504,10 +492,6 @@ export interface TestComponent2 extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -620,8 +604,6 @@ export interface TestComponent2 extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -721,8 +703,6 @@ export interface TestComponent2 extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/TestComponent3.ts
+++ b/packages/client/types/ethers-contracts/TestComponent3.ts
@@ -38,7 +38,6 @@ export interface TestComponent3Interface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -65,7 +64,6 @@ export interface TestComponent3Interface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -114,7 +112,6 @@ export interface TestComponent3Interface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -183,7 +180,6 @@ export interface TestComponent3Interface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -299,10 +295,6 @@ export interface TestComponent3 extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -402,10 +394,6 @@ export interface TestComponent3 extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -504,10 +492,6 @@ export interface TestComponent3 extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -620,8 +604,6 @@ export interface TestComponent3 extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -721,8 +703,6 @@ export interface TestComponent3 extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/TestComponent4.ts
+++ b/packages/client/types/ethers-contracts/TestComponent4.ts
@@ -38,7 +38,6 @@ export interface TestComponent4Interface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -65,7 +64,6 @@ export interface TestComponent4Interface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -114,7 +112,6 @@ export interface TestComponent4Interface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -183,7 +180,6 @@ export interface TestComponent4Interface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -299,10 +295,6 @@ export interface TestComponent4 extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -402,10 +394,6 @@ export interface TestComponent4 extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -504,10 +492,6 @@ export interface TestComponent4 extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -620,8 +604,6 @@ export interface TestComponent4 extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -721,8 +703,6 @@ export interface TestComponent4 extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/TimeComponent.ts
+++ b/packages/client/types/ethers-contracts/TimeComponent.ts
@@ -40,7 +40,6 @@ export interface TimeComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface TimeComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface TimeComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface TimeComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface TimeComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface TimeComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface TimeComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface TimeComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface TimeComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/TimeLastActionComponent.ts
+++ b/packages/client/types/ethers-contracts/TimeLastActionComponent.ts
@@ -40,7 +40,6 @@ export interface TimeLastActionComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface TimeLastActionComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface TimeLastActionComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface TimeLastActionComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface TimeLastActionComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface TimeLastActionComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface TimeLastActionComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface TimeLastActionComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface TimeLastActionComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/TimeLastComponent.ts
+++ b/packages/client/types/ethers-contracts/TimeLastComponent.ts
@@ -40,7 +40,6 @@ export interface TimeLastComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface TimeLastComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface TimeLastComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface TimeLastComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface TimeLastComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface TimeLastComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface TimeLastComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface TimeLastComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface TimeLastComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/TimeResetComponent.ts
+++ b/packages/client/types/ethers-contracts/TimeResetComponent.ts
@@ -40,7 +40,6 @@ export interface TimeResetComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface TimeResetComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface TimeResetComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface TimeResetComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface TimeResetComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface TimeResetComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface TimeResetComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface TimeResetComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface TimeResetComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/TimeStartComponent.ts
+++ b/packages/client/types/ethers-contracts/TimeStartComponent.ts
@@ -40,7 +40,6 @@ export interface TimeStartComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface TimeStartComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface TimeStartComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface TimeStartComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface TimeStartComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface TimeStartComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface TimeStartComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface TimeStartComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface TimeStartComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/TimelockComponent.ts
+++ b/packages/client/types/ethers-contracts/TimelockComponent.ts
@@ -51,7 +51,6 @@ export interface TimelockComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -80,7 +79,6 @@ export interface TimelockComponentInterface extends utils.Interface {
       | "getEntitiesWithValue(bytes)"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -137,7 +135,6 @@ export interface TimelockComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -214,7 +211,6 @@ export interface TimelockComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -345,10 +341,6 @@ export interface TimelockComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -462,10 +454,6 @@ export interface TimelockComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -578,10 +566,6 @@ export interface TimelockComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -708,8 +692,6 @@ export interface TimelockComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -823,8 +805,6 @@ export interface TimelockComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/TypeComponent.ts
+++ b/packages/client/types/ethers-contracts/TypeComponent.ts
@@ -40,7 +40,6 @@ export interface TypeComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "hasValue(uint256,string)": FunctionFragment;
     "id()": FunctionFragment;
@@ -71,7 +70,6 @@ export interface TypeComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "hasValue"
       | "id"
@@ -133,7 +131,6 @@ export interface TypeComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -215,7 +212,6 @@ export interface TypeComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "hasValue", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
@@ -357,10 +353,6 @@ export interface TypeComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -485,10 +477,6 @@ export interface TypeComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -612,10 +600,6 @@ export interface TypeComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -753,8 +737,6 @@ export interface TypeComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -879,8 +861,6 @@ export interface TypeComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/Uint256ArrayBareComponent.ts
+++ b/packages/client/types/ethers-contracts/Uint256ArrayBareComponent.ts
@@ -40,7 +40,6 @@ export interface Uint256ArrayBareComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface Uint256ArrayBareComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface Uint256ArrayBareComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface Uint256ArrayBareComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface Uint256ArrayBareComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface Uint256ArrayBareComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface Uint256ArrayBareComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface Uint256ArrayBareComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface Uint256ArrayBareComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/Uint256ArrayComponent.ts
+++ b/packages/client/types/ethers-contracts/Uint256ArrayComponent.ts
@@ -42,7 +42,6 @@ export interface Uint256ArrayComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -75,7 +74,6 @@ export interface Uint256ArrayComponentInterface extends utils.Interface {
       | "getEntitiesWithValue(bytes)"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -145,7 +143,6 @@ export interface Uint256ArrayComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -232,7 +229,6 @@ export interface Uint256ArrayComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -385,10 +381,6 @@ export interface Uint256ArrayComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -523,10 +515,6 @@ export interface Uint256ArrayComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -660,10 +648,6 @@ export interface Uint256ArrayComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -811,8 +795,6 @@ export interface Uint256ArrayComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -947,8 +929,6 @@ export interface Uint256ArrayComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/Uint256BareComponent.ts
+++ b/packages/client/types/ethers-contracts/Uint256BareComponent.ts
@@ -40,7 +40,6 @@ export interface Uint256BareComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface Uint256BareComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface Uint256BareComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface Uint256BareComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface Uint256BareComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface Uint256BareComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface Uint256BareComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface Uint256BareComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface Uint256BareComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/Uint32ArrayBareComponent.ts
+++ b/packages/client/types/ethers-contracts/Uint32ArrayBareComponent.ts
@@ -40,7 +40,6 @@ export interface Uint32ArrayBareComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface Uint32ArrayBareComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface Uint32ArrayBareComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface Uint32ArrayBareComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface Uint32ArrayBareComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface Uint32ArrayBareComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface Uint32ArrayBareComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface Uint32ArrayBareComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface Uint32ArrayBareComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/Uint32ArrayComponent.ts
+++ b/packages/client/types/ethers-contracts/Uint32ArrayComponent.ts
@@ -42,7 +42,6 @@ export interface Uint32ArrayComponentInterface extends utils.Interface {
     "getEntitiesWithValue(uint32[])": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -75,7 +74,6 @@ export interface Uint32ArrayComponentInterface extends utils.Interface {
       | "getEntitiesWithValue(uint32[])"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -145,7 +143,6 @@ export interface Uint32ArrayComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -232,7 +229,6 @@ export interface Uint32ArrayComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -385,10 +381,6 @@ export interface Uint32ArrayComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -523,10 +515,6 @@ export interface Uint32ArrayComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -660,10 +648,6 @@ export interface Uint32ArrayComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -811,8 +795,6 @@ export interface Uint32ArrayComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -947,8 +929,6 @@ export interface Uint32ArrayComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/Uint32BareComponent.ts
+++ b/packages/client/types/ethers-contracts/Uint32BareComponent.ts
@@ -40,7 +40,6 @@ export interface Uint32BareComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface Uint32BareComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface Uint32BareComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface Uint32BareComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface Uint32BareComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface Uint32BareComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface Uint32BareComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface Uint32BareComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface Uint32BareComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/Uint32Component.ts
+++ b/packages/client/types/ethers-contracts/Uint32Component.ts
@@ -42,7 +42,6 @@ export interface Uint32ComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -75,7 +74,6 @@ export interface Uint32ComponentInterface extends utils.Interface {
       | "getEntitiesWithValue(bytes)"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -145,7 +143,6 @@ export interface Uint32ComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -232,7 +229,6 @@ export interface Uint32ComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -385,10 +381,6 @@ export interface Uint32Component extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -523,10 +515,6 @@ export interface Uint32Component extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -660,10 +648,6 @@ export interface Uint32Component extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -811,8 +795,6 @@ export interface Uint32Component extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -947,8 +929,6 @@ export interface Uint32Component extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/ValueComponent.ts
+++ b/packages/client/types/ethers-contracts/ValueComponent.ts
@@ -40,7 +40,6 @@ export interface ValueComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface ValueComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface ValueComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface ValueComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface ValueComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface ValueComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface ValueComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface ValueComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface ValueComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/ValueSignedComponent.ts
+++ b/packages/client/types/ethers-contracts/ValueSignedComponent.ts
@@ -40,7 +40,6 @@ export interface ValueSignedComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface ValueSignedComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface ValueSignedComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface ValueSignedComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface ValueSignedComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface ValueSignedComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface ValueSignedComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface ValueSignedComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface ValueSignedComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/ValuesComponent.ts
+++ b/packages/client/types/ethers-contracts/ValuesComponent.ts
@@ -40,7 +40,6 @@ export interface ValuesComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface ValuesComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface ValuesComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface ValuesComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface ValuesComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface ValuesComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface ValuesComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface ValuesComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface ValuesComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/ViolenceComponent.ts
+++ b/packages/client/types/ethers-contracts/ViolenceComponent.ts
@@ -56,7 +56,6 @@ export interface ViolenceComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -91,7 +90,6 @@ export interface ViolenceComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -163,7 +161,6 @@ export interface ViolenceComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -259,7 +256,6 @@ export interface ViolenceComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -420,10 +416,6 @@ export interface ViolenceComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -572,10 +564,6 @@ export interface ViolenceComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -723,10 +711,6 @@ export interface ViolenceComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -888,8 +872,6 @@ export interface ViolenceComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -1038,8 +1020,6 @@ export interface ViolenceComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/WeightsComponent.ts
+++ b/packages/client/types/ethers-contracts/WeightsComponent.ts
@@ -40,7 +40,6 @@ export interface WeightsComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface WeightsComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface WeightsComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface WeightsComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface WeightsComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface WeightsComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface WeightsComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface WeightsComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface WeightsComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/client/types/ethers-contracts/WhitelistComponent.ts
+++ b/packages/client/types/ethers-contracts/WhitelistComponent.ts
@@ -40,7 +40,6 @@ export interface WhitelistComponentInterface extends utils.Interface {
     "getEntitiesWithValue(bytes)": FunctionFragment;
     "getRaw(uint256)": FunctionFragment;
     "getRawBatch(uint256[])": FunctionFragment;
-    "getSchema()": FunctionFragment;
     "has(uint256)": FunctionFragment;
     "id()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -70,7 +69,6 @@ export interface WhitelistComponentInterface extends utils.Interface {
       | "getEntitiesWithValue"
       | "getRaw"
       | "getRawBatch"
-      | "getSchema"
       | "has"
       | "id"
       | "owner"
@@ -131,7 +129,6 @@ export interface WhitelistComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     values: [PromiseOrValue<BigNumberish>[]]
   ): string;
-  encodeFunctionData(functionFragment: "getSchema", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "has",
     values: [PromiseOrValue<BigNumberish>]
@@ -209,7 +206,6 @@ export interface WhitelistComponentInterface extends utils.Interface {
     functionFragment: "getRawBatch",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "getSchema", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "has", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "id", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
@@ -350,10 +346,6 @@ export interface WhitelistComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -472,10 +464,6 @@ export interface WhitelistComponent extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
-  getSchema(
-    overrides?: CallOverrides
-  ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
-
   has(
     entity: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -593,10 +581,6 @@ export interface WhitelistComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<string[]>;
-
-    getSchema(
-      overrides?: CallOverrides
-    ): Promise<[string[], number[]] & { keys: string[]; values: number[] }>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,
@@ -728,8 +712,6 @@ export interface WhitelistComponent extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    getSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
     has(
       entity: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -848,8 +830,6 @@ export interface WhitelistComponent extends BaseContract {
       entities: PromiseOrValue<BigNumberish>[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    getSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     has(
       entity: PromiseOrValue<BigNumberish>,

--- a/packages/contracts/src/components/TimelockComponent.sol
+++ b/packages/contracts/src/components/TimelockComponent.sol
@@ -13,25 +13,6 @@ struct TimelockOp {
 contract TimelockComponent is Component {
   constructor(address world) Component(world, ID) {}
 
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    keys = new string[](3);
-    values = new LibTypes.SchemaValue[](3);
-
-    keys[0] = "target";
-    values[0] = LibTypes.SchemaValue.ADDRESS;
-
-    keys[1] = "value";
-    values[1] = LibTypes.SchemaValue.UINT256;
-
-    keys[2] = "salt";
-    values[2] = LibTypes.SchemaValue.UINT256;
-  }
-
   function set(uint256 entity, TimelockOp memory value) public {
     set(entity, abi.encode(value));
   }

--- a/packages/contracts/src/components/base/AddressBareComponent.sol
+++ b/packages/contracts/src/components/base/AddressBareComponent.sol
@@ -6,19 +6,6 @@ import { TypeLib } from "components/types/standard.sol";
 contract AddressBareComponent is BareComponent {
   constructor(address world, uint256 id) BareComponent(world, id) {}
 
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    keys = new string[](1);
-    values = new LibTypes.SchemaValue[](1);
-
-    keys[0] = "value";
-    values[0] = LibTypes.SchemaValue.UINT256;
-  }
-
   function set(uint256 entity, address value) external virtual onlyWriter {
     _set(entity, TypeLib.encodeAddress(value));
   }

--- a/packages/contracts/src/components/base/AddressComponent.sol
+++ b/packages/contracts/src/components/base/AddressComponent.sol
@@ -6,19 +6,6 @@ import { TypeLib } from "components/types/standard.sol";
 contract AddressComponent is Component {
   constructor(address world, uint256 id) Component(world, id) {}
 
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    keys = new string[](1);
-    values = new LibTypes.SchemaValue[](1);
-
-    keys[0] = "value";
-    values[0] = LibTypes.SchemaValue.UINT256;
-  }
-
   function set(uint256 entity, address value) external virtual onlyWriter {
     _set(entity, TypeLib.encodeAddress(value));
   }

--- a/packages/contracts/src/components/base/BoolBareComponent.sol
+++ b/packages/contracts/src/components/base/BoolBareComponent.sol
@@ -6,19 +6,6 @@ import { TypeLib } from "components/types/standard.sol";
 contract BoolBareComponent is BareComponent {
   constructor(address world, uint256 id) BareComponent(world, id) {}
 
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    keys = new string[](1);
-    values = new LibTypes.SchemaValue[](1);
-
-    keys[0] = "value";
-    values[0] = LibTypes.SchemaValue.BOOL;
-  }
-
   function set(uint256 entity) external virtual onlyWriter {
     _set(entity, TypeLib.encodeBool(true));
   }

--- a/packages/contracts/src/components/base/BoolComponent.sol
+++ b/packages/contracts/src/components/base/BoolComponent.sol
@@ -6,19 +6,6 @@ import { TypeLib } from "components/types/standard.sol";
 contract BoolComponent is Component {
   constructor(address world, uint256 id) Component(world, id) {}
 
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    keys = new string[](1);
-    values = new LibTypes.SchemaValue[](1);
-
-    keys[0] = "value";
-    values[0] = LibTypes.SchemaValue.BOOL;
-  }
-
   function set(uint256 entity) external virtual onlyWriter {
     _set(entity, TypeLib.encodeBool(true));
   }

--- a/packages/contracts/src/components/base/CoordComponent.sol
+++ b/packages/contracts/src/components/base/CoordComponent.sol
@@ -7,19 +7,6 @@ import { Coord, CoordLib } from "components/types/Coord.sol";
 contract CoordComponent is Component {
   constructor(address world, uint256 id) Component(world, id) {}
 
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    keys = new string[](1);
-    values = new LibTypes.SchemaValue[](1);
-
-    keys[0] = "value";
-    values[0] = LibTypes.SchemaValue.UINT256;
-  }
-
   function set(uint256 entity, Coord memory value) external virtual onlyWriter {
     _set(entity, CoordLib.encode(value));
   }

--- a/packages/contracts/src/components/base/Int256BareComponent.sol
+++ b/packages/contracts/src/components/base/Int256BareComponent.sol
@@ -6,19 +6,6 @@ import { TypeLib } from "components/types/standard.sol";
 contract Int256BareComponent is BareComponent {
   constructor(address world, uint256 id) BareComponent(world, id) {}
 
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    keys = new string[](1);
-    values = new LibTypes.SchemaValue[](1);
-
-    keys[0] = "value";
-    values[0] = LibTypes.SchemaValue.INT256;
-  }
-
   function set(uint256 entity, int256 value) external virtual onlyWriter {
     _set(entity, TypeLib.encodeInt256(value));
   }

--- a/packages/contracts/src/components/base/Int32BareComponent.sol
+++ b/packages/contracts/src/components/base/Int32BareComponent.sol
@@ -6,19 +6,6 @@ import { TypeLib } from "components/types/standard.sol";
 contract Int32BareComponent is BareComponent {
   constructor(address world, uint256 id) BareComponent(world, id) {}
 
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    keys = new string[](1);
-    values = new LibTypes.SchemaValue[](1);
-
-    keys[0] = "value";
-    values[0] = LibTypes.SchemaValue.INT32;
-  }
-
   function set(uint256 entity, int32 value) external virtual onlyWriter {
     _set(entity, TypeLib.encodeInt32(value));
   }

--- a/packages/contracts/src/components/base/Int32Component.sol
+++ b/packages/contracts/src/components/base/Int32Component.sol
@@ -6,19 +6,6 @@ import { TypeLib } from "components/types/standard.sol";
 contract Int32Component is Component {
   constructor(address world, uint256 id) Component(world, id) {}
 
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    keys = new string[](1);
-    values = new LibTypes.SchemaValue[](1);
-
-    keys[0] = "value";
-    values[0] = LibTypes.SchemaValue.INT32;
-  }
-
   function set(uint256 entity, int32 value) external virtual onlyWriter {
     _set(entity, TypeLib.encodeInt32(value));
   }

--- a/packages/contracts/src/components/base/StatComponent.sol
+++ b/packages/contracts/src/components/base/StatComponent.sol
@@ -8,19 +8,6 @@ import { Stat, StatLib } from "components/types/Stat.sol";
 contract StatComponent is BareComponent {
   constructor(address world, uint256 id) BareComponent(world, id) {}
 
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    keys = new string[](1);
-    values = new LibTypes.SchemaValue[](1);
-
-    keys[0] = "value";
-    values[0] = LibTypes.SchemaValue.UINT256;
-  }
-
   function set(uint256 entity, Stat memory value) external virtual onlyWriter {
     _set(entity, value);
   }

--- a/packages/contracts/src/components/base/StringBareComponent.sol
+++ b/packages/contracts/src/components/base/StringBareComponent.sol
@@ -6,19 +6,6 @@ import { TypeLib } from "components/types/standard.sol";
 contract StringBareComponent is BareComponent {
   constructor(address world, uint256 id) BareComponent(world, id) {}
 
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    keys = new string[](1);
-    values = new LibTypes.SchemaValue[](1);
-
-    keys[0] = "value";
-    values[0] = LibTypes.SchemaValue.STRING;
-  }
-
   function set(uint256 entity, string memory value) external virtual onlyWriter {
     _set(entity, TypeLib.encodeString(value));
   }

--- a/packages/contracts/src/components/base/StringComponent.sol
+++ b/packages/contracts/src/components/base/StringComponent.sol
@@ -6,19 +6,6 @@ import { TypeLib } from "components/types/standard.sol";
 contract StringComponent is Component {
   constructor(address world, uint256 id) Component(world, id) {}
 
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    keys = new string[](1);
-    values = new LibTypes.SchemaValue[](1);
-
-    keys[0] = "value";
-    values[0] = LibTypes.SchemaValue.STRING;
-  }
-
   function set(uint256 entity, string memory value) external virtual onlyWriter {
     _set(entity, TypeLib.encodeString(value));
   }

--- a/packages/contracts/src/components/base/Uint256ArrayBareComponent.sol
+++ b/packages/contracts/src/components/base/Uint256ArrayBareComponent.sol
@@ -6,19 +6,6 @@ import { TypeLib } from "components/types/standard.sol";
 contract Uint256ArrayBareComponent is BareComponent {
   constructor(address world, uint256 id) BareComponent(world, id) {}
 
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    keys = new string[](1);
-    values = new LibTypes.SchemaValue[](1);
-
-    keys[0] = "value";
-    values[0] = LibTypes.SchemaValue.UINT256_ARRAY;
-  }
-
   function set(uint256 entity, uint256[] memory value) external virtual onlyWriter {
     _set(entity, TypeLib.encodeUint256Array(value));
   }

--- a/packages/contracts/src/components/base/Uint256ArrayComponent.sol
+++ b/packages/contracts/src/components/base/Uint256ArrayComponent.sol
@@ -6,19 +6,6 @@ import { TypeLib } from "components/types/standard.sol";
 contract Uint256ArrayComponent is Component {
   constructor(address world, uint256 id) Component(world, id) {}
 
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    keys = new string[](1);
-    values = new LibTypes.SchemaValue[](1);
-
-    keys[0] = "value";
-    values[0] = LibTypes.SchemaValue.UINT256_ARRAY;
-  }
-
   function set(uint256 entity, uint256[] memory value) external virtual onlyWriter {
     _set(entity, TypeLib.encodeUint256Array(value));
   }

--- a/packages/contracts/src/components/base/Uint256BareComponent.sol
+++ b/packages/contracts/src/components/base/Uint256BareComponent.sol
@@ -9,19 +9,6 @@ import { TypeLib } from "components/types/standard.sol";
 contract Uint256BareComponent is BareComponent {
   constructor(address world, uint256 id) BareComponent(world, id) {}
 
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    keys = new string[](1);
-    values = new LibTypes.SchemaValue[](1);
-
-    keys[0] = "value";
-    values[0] = LibTypes.SchemaValue.UINT256;
-  }
-
   function set(uint256 entity, uint256 value) external virtual onlyWriter {
     _set(entity, TypeLib.encodeUint256(value));
   }

--- a/packages/contracts/src/components/base/Uint256Component.sol
+++ b/packages/contracts/src/components/base/Uint256Component.sol
@@ -6,19 +6,6 @@ import { TypeLib } from "components/types/standard.sol";
 contract Uint256Component is Component {
   constructor(address world, uint256 id) Component(world, id) {}
 
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    keys = new string[](1);
-    values = new LibTypes.SchemaValue[](1);
-
-    keys[0] = "value";
-    values[0] = LibTypes.SchemaValue.UINT256;
-  }
-
   function set(uint256 entity, uint256 value) external virtual onlyWriter {
     _set(entity, TypeLib.encodeUint256(value));
   }

--- a/packages/contracts/src/components/base/Uint32ArrayBareComponent.sol
+++ b/packages/contracts/src/components/base/Uint32ArrayBareComponent.sol
@@ -6,19 +6,6 @@ import { TypeLib } from "components/types/standard.sol";
 contract Uint32ArrayBareComponent is BareComponent {
   constructor(address world, uint256 id) BareComponent(world, id) {}
 
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    keys = new string[](1);
-    values = new LibTypes.SchemaValue[](1);
-
-    keys[0] = "value";
-    values[0] = LibTypes.SchemaValue.UINT32_ARRAY;
-  }
-
   function set(uint256 entity, uint32[] memory value) external virtual onlyWriter {
     _set(entity, TypeLib.encodeUint32Array(value));
   }

--- a/packages/contracts/src/components/base/Uint32ArrayComponent.sol
+++ b/packages/contracts/src/components/base/Uint32ArrayComponent.sol
@@ -6,19 +6,6 @@ import { TypeLib } from "components/types/standard.sol";
 contract Uint32ArrayComponent is Component {
   constructor(address world, uint256 id) Component(world, id) {}
 
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    keys = new string[](1);
-    values = new LibTypes.SchemaValue[](1);
-
-    keys[0] = "value";
-    values[0] = LibTypes.SchemaValue.UINT32_ARRAY;
-  }
-
   function set(uint256 entity, uint32[] memory value) external virtual onlyWriter {
     _set(entity, TypeLib.encodeUint32Array(value));
   }

--- a/packages/contracts/src/components/base/Uint32BareComponent.sol
+++ b/packages/contracts/src/components/base/Uint32BareComponent.sol
@@ -6,19 +6,6 @@ import { TypeLib } from "components/types/standard.sol";
 contract Uint32BareComponent is BareComponent {
   constructor(address world, uint256 id) BareComponent(world, id) {}
 
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    keys = new string[](1);
-    values = new LibTypes.SchemaValue[](1);
-
-    keys[0] = "value";
-    values[0] = LibTypes.SchemaValue.UINT32;
-  }
-
   function set(uint256 entity, uint32 value) external virtual onlyWriter {
     _set(entity, TypeLib.encodeUint32(value));
   }

--- a/packages/contracts/src/components/base/Uint32Component.sol
+++ b/packages/contracts/src/components/base/Uint32Component.sol
@@ -6,19 +6,6 @@ import { TypeLib } from "components/types/standard.sol";
 contract Uint32Component is Component {
   constructor(address world, uint256 id) Component(world, id) {}
 
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    keys = new string[](1);
-    values = new LibTypes.SchemaValue[](1);
-
-    keys[0] = "value";
-    values[0] = LibTypes.SchemaValue.UINT32;
-  }
-
   function set(uint256 entity, uint32 value) external virtual onlyWriter {
     _set(entity, TypeLib.encodeUint32(value));
   }

--- a/packages/contracts/src/solecs/components/Uint256Component.sol
+++ b/packages/contracts/src/solecs/components/Uint256Component.sol
@@ -12,19 +12,6 @@ import { IUint256Component } from "../interfaces/IUint256Component.sol";
 contract Uint256Component is Component, IUint256Component {
   constructor(address world, uint256 id) Component(world, id) {}
 
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    keys = new string[](1);
-    values = new LibTypes.SchemaValue[](1);
-
-    keys[0] = "value";
-    values[0] = LibTypes.SchemaValue.UINT256;
-  }
-
   function set(uint256 entity, uint256 value) public virtual {
     set(entity, abi.encode(value));
   }

--- a/packages/contracts/src/solecs/interfaces/IComponent.sol
+++ b/packages/contracts/src/solecs/interfaces/IComponent.sol
@@ -5,12 +5,6 @@ import { IOwnableWritable } from "./IOwnableWritable.sol";
 import { LibTypes } from "../LibTypes.sol";
 
 interface IComponent is IOwnableWritable {
-  /** Return the keys and value types of the schema of this component. */
-  function getSchema()
-    external
-    pure
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values);
-
   function set(uint256 entity, bytes memory value) external;
 
   function setBatch(uint256[] memory entities, bytes[] memory values) external;

--- a/packages/contracts/src/solecs/test/components/DamageComponent.sol
+++ b/packages/contracts/src/solecs/test/components/DamageComponent.sol
@@ -8,15 +8,6 @@ uint256 constant ID = uint256(keccak256("mudwar.components.Damage"));
 contract DamageComponent is Component {
   constructor(address world) Component(world, ID) {}
 
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    values[0] = LibTypes.SchemaValue.UINT256;
-  }
-
   function set(uint256 entity, uint256 value) public {
     set(entity, abi.encode(value));
   }

--- a/packages/contracts/src/solecs/test/components/FromPrototypeComponent.sol
+++ b/packages/contracts/src/solecs/test/components/FromPrototypeComponent.sol
@@ -8,15 +8,6 @@ contract FromPrototypeComponent is Component {
 
   constructor(address world) Component(world, ID) {}
 
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    values[0] = LibTypes.SchemaValue.UINT256;
-  }
-
   function set(uint256 entity, uint256 prototypeEntity) public {
     set(entity, abi.encode(prototypeEntity));
   }

--- a/packages/contracts/src/solecs/test/components/OwnedByEntityComponent.sol
+++ b/packages/contracts/src/solecs/test/components/OwnedByEntityComponent.sol
@@ -8,15 +8,6 @@ contract OwnedByEntityComponent is Component {
 
   constructor(address world) Component(world, ID) {}
 
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    values[0] = LibTypes.SchemaValue.UINT256;
-  }
-
   function set(uint256 entity, uint256 ownedByEntity) public {
     set(entity, abi.encode(ownedByEntity));
   }

--- a/packages/contracts/src/solecs/test/components/PositionComponent.sol
+++ b/packages/contracts/src/solecs/test/components/PositionComponent.sol
@@ -14,19 +14,6 @@ uint256 constant ID = uint256(keccak256("mudwar.components.Position"));
 contract PositionComponent is Component {
   constructor(address world) Component(world, ID) {}
 
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    keys[0] = "x";
-    values[0] = LibTypes.SchemaValue.INT64;
-
-    keys[1] = "y";
-    values[1] = LibTypes.SchemaValue.INT64;
-  }
-
   function set(uint256 entity, Position calldata value) public {
     set(entity, abi.encode(value));
   }

--- a/packages/contracts/src/solecs/test/components/PrototypeTagComponent.sol
+++ b/packages/contracts/src/solecs/test/components/PrototypeTagComponent.sol
@@ -8,15 +8,6 @@ contract PrototypeTagComponent is Component {
 
   constructor(address world) Component(world, ID) {}
 
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    values[0] = LibTypes.SchemaValue.UINT256;
-  }
-
   function set(uint256 entity, bool value) public {
     set(entity, abi.encode(value));
   }

--- a/packages/contracts/src/solecs/test/components/TestComponent.sol
+++ b/packages/contracts/src/solecs/test/components/TestComponent.sol
@@ -7,73 +7,28 @@ contract TestComponent is Component {
   uint256 public constant ID = uint256(keccak256("lib.testComponent"));
 
   constructor(address world) Component(world, ID) {}
-
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    values[0] = LibTypes.SchemaValue.UINT256;
-  }
 }
 
 contract TestComponent1 is Component {
   uint256 public constant ID = uint256(keccak256("lib.testComponent1"));
 
   constructor(address world) Component(world, ID) {}
-
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    values[0] = LibTypes.SchemaValue.UINT256;
-  }
 }
 
 contract TestComponent2 is Component {
   uint256 public constant ID = uint256(keccak256("lib.testComponent2"));
 
   constructor(address world) Component(world, ID) {}
-
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    values[0] = LibTypes.SchemaValue.UINT256;
-  }
 }
 
 contract TestComponent3 is Component {
   uint256 public constant ID = uint256(keccak256("lib.testComponent3"));
 
   constructor(address world) Component(world, ID) {}
-
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    values[0] = LibTypes.SchemaValue.UINT256;
-  }
 }
 
 contract TestComponent4 is Component {
   uint256 public constant ID = uint256(keccak256("lib.testComponent4"));
 
   constructor(address world) Component(world, ID) {}
-
-  function getSchema()
-    public
-    pure
-    override
-    returns (string[] memory keys, LibTypes.SchemaValue[] memory values)
-  {
-    values[0] = LibTypes.SchemaValue.UINT256;
-  }
 }


### PR DESCRIPTION
3rd try

`getSchema()` no longer needed. Removes it and updates abis

No redeployment needed - `getSchema()` wasn't used anywhere else