### PR TITLE
Item shape updates

### DIFF
--- a/packages/client/abi/_ItemRegistrySystem.json
+++ b/packages/client/abi/_ItemRegistrySystem.json
@@ -18,6 +18,38 @@
     },
     {
       "type": "function",
+      "name": "addStat",
+      "inputs": [
+        {
+          "name": "arguments",
+          "type": "bytes",
+          "internalType": "bytes"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "create",
+      "inputs": [
+        {
+          "name": "arguments",
+          "type": "bytes",
+          "internalType": "bytes"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
       "name": "createConsumable",
       "inputs": [
         {
@@ -37,45 +69,7 @@
     },
     {
       "type": "function",
-      "name": "createFood",
-      "inputs": [
-        {
-          "name": "arguments",
-          "type": "bytes",
-          "internalType": "bytes"
-        }
-      ],
-      "outputs": [
-        {
-          "name": "",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
-      ],
-      "stateMutability": "nonpayable"
-    },
-    {
-      "type": "function",
       "name": "createLootbox",
-      "inputs": [
-        {
-          "name": "arguments",
-          "type": "bytes",
-          "internalType": "bytes"
-        }
-      ],
-      "outputs": [
-        {
-          "name": "",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
-      ],
-      "stateMutability": "nonpayable"
-    },
-    {
-      "type": "function",
-      "name": "createRevive",
       "inputs": [
         {
           "name": "arguments",
@@ -181,10 +175,10 @@
     }
   ],
   "methodIdentifiers": {
+    "addStat(bytes)": "350df03e",
+    "create(bytes)": "cf5ba53f",
     "createConsumable(bytes)": "e96e3836",
-    "createFood(bytes)": "62bd64bd",
     "createLootbox(bytes)": "b72c6001",
-    "createRevive(bytes)": "a0e9f15c",
     "execute(bytes)": "09c5eabe",
     "owner()": "8da5cb5b",
     "remove(uint32)": "00d84fd8",

--- a/packages/client/src/app/components/modals/naming/EmaBoard.tsx
+++ b/packages/client/src/app/components/modals/naming/EmaBoard.tsx
@@ -52,7 +52,7 @@ export function registerEMABoardModal() {
       };
 
       const useRenamePotion = (kami: Kami) => {
-        const itemIndex = 9001;
+        const itemIndex = 111;
         actions.add({
           action: 'KamiFeed',
           params: [kami.id, itemIndex],

--- a/packages/client/types/ethers-contracts/_ItemRegistrySystem.ts
+++ b/packages/client/types/ethers-contracts/_ItemRegistrySystem.ts
@@ -29,10 +29,10 @@ import type {
 
 export interface _ItemRegistrySystemInterface extends utils.Interface {
   functions: {
+    "addStat(bytes)": FunctionFragment;
+    "create(bytes)": FunctionFragment;
     "createConsumable(bytes)": FunctionFragment;
-    "createFood(bytes)": FunctionFragment;
     "createLootbox(bytes)": FunctionFragment;
-    "createRevive(bytes)": FunctionFragment;
     "execute(bytes)": FunctionFragment;
     "owner()": FunctionFragment;
     "remove(uint32)": FunctionFragment;
@@ -41,10 +41,10 @@ export interface _ItemRegistrySystemInterface extends utils.Interface {
 
   getFunction(
     nameOrSignatureOrTopic:
+      | "addStat"
+      | "create"
       | "createConsumable"
-      | "createFood"
       | "createLootbox"
-      | "createRevive"
       | "execute"
       | "owner"
       | "remove"
@@ -52,19 +52,19 @@ export interface _ItemRegistrySystemInterface extends utils.Interface {
   ): FunctionFragment;
 
   encodeFunctionData(
+    functionFragment: "addStat",
+    values: [PromiseOrValue<BytesLike>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "create",
+    values: [PromiseOrValue<BytesLike>]
+  ): string;
+  encodeFunctionData(
     functionFragment: "createConsumable",
     values: [PromiseOrValue<BytesLike>]
   ): string;
   encodeFunctionData(
-    functionFragment: "createFood",
-    values: [PromiseOrValue<BytesLike>]
-  ): string;
-  encodeFunctionData(
     functionFragment: "createLootbox",
-    values: [PromiseOrValue<BytesLike>]
-  ): string;
-  encodeFunctionData(
-    functionFragment: "createRevive",
     values: [PromiseOrValue<BytesLike>]
   ): string;
   encodeFunctionData(
@@ -81,17 +81,14 @@ export interface _ItemRegistrySystemInterface extends utils.Interface {
     values: [PromiseOrValue<string>]
   ): string;
 
+  decodeFunctionResult(functionFragment: "addStat", data: BytesLike): Result;
+  decodeFunctionResult(functionFragment: "create", data: BytesLike): Result;
   decodeFunctionResult(
     functionFragment: "createConsumable",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "createFood", data: BytesLike): Result;
   decodeFunctionResult(
     functionFragment: "createLootbox",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
-    functionFragment: "createRevive",
     data: BytesLike
   ): Result;
   decodeFunctionResult(functionFragment: "execute", data: BytesLike): Result;
@@ -148,22 +145,22 @@ export interface _ItemRegistrySystem extends BaseContract {
   removeListener: OnEvent<this>;
 
   functions: {
+    addStat(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    create(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
     createConsumable(
       arguments: PromiseOrValue<BytesLike>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
-    createFood(
-      arguments: PromiseOrValue<BytesLike>,
-      overrides?: Overrides & { from?: PromiseOrValue<string> }
-    ): Promise<ContractTransaction>;
-
     createLootbox(
-      arguments: PromiseOrValue<BytesLike>,
-      overrides?: Overrides & { from?: PromiseOrValue<string> }
-    ): Promise<ContractTransaction>;
-
-    createRevive(
       arguments: PromiseOrValue<BytesLike>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
@@ -186,22 +183,22 @@ export interface _ItemRegistrySystem extends BaseContract {
     ): Promise<ContractTransaction>;
   };
 
+  addStat(
+    arguments: PromiseOrValue<BytesLike>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  create(
+    arguments: PromiseOrValue<BytesLike>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
   createConsumable(
     arguments: PromiseOrValue<BytesLike>,
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
-  createFood(
-    arguments: PromiseOrValue<BytesLike>,
-    overrides?: Overrides & { from?: PromiseOrValue<string> }
-  ): Promise<ContractTransaction>;
-
   createLootbox(
-    arguments: PromiseOrValue<BytesLike>,
-    overrides?: Overrides & { from?: PromiseOrValue<string> }
-  ): Promise<ContractTransaction>;
-
-  createRevive(
     arguments: PromiseOrValue<BytesLike>,
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
@@ -224,22 +221,22 @@ export interface _ItemRegistrySystem extends BaseContract {
   ): Promise<ContractTransaction>;
 
   callStatic: {
+    addStat(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
+    create(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
     createConsumable(
       arguments: PromiseOrValue<BytesLike>,
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    createFood(
-      arguments: PromiseOrValue<BytesLike>,
-      overrides?: CallOverrides
-    ): Promise<BigNumber>;
-
     createLootbox(
-      arguments: PromiseOrValue<BytesLike>,
-      overrides?: CallOverrides
-    ): Promise<BigNumber>;
-
-    createRevive(
       arguments: PromiseOrValue<BytesLike>,
       overrides?: CallOverrides
     ): Promise<BigNumber>;
@@ -274,22 +271,22 @@ export interface _ItemRegistrySystem extends BaseContract {
   };
 
   estimateGas: {
+    addStat(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    create(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
     createConsumable(
       arguments: PromiseOrValue<BytesLike>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
-    createFood(
-      arguments: PromiseOrValue<BytesLike>,
-      overrides?: Overrides & { from?: PromiseOrValue<string> }
-    ): Promise<BigNumber>;
-
     createLootbox(
-      arguments: PromiseOrValue<BytesLike>,
-      overrides?: Overrides & { from?: PromiseOrValue<string> }
-    ): Promise<BigNumber>;
-
-    createRevive(
       arguments: PromiseOrValue<BytesLike>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
@@ -313,22 +310,22 @@ export interface _ItemRegistrySystem extends BaseContract {
   };
 
   populateTransaction: {
+    addStat(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    create(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
     createConsumable(
       arguments: PromiseOrValue<BytesLike>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 
-    createFood(
-      arguments: PromiseOrValue<BytesLike>,
-      overrides?: Overrides & { from?: PromiseOrValue<string> }
-    ): Promise<PopulatedTransaction>;
-
     createLootbox(
-      arguments: PromiseOrValue<BytesLike>,
-      overrides?: Overrides & { from?: PromiseOrValue<string> }
-    ): Promise<PopulatedTransaction>;
-
-    createRevive(
       arguments: PromiseOrValue<BytesLike>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;

--- a/packages/contracts/deploy.json
+++ b/packages/contracts/deploy.json
@@ -153,16 +153,22 @@
       "writeAccess": [
         "DescriptionComponent",
         "ExperienceComponent",
+        "ForComponent",
         "IsRegistryComponent",
         "IsConsumableComponent",
         "IsLootboxComponent",
         "IndexItemComponent",
         "HealthComponent",
+        "HarmonyComponent",
+        "PowerComponent",
         "KeysComponent",
         "WeightsComponent",
         "NameComponent",
         "MediaURIComponent",
-        "TypeComponent"
+        "TypeComponent",
+        "SlotsComponent",
+        "StaminaComponent",
+        "ViolenceComponent"
       ]
     },
     {

--- a/packages/contracts/src/deployment/commands/callGodSystem.ts
+++ b/packages/contracts/src/deployment/commands/callGodSystem.ts
@@ -16,9 +16,9 @@ const run = async () => {
   const mode = argv.mode || 'DEV';
   const world = argv.world ? argv.world : getWorld(mode);
 
-  await setAutoMine(mode, true);
+  if (mode === 'DEV') setAutoMine(true);
   await executeGodSystem(getRpc(mode)!, getDeployerKey(mode)!, world);
-  await setAutoMine(mode, false);
+  if (mode === 'DEV') setAutoMine(false);
 };
 
 run();

--- a/packages/contracts/src/deployment/commands/callSystem.ts
+++ b/packages/contracts/src/deployment/commands/callSystem.ts
@@ -21,7 +21,7 @@ const run = async () => {
   const func = argv.func ? argv.func : 'executeTyped';
   const args = argv.args ? argv.args.split(',') : [];
 
-  await setAutoMine(mode, true);
+  if (mode === 'DEV') setAutoMine(true);
 
   // generate init script and calls
   await generateSingleCall(mode, system, func, args);
@@ -29,7 +29,7 @@ const run = async () => {
   // running script.sol
   await initWorld(getDeployerKey(mode), getRpc(mode)!, world);
 
-  await setAutoMine(mode, false);
+  if (mode === 'DEV') setAutoMine(false);
 };
 
 run();

--- a/packages/contracts/src/deployment/commands/initWorld.ts
+++ b/packages/contracts/src/deployment/commands/initWorld.ts
@@ -25,7 +25,7 @@ const run = async () => {
   if (action !== 'init' && categories.length > 1)
     throw new Error('Only one category allowed for non-init actions');
 
-  await setAutoMine(mode, true);
+  if (mode === 'DEV') setAutoMine(true);
 
   // generate init script and calls
   await generateInitScript(mode, categories, action, argv.args);
@@ -33,7 +33,7 @@ const run = async () => {
   // running script.sol
   await initWorld(getDeployerKey(mode), getRpc(mode)!, world);
 
-  await setAutoMine(mode, false);
+  if (mode === 'DEV') setAutoMine(false);
 };
 
 run();

--- a/packages/contracts/src/deployment/world/admin.ts
+++ b/packages/contracts/src/deployment/world/admin.ts
@@ -388,20 +388,36 @@ export function createAdminAPI(compiledCalls: string[]) {
   /////////////////
   //  ITEMS
 
-  // @dev add a food item registry entry
-  async function registerFood(
+  async function registerBaseItem(
     index: number,
+    for_: string,
     name: string,
     description: string,
-    health: number,
-    experience: number,
+    media: string
+  ) {
+    genCall('system.item.registry', [index, for_, name, description, media], 'create', [
+      'uint32',
+      'string',
+      'string',
+      'string',
+      'string',
+    ]);
+  }
+
+  // @dev add a misc item in registry entry
+  async function registerConsumable(
+    index: number,
+    for_: string,
+    name: string,
+    description: string,
+    type_: string,
     media: string
   ) {
     genCall(
       'system.item.registry',
-      [index, name, description, health, experience, media],
-      'createFood',
-      ['uint32', 'string', 'string', 'int32', 'uint256', 'string']
+      [index, for_, name, description, type_, media],
+      'createConsumable',
+      ['uint32', 'string', 'string', 'string', 'string', 'string']
     );
   }
 
@@ -421,38 +437,8 @@ export function createAdminAPI(compiledCalls: string[]) {
     );
   }
 
-  // @dev add a misc item in registry entry
-  async function registerConsumable(
-    index: number,
-    name: string,
-    description: string,
-    type_: string,
-    media: string
-  ) {
-    genCall('system.item.registry', [index, name, description, type_, media], 'createConsumable', [
-      'uint32',
-      'string',
-      'string',
-      'string',
-      'string',
-    ]);
-  }
-
-  // @dev add a revive item registry entry
-  async function registerRevive(
-    index: number,
-    name: string,
-    description: string,
-    health: number,
-    media: string
-  ) {
-    genCall('system.item.registry', [index, name, description, health, media], 'createRevive', [
-      'uint32',
-      'string',
-      'string',
-      'int32',
-      'string',
-    ]);
+  async function addStat(index: number, type_: string, value: number) {
+    genCall('system.item.registry', [index, type_, value], 'addStat');
   }
 
   // @dev deletes an item registry
@@ -587,10 +573,12 @@ export function createAdminAPI(compiledCalls: string[]) {
     registry: {
       item: {
         create: {
-          food: registerFood,
+          base: registerBaseItem,
           lootbox: registerLootbox,
           consumable: registerConsumable,
-          revive: registerRevive,
+        },
+        add: {
+          stat: addStat,
         },
         delete: deleteItem,
       },

--- a/packages/contracts/src/deployment/world/data/items/Items.csv
+++ b/packages/contracts/src/deployment/world/data/items/Items.csv
@@ -1,13 +1,37 @@
-﻿Image,Index,Name,Type,Description,FamilyIndex(depreciated),Health,Power,Violence,Harmony,Slots,XP,Droptable,_type,miscCategory
-Items%201b9894152b7f4649a68169aa3a6bcffe/musu.png,1,MUSU,Misc,Kamigotchi kurrency,,,,,,,,,,
-Items%201b9894152b7f4649a68169aa3a6bcffe/ghost_gum_wip_native.png,101,Maple-Flavor Ghost Gum,Food,"The most basic form of food available in this world - restores 25 Health to a Kamigotchi. ",1,25,,,,,,,,
-Items%201b9894152b7f4649a68169aa3a6bcffe/pom_poms_candy_wip_native.png,102,Pom-Pom Fruit Candy,Food,These fruit candies contain a huge amount of energy. Restores 100 Health to a Kamigotchi.,2,100,,,,,,,,
-Items%201b9894152b7f4649a68169aa3a6bcffe/gakki_wip_native.png,103,Gakki Cookie Sticks,Food,Heavy duty rations by a Kami’s standards.. Restores 200 Health to a Kamigotchi.,3,200,,,,,,,,
-Items%201b9894152b7f4649a68169aa3a6bcffe/large_xp_candy_native.png,104,XP Candy (Large),Food,"This gives a lot of XP when fed to a Kamigotchi. ",4,,,,,,200,,,
-Items%201b9894152b7f4649a68169aa3a6bcffe/medium_xp_candy_native.png,105,XP Candy (Medium),Food,"Provides a decent amount of XP when fed to a Kami. ",5,,,,,,100,,,
-Items%201b9894152b7f4649a68169aa3a6bcffe/small_xp_candy_native.png,106,XP Candy (Small),Food,"Feed this to a Kamigotchi to give them a little bit of experience. ",6,,,,,,25,,,
-Items%201b9894152b7f4649a68169aa3a6bcffe/red_ribbons_candy_wip_native.png,1001,Red Gakki Ribbon,Revive,"Capable of raising a Kamigotchi from the dead. 
+﻿Image,Index,Name,Status,Type,ConsumableType,For,Description,Health,MaxHealth,Power,Violence,Harmony,Slots,XP,Stamina,DTIndices,DTWeights,_type,IgnoreContract,FamilyIndex(depreciated)
+Items%201b9894152b7f4649a68169aa3a6bcffe/musu.png,1,MUSU,For Implementation,Misc,,,Kamigotchi kurrency,,,,,,,,,,,,No,
+Items%201b9894152b7f4649a68169aa3a6bcffe/ghost_gum_wip_native.png,101,Maple-Flavor Ghost Gum,For Implementation,Consumable,FOOD,Kami,"The most basic form of food available in this world - restores 25 Health to a Kamigotchi. ",25,,,,,,,,,,,No,1
+Items%201b9894152b7f4649a68169aa3a6bcffe/pom_poms_candy_wip_native.png,102,Pom-Pom Fruit Candy,For Implementation,Consumable,FOOD,Kami,These fruit candies contain a huge amount of energy. Restores 100 Health to a Kamigotchi.,100,,,,,,,,,,,No,2
+Items%201b9894152b7f4649a68169aa3a6bcffe/gakki_wip_native.png,103,Gakki Cookie Sticks,For Implementation,Consumable,FOOD,Kami,Heavy duty rations by a Kami’s standards.. Restores 200 Health to a Kamigotchi.,200,,,,,,,,,,,No,3
+Items%201b9894152b7f4649a68169aa3a6bcffe/large_xp_candy_native.png,104,XP Candy (Large),For Implementation,Consumable,FOOD,Kami,"This gives a lot of XP when fed to a Kamigotchi. ",,,,,,,200,,,,,No,4
+Items%201b9894152b7f4649a68169aa3a6bcffe/medium_xp_candy_native.png,105,XP Candy (Medium),For Implementation,Consumable,FOOD,Kami,"Provides a decent amount of XP when fed to a Kami. ",,,,,,,100,,,,,No,5
+Items%201b9894152b7f4649a68169aa3a6bcffe/small_xp_candy_native.png,106,XP Candy (Small),For Implementation,Consumable,FOOD,Kami,"Feed this to a Kamigotchi to give them a little bit of experience. ",,,,,,,25,,,,,No,6
+Items%201b9894152b7f4649a68169aa3a6bcffe/cheeseburger_native.png,,Cheeseburger,Not Implemented,Consumable,FOOD,,,,,,,,,,,,,,No,
+Items%201b9894152b7f4649a68169aa3a6bcffe/ice_cream_large_native.png,107,Ice Cream (Large),For Implementation,Consumable,FOOD,Account,,,,,,,,,80,,,,No,
+Items%201b9894152b7f4649a68169aa3a6bcffe/ice_cream_medium_native.png,108,Ice Cream (Medium),For Implementation,Consumable,FOOD,Account,,,,,,,,,40,,,,No,
+Items%201b9894152b7f4649a68169aa3a6bcffe/ice_cream_small_native.png,109,Ice Cream (Small),For Implementation,Consumable,FOOD,Account,,,,,,,,,20,,,,No,
+Items%201b9894152b7f4649a68169aa3a6bcffe/red_ribbons_candy_wip_native.png,110,Red Gakki Ribbon,For Implementation,Consumable,REVIVE,Kami,"Capable of raising a Kamigotchi from the dead. 
 
-These ribbons are greatly prized…. ",1,10,,,,,,,,
-Items%201b9894152b7f4649a68169aa3a6bcffe/holy_dust_native.png,9001,Holy Dust,Misc,This sacred dust can be used to rename Kamigotchi… At the proper place.,,,,,,,,,,RENAME_POTION
-Items%201b9894152b7f4649a68169aa3a6bcffe/lootbox_native.png,10001,Giftbox,Lootbox,Something is inside…..,,,,,,,,1,,
+These ribbons are greatly prized…. ",10,,,,,,,,,,,No,1
+Items%201b9894152b7f4649a68169aa3a6bcffe/holy_dust_native.png,111,Holy Dust,For Implementation,Consumable,RENAME_POTION,Kami,This sacred dust can be used to rename Kamigotchi… At the proper place.,,,,,,,,,,,,No,
+Items%201b9894152b7f4649a68169aa3a6bcffe/lootbox_native.png,10001,Agency Giftbox,For Implementation,Lootbox,,,Something is inside…..,,,,,,,,,"[11001, 11002, 11006, 101, 102, 103, 106, 105, 104, 109, 108, 107, 110]","[9, 9, 9, 9, 8, 7, 8, 7, 6, 9, 8, 7, 7]",,No,
+Items%201b9894152b7f4649a68169aa3a6bcffe/plastic_bottle_native.png,11001,Plastic Bottle,For Implementation,Material,,,"Can be reprocessed into valuable raw Microplastics. ",,,,,,,,,,,,No,
+Items%201b9894152b7f4649a68169aa3a6bcffe/stone_native.png,11002,Stone,For Implementation,Material,,,"It’s just a stone. Can be used to get Stone. ",,,,,,,,,,,,No,
+Items%201b9894152b7f4649a68169aa3a6bcffe/screwdriver_native.png,11003,Screwdriver,Not Implemented,Material,,,,,,,,,,,,,,,No,
+Items%201b9894152b7f4649a68169aa3a6bcffe/glass_jar_native.png,11004,Glass Jar,Not Implemented,Material,,,,,,,,,,,,,,,No,
+Items%201b9894152b7f4649a68169aa3a6bcffe/pine_pollen_native.png,11005,Pine Pollen,Not Implemented,Material,,,,,,,,,,,,,,,No,
+Items%201b9894152b7f4649a68169aa3a6bcffe/wooden_stick_native.png,11006,Wooden Stick,For Implementation,Material,,,"Wood in its unprocessed form. Grows on trees. ",,,,,,,,,,,,No,
+Items%201b9894152b7f4649a68169aa3a6bcffe/mint_native.png,11007,Mint,Not Implemented,Material,,,,,,,,,,,,,,,No,
+Items%201b9894152b7f4649a68169aa3a6bcffe/pine_cone_native.png,11008,Pine Cone,Not Implemented,Material,,,,,,,,,,,,,,,No,
+Items%201b9894152b7f4649a68169aa3a6bcffe/ring_of_water_breathing_native.png,12001,Ring of Water Breathing,Not Implemented,Ring,,,Allows the bearer to travel underwater.,,,,,,,,,,,,No,
+Items%201b9894152b7f4649a68169aa3a6bcffe/ring_of_spirits_native.png,12002,Ring of Spirits,Not Implemented,Ring,,,,,,,,,,,,,,,No,
+Items%201b9894152b7f4649a68169aa3a6bcffe/kamigotchi_ticket_native.png,,Gacha Ticket,Ingame,Other,,,"Redeemable for one Kami. You should take this to the vending machine… ",,,,,,,,,,,,Yes,
+Items%201b9894152b7f4649a68169aa3a6bcffe/passport_yellow.png,,Passport,Not Implemented,NFT,,,,,,,,,,,,,,,Yes,
+,,Land Deed,Not Implemented,NFT,,,,,,,,,,,,,,,Yes,
+,," Sunset Apple Mochi
+",Not Implemented,Consumable,,,"A deep red and orange mochi. It's filled with a golden apple jam that has a warm, heavenly flavor. Permanently adds +1 to a Kamigotchi’s Power.",,,1,,,,,,,,,No,
+,," Kami Mochi
+",Not Implemented,Consumable,,,"A deep blue mochi with a butterfly stamp. It's filled with soft, white curds that resemble a fresh cheese. Permanently adds +1 to a Kamigotchi’s Violence. ",,,,1,,,,,,,,No,
+,,Mana Mochi,Not Implemented,Consumable,,,A sky blue mochi. It's filled with small white grains that burst with a honey-sweet flavor. Permanently adds +1 to a Kamigotchi’s Harmony.,,,,,1,,,,,,,No,
+,," Gaokerena Mochi
+",Not Implemented,Consumable,,,"A glossy purple mochi. It's filled with a green and fibrous root paste confection made with milk. Permanently adds +10 to a Kamigotchi’s Health. ",,10,,,,,,,,,,No,

--- a/packages/contracts/src/deployment/world/state/npcs.ts
+++ b/packages/contracts/src/deployment/world/state/npcs.ts
@@ -11,5 +11,5 @@ export async function initMerchants(api: AdminAPI) {
   await api.listing.set(1, 101, 50, 0); // merchant index, item index, buy price, sell price
   await api.listing.set(1, 102, 180, 0);
   await api.listing.set(1, 103, 320, 0);
-  await api.listing.set(1, 1001, 500, 0);
+  await api.listing.set(1, 110, 500, 0);
 }

--- a/packages/contracts/src/systems/_ItemRegistrySystem.sol
+++ b/packages/contracts/src/systems/_ItemRegistrySystem.sol
@@ -12,20 +12,35 @@ uint256 constant ID = uint256(keccak256("system.item.registry"));
 contract _ItemRegistrySystem is System {
   constructor(IWorld _world, address _components) System(_world, _components) {}
 
+  function create(bytes memory arguments) public onlyOwner returns (uint256) {
+    (
+      uint32 index,
+      string memory type_,
+      string memory name,
+      string memory description,
+      string memory media
+    ) = abi.decode(arguments, (uint32, string, string, string, string));
+
+    uint256 id = LibItemRegistry.createItem(components, index, type_, name, description, media);
+    return id;
+  }
+
   function createConsumable(bytes memory arguments) public onlyOwner returns (uint256) {
     (
       uint32 index,
+      string memory for_,
       string memory name,
       string memory description,
       string memory type_,
       string memory media
-    ) = abi.decode(arguments, (uint32, string, string, string, string));
+    ) = abi.decode(arguments, (uint32, string, string, string, string, string));
 
     uint256 registryID = LibItemRegistry.getByIndex(components, index);
     require(registryID == 0, "ItemReg: item already exists");
     require(!LibString.eq(name, ""), "ItemReg: name empty");
 
-    return LibItemRegistry.createConsumable(components, index, name, description, type_, media);
+    return
+      LibItemRegistry.createConsumable(components, index, for_, name, description, type_, media);
   }
 
   function createLootbox(bytes memory arguments) public onlyOwner returns (uint256) {
@@ -46,38 +61,11 @@ contract _ItemRegistrySystem is System {
       LibItemRegistry.createLootbox(components, index, name, description, keys, weights, media);
   }
 
-  function createFood(bytes memory arguments) public onlyOwner returns (uint256) {
-    (
-      uint32 index,
-      string memory name,
-      string memory description,
-      int32 health,
-      uint256 experience,
-      string memory media
-    ) = abi.decode(arguments, (uint32, string, string, int32, uint256, string));
-
+  function addStat(uint32 index, string memory type_, int32 value) public onlyOwner {
     uint256 registryID = LibItemRegistry.getByIndex(components, index);
-    require(registryID == 0, "ItemReg: item already exists");
-    require(!LibString.eq(name, ""), "ItemReg: name empty");
+    require(registryID != 0, "ItemReg: item does not exist");
 
-    return
-      LibItemRegistry.createFood(components, index, name, description, health, experience, media);
-  }
-
-  function createRevive(bytes memory arguments) public onlyOwner returns (uint256) {
-    (
-      uint32 index,
-      string memory name,
-      string memory description,
-      int32 health,
-      string memory media
-    ) = abi.decode(arguments, (uint32, string, string, int32, string));
-
-    uint256 registryID = LibItemRegistry.getByIndex(components, index);
-    require(registryID == 0, "ItemReg: item already exists");
-    require(!LibString.eq(name, ""), "ItemReg: name empty");
-
-    return LibItemRegistry.createRevive(components, index, name, description, health, media);
+    LibItemRegistry.addStat(components, registryID, type_, value);
   }
 
   function remove(uint32 index) public onlyOwner {

--- a/packages/contracts/src/test/systems/Merchant.t.sol
+++ b/packages/contracts/src/test/systems/Merchant.t.sol
@@ -283,14 +283,16 @@ contract NPCTest is SetupTemplate {
 
         uint32[] memory itemIndices = new uint32[](1);
         itemIndices[0] = listings2[j].itemIndex;
+        uint32[] memory amts = new uint32[](1);
+        amts[0] = uint32(amt);
 
         vm.prank(_getOperator(i));
         vm.expectRevert("Listing.Buy(): must be in same room as npc");
-        _ListingBuySystem.executeTyped(listings2[j].npcIndex, itemIndices, amt);
+        _ListingBuySystem.executeTyped(listings2[j].npcIndex, itemIndices, amts);
 
         vm.prank(_getOperator(i));
         vm.expectRevert("Listing.Sell(): must be in same room as npc");
-        _ListingSellSystem.executeTyped(listings2[j].npcIndex, itemIndices, amt);
+        _ListingSellSystem.executeTyped(listings2[j].npcIndex, itemIndices, amts);
       }
     }
 
@@ -307,14 +309,16 @@ contract NPCTest is SetupTemplate {
         uint amt = j + 1;
         uint32[] memory itemIndices = new uint32[](1);
         itemIndices[0] = listings1[j].itemIndex;
+        uint32[] memory amts = new uint32[](1);
+        amts[0] = uint32(amt);
 
         vm.prank(_getOperator(i));
         vm.expectRevert("Listing.Buy(): must be in same room as npc");
-        _ListingBuySystem.executeTyped(listings1[j].npcIndex, itemIndices, amt);
+        _ListingBuySystem.executeTyped(listings1[j].npcIndex, itemIndices, amts);
 
         vm.prank(_getOperator(i));
         vm.expectRevert("Listing.Sell(): must be in same room as npc");
-        _ListingSellSystem.executeTyped(listings1[j].npcIndex, itemIndices, amt);
+        _ListingSellSystem.executeTyped(listings1[j].npcIndex, itemIndices, amts);
 
         _buyFromListing(i, listingIDs2[j], amt);
         _sellToListing(i, listingIDs2[j], amt);
@@ -373,8 +377,11 @@ contract NPCTest is SetupTemplate {
       for (uint j = 0; j < listingIDs.length; j++) {
         uint32[] memory itemIndices = new uint32[](1);
         itemIndices[0] = listings[j].itemIndex;
+        uint32[] memory amts = new uint32[](1);
+        amts[0] = uint32(1);
+
         vm.prank(_getOperator(i));
-        _ListingBuySystem.executeTyped(listings[j].npcIndex, itemIndices, 1);
+        _ListingBuySystem.executeTyped(listings[j].npcIndex, itemIndices, amts);
       }
     }
 
@@ -401,9 +408,12 @@ contract NPCTest is SetupTemplate {
         if (testData.balanceChange > _getAccountBalance(testData.playerIndex)) {
           uint32[] memory itemIndices = new uint32[](1);
           itemIndices[0] = listing.itemIndex;
+          uint32[] memory amts = new uint32[](1);
+          amts[0] = uint32(uint256(testData.stockChange));
+
           vm.prank(_getOperator(testData.playerIndex));
           vm.expectRevert("Inventory: insufficient balance");
-          _ListingBuySystem.executeTyped(listing.npcIndex, itemIndices, testData.stockChange);
+          _ListingBuySystem.executeTyped(listing.npcIndex, itemIndices, amts);
         } else {
           _buyFromListing(testData.playerIndex, listingID, testData.stockChange);
           assertEq(
@@ -422,9 +432,12 @@ contract NPCTest is SetupTemplate {
         if (testData.stockChange > _getItemBalance(testData.playerIndex, testData.itemIndex)) {
           uint32[] memory itemIndices = new uint32[](1);
           itemIndices[0] = listing.itemIndex;
+          uint32[] memory amts = new uint32[](1);
+          amts[0] = uint32(uint256(testData.stockChange));
+
           vm.prank(_getOperator(testData.playerIndex));
           vm.expectRevert("Inventory: insufficient balance");
-          _ListingSellSystem.executeTyped(listing.npcIndex, itemIndices, testData.stockChange);
+          _ListingSellSystem.executeTyped(listing.npcIndex, itemIndices, amts);
         } else {
           _sellToListing(testData.playerIndex, listingID, testData.stockChange);
           assertEq(

--- a/packages/contracts/src/test/utils/SetupTemplate.t.sol
+++ b/packages/contracts/src/test/utils/SetupTemplate.t.sol
@@ -233,11 +233,11 @@ abstract contract SetupTemplate is TestSetupImports {
     return _moveAccount(playerIndex, LibRoom.getIndex(components, roomID));
   }
 
-  function _buyFromListing(uint playerIndex, uint listingID, uint32 amt) internal {
+  function _buyFromListing(uint playerIndex, uint listingID, uint256 amt) internal {
     uint32[] memory amts = new uint32[](1);
     uint32[] memory itemIndices = new uint32[](1);
 
-    amts[0] = amt;
+    amts[0] = uint32(amt);
     itemIndices[0] = LibListing.getItemIndex(components, listingID);
     uint32 npcIndex = LibListing.getNPCIndex(components, listingID);
 
@@ -245,11 +245,11 @@ abstract contract SetupTemplate is TestSetupImports {
     _ListingBuySystem.executeTyped(npcIndex, itemIndices, amts);
   }
 
-  function _sellToListing(uint playerIndex, uint listingID, uint32 amt) internal {
+  function _sellToListing(uint playerIndex, uint listingID, uint256 amt) internal {
     uint32[] memory amts = new uint32[](1);
     uint32[] memory itemIndices = new uint32[](1);
 
-    amts[0] = amt;
+    amts[0] = uint32(amt);
     itemIndices[0] = LibListing.getItemIndex(components, listingID);
     uint32 npcIndex = LibListing.getNPCIndex(components, listingID);
 
@@ -575,10 +575,11 @@ abstract contract SetupTemplate is TestSetupImports {
     string memory mediaURI
   ) public returns (uint256 id) {
     vm.prank(deployer);
-    return
-      __ItemRegistrySystem.createFood(
-        abi.encode(index, name, description, health, experience, mediaURI)
-      );
+    id = __ItemRegistrySystem.createConsumable(
+      abi.encode(index, "KAMI", name, description, "FOOD", mediaURI)
+    );
+    __ItemRegistrySystem.addStat(index, "XP", int32(int(experience)));
+    __ItemRegistrySystem.addStat(index, "HEALTH", health);
   }
 
   function _createRevive(
@@ -589,8 +590,10 @@ abstract contract SetupTemplate is TestSetupImports {
     string memory mediaURI
   ) public returns (uint256 id) {
     vm.prank(deployer);
-    return
-      __ItemRegistrySystem.createRevive(abi.encode(index, name, description, health, mediaURI));
+    id = __ItemRegistrySystem.createConsumable(
+      abi.encode(index, "KAMI", name, description, "REVIVE", mediaURI)
+    );
+    __ItemRegistrySystem.addStat(index, "HEALTH", health);
   }
 
   function _createLootbox(


### PR DESCRIPTION
Minor updates to item shapes.
- Removes `createFood` and `createRevive` functions in favour of `createConsumable`. No changes to underlying shapes (types are the same)
  - groundwork for this was laid a long time ago, apt time to pull the trigger with new item shapes coming in
- `base` type for component, intended for MUSU and materials. basically, an item that doesn't really do anything on its own
- explicitly defines `addStat`, intended as a similar `add` pattern from quests and skills. more flexibility
- stats defined for `violence`, `maxHealth`, `stamina` etc. in item shape, although no system implementation for consumption yet
- reimplements `for` for `consumables`
 