### PR TITLE
display common chain names on network switch

### DIFF
--- a/packages/client/src/clients/wagmi/config.ts
+++ b/packages/client/src/clients/wagmi/config.ts
@@ -1,55 +1,16 @@
-import {
-  arbitrum,
-  base,
-  blast,
-  canto,
-  linea,
-  localhost,
-  mantle,
-  optimism,
-  scroll,
-  zkSync,
-  zora,
-} from '@wagmi/core/chains';
 import { createConfig, http } from 'wagmi';
 import { injected } from 'wagmi/connectors';
 
-import { defaultChain, ethereum } from 'constants/chains';
+import { defaultChain } from 'constants/chains';
 
 const mode = import.meta.env.MODE;
 const transportUrl = import.meta.env.VITE_RPC_TRANSPORT_URL;
 const defaultTransport = mode === 'development' ? http() : http(transportUrl);
 
 export const config = createConfig({
-  chains: [
-    defaultChain,
-    localhost,
-    arbitrum,
-    base,
-    blast,
-    canto,
-    ethereum,
-    linea,
-    mantle,
-    optimism,
-    scroll,
-    zkSync,
-    zora,
-  ],
+  chains: [defaultChain],
   transports: {
     [defaultChain.id]: defaultTransport,
-    [localhost.id]: defaultTransport,
-    [arbitrum.id]: defaultTransport,
-    [base.id]: defaultTransport,
-    [blast.id]: defaultTransport,
-    [canto.id]: defaultTransport,
-    [ethereum.id]: defaultTransport,
-    [linea.id]: defaultTransport,
-    [mantle.id]: defaultTransport,
-    [optimism.id]: defaultTransport,
-    [scroll.id]: defaultTransport,
-    [zkSync.id]: defaultTransport,
-    [zora.id]: defaultTransport,
   },
   connectors: [injected()],
   pollingInterval: 1000, // TODO: set this with a config value

--- a/packages/client/src/constants/chains.ts
+++ b/packages/client/src/constants/chains.ts
@@ -1,29 +1,12 @@
 import { addRpcUrlOverrideToChain } from '@privy-io/react-auth';
 import { Chain, localhost, optimism } from '@wagmi/core/chains';
 
-export const ethereum = {
-  id: 1,
-  name: 'Ethereum',
-  nativeCurrency: {
-    decimals: 18,
-    name: 'Ether',
-    symbol: 'ETH',
-  },
-  rpcUrls: {
-    default: { http: [import.meta.env.VITE_RPC_TRANSPORT_URL] },
-  },
-
-  blockExplorers: {
-    default: { name: 'Explorer', url: 'https://etherscan.io' },
-  },
-} as const satisfies Chain;
-
 const rawYominet = {
   id: 5264468217,
   name: 'yominet',
   nativeCurrency: {
     decimals: 18,
-    name: 'Ether',
+    name: 'Ethereum',
     symbol: 'ETH',
   },
   rpcUrls: {


### PR DESCRIPTION
display common chain names on WalletConnector validator. use 'wrong Network' when unknown

<img width="835" alt="Screen Shot 2024-06-24 at 10 45 24 PM" src="https://github.com/Asphodel-OS/kamigotchi/assets/109483360/b6df9281-dacb-4b4d-aff9-4fc2330a6d42">

<img width="817" alt="Screen Shot 2024-06-24 at 10 45 47 PM" src="https://github.com/Asphodel-OS/kamigotchi/assets/109483360/86276ba4-e3a1-4288-bf99-166b769e39ba">
