### PR TITLE
solecs world cleanups

### DIFF
--- a/packages/contracts/src/solecs/World.sol
+++ b/packages/contracts/src/solecs/World.sol
@@ -1,18 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
-import { LibQuery, QueryFragment } from "./LibQuery.sol";
 import { IWorld } from "./interfaces/IWorld.sol";
 import { IUint256Component } from "./interfaces/IUint256Component.sol";
 import { Uint256Component } from "./components/Uint256Component.sol";
-import { addressToEntity, entityToAddress, getIdByAddress, getAddressById, getComponentById } from "./utils.sol";
+import { addressToEntity, getIdByAddress } from "./utils.sol";
 import { componentsComponentId, systemsComponentId } from "./constants.sol";
 import { RegisterSystem, ID as registerSystemId, RegisterType } from "./systems/RegisterSystem.sol";
-import { EnumerableSet } from "openzeppelin/utils/structs/EnumerableSet.sol";
 
-/**
+/** @notice
  * The `World` contract is at the core of every on-chain world.
- * Entities, components and systems are registered in the `World`.
  * Components register updates to their state via the `registerComponentValueSet`
  * and `registerComponentValueRemoved` methods, which emit the `ComponentValueSet` and `ComponentValueRemoved` events respectively.
  *
@@ -20,14 +17,9 @@ import { EnumerableSet } from "openzeppelin/utils/structs/EnumerableSet.sol";
  * these two events, instead of having to add a separate getter or event listener
  * for every type of data. (Have a look at the MUD network package for a TypeScript
  * implementation of contract/client state sync.)
- *
- * The `World` is an ownerless and permissionless contract.
- * Anyone can register new components and systems in the world (via the `registerComponent` and `registerSystem` methods).
- * Clients decide which components and systems they care about.
  */
 contract World is IWorld {
-  using EnumerableSet for EnumerableSet.UintSet;
-  EnumerableSet.UintSet private entities;
+  uint256 private nonce;
 
   Uint256Component private _components;
   Uint256Component private _systems;
@@ -39,6 +31,7 @@ contract World is IWorld {
     uint256 indexed entity,
     bytes data
   );
+
   event ComponentValueRemoved(
     uint256 indexed componentId,
     address indexed component,
@@ -53,7 +46,7 @@ contract World is IWorld {
     _components.authorizeWriter(address(register));
   }
 
-  /**
+  /** @notice
    * Initialize the World.
    * Separated from the constructor to prevent circular dependencies.
    */
@@ -65,7 +58,7 @@ contract World is IWorld {
     );
   }
 
-  /**
+  /** @notice
    * Get the component registry Uint256Component
    * (mapping from component address to component id)
    */
@@ -73,7 +66,7 @@ contract World is IWorld {
     return _components;
   }
 
-  /**
+  /** @notice
    * Get the system registry Uint256Component
    * (mapping from system address to system id)
    */
@@ -81,7 +74,7 @@ contract World is IWorld {
     return _systems;
   }
 
-  /**
+  /** @notice
    * Register a new component in this World.
    * ID must be unique.
    */
@@ -89,7 +82,7 @@ contract World is IWorld {
     register.execute(abi.encode(msg.sender, RegisterType.Component, componentAddr, id));
   }
 
-  /**
+  /** @notice
    * Register a new system in this World.
    * ID must be unique.
    */
@@ -97,101 +90,28 @@ contract World is IWorld {
     register.execute(abi.encode(msg.sender, RegisterType.System, systemAddr, id));
   }
 
-  /**
-   * Reverts if the component is not registered in this World.
-   */
-  modifier requireComponentRegistered(address component) {
-    require(_components.has(addressToEntity(component)), "component not registered");
-    _;
-  }
-
-  /**
-   * Deprecated - use registerComponentValueSet(entity, data) instead
+  /** @notice
    * Register a component value update.
    * Emits the `ComponentValueSet` event for clients to reconstruct the state.
    */
-  function registerComponentValueSet(
-    address component,
-    uint256 entity,
-    bytes calldata data
-  ) public requireComponentRegistered(component) {
-    require(msg.sender == component);
-    entities.add(entity);
-    emit ComponentValueSet(getIdByAddress(_components, component), component, entity, data);
-  }
-
-  /**
-   * Register a component value update.
-   * Emits the `ComponentValueSet` event for clients to reconstruct the state.
-   */
-  function registerComponentValueSet(
-    uint256 entity,
-    bytes calldata data
-  ) public requireComponentRegistered(msg.sender) {
-    entities.add(entity);
+  function registerComponentValueSet(uint256 entity, bytes calldata data) public {
+    require(_components.has(addressToEntity(msg.sender)), "component not registered");
     emit ComponentValueSet(getIdByAddress(_components, msg.sender), msg.sender, entity, data);
   }
 
-  /**
-   * Deprecated - use registerComponentValueRemoved(entity) instead
+  /** @notice
    * Register a component value removal.
    * Emits the `ComponentValueRemoved` event for clients to reconstruct the state.
    */
-  function registerComponentValueRemoved(
-    address component,
-    uint256 entity
-  ) public requireComponentRegistered(component) {
-    require(msg.sender == component);
-    emit ComponentValueRemoved(getIdByAddress(_components, component), component, entity);
-  }
-
-  /**
-   * Register a component value removal.
-   * Emits the `ComponentValueRemoved` event for clients to reconstruct the state.
-   */
-  function registerComponentValueRemoved(
-    uint256 entity
-  ) public requireComponentRegistered(msg.sender) {
+  function registerComponentValueRemoved(uint256 entity) public {
+    require(_components.has(addressToEntity(msg.sender)), "component not registered");
     emit ComponentValueRemoved(getIdByAddress(_components, msg.sender), msg.sender, entity);
   }
 
-  /** Deprecated, but left here for backward compatibility. TODO: refactor all consumers. */
-  function getComponent(uint256 id) external view returns (address) {
-    return getAddressById(_components, id);
-  }
-
-  /** Deprecated, but left here for backward compatibility. TODO: refactor all consumers. */
-  function getComponentIdFromAddress(address componentAddr) external view returns (uint256) {
-    return getIdByAddress(_components, componentAddr);
-  }
-
-  /** Deprecated, but left here for backward compatibility. TODO: refactor all consumers. */
-  function getSystemAddress(uint256 systemId) external view returns (address) {
-    return getAddressById(_systems, systemId);
-  }
-
-  function getNumEntities() public view returns (uint256) {
-    return entities.length();
-  }
-
-  /**
-   * Check whether an entity exists in this world.
+  /** @notice
+   * Get a unique entity ID.
    */
-  function hasEntity(uint256 entity) public view returns (bool) {
-    return entities.contains(entity);
-  }
-
-  /**
-   * Get a new unique entity ID.
-   */
-  function getUniqueEntityId() public view returns (uint256) {
-    uint256 entityNum = getNumEntities();
-    uint256 id;
-    do {
-      entityNum++;
-      id = uint256(keccak256(abi.encodePacked(entityNum)));
-    } while (hasEntity(id));
-
-    return id;
+  function getUniqueEntityId() public returns (uint256) {
+    return uint256(keccak256(abi.encodePacked(++nonce)));
   }
 }

--- a/packages/contracts/src/solecs/interfaces/IWorld.sol
+++ b/packages/contracts/src/solecs/interfaces/IWorld.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
-import { QueryType } from "./Query.sol";
 import { IUint256Component } from "./IUint256Component.sol";
 
 interface IWorld {
@@ -11,29 +10,13 @@ interface IWorld {
 
   function registerComponent(address componentAddr, uint256 id) external;
 
-  function getComponent(uint256 id) external view returns (address);
-
-  function getComponentIdFromAddress(address componentAddr) external view returns (uint256);
-
   function registerSystem(address systemAddr, uint256 id) external;
-
-  function registerComponentValueSet(
-    address component,
-    uint256 entity,
-    bytes calldata data
-  ) external;
 
   function registerComponentValueSet(uint256 entity, bytes calldata data) external;
 
-  function registerComponentValueRemoved(address component, uint256 entity) external;
-
   function registerComponentValueRemoved(uint256 entity) external;
 
-  function getNumEntities() external view returns (uint256);
-
-  function hasEntity(uint256 entity) external view returns (bool);
-
-  function getUniqueEntityId() external view returns (uint256);
+  function getUniqueEntityId() external returns (uint256);
 
   function init() external;
 }


### PR DESCRIPTION
- better `getUniqueEntityId` handling
- cleans up `world.sol`, removes many depreciated stuff

no redeploy needed; perfectly backward compatible 