### PR TITLE
settings debug menu

### DIFF
--- a/packages/client/src/app/components/modals/settings/Debugging.tsx
+++ b/packages/client/src/app/components/modals/settings/Debugging.tsx
@@ -1,0 +1,89 @@
+import styled from 'styled-components';
+
+import { ActionButton } from 'app/components/library';
+import { useVisibility } from 'app/stores';
+
+export const Debugging = () => {
+  const { modals, setModals } = useVisibility();
+
+  const FieldRow = (label: string, buttonText: string, onClick: () => void) => {
+    return (
+      <Row>
+        <Text>{label}</Text>
+        <RowContent>
+          <ActionButton text={buttonText} onClick={onClick} size='small' />
+        </RowContent>
+      </Row>
+    );
+  };
+
+  return (
+    <Container>
+      <HeaderRow>
+        <Header>Testnet debugging</Header>
+      </HeaderRow>
+      <Section key='lootbox'>
+        {FieldRow('Lootbox Modal', 'Open', () => setModals({ ...modals, lootboxes: true }))}
+      </Section>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  flex-flow: column nowrap;
+  padding: 0.6vw;
+`;
+
+const Header = styled.div`
+  color: #333;
+  margin: 0.6vw 0vw;
+  font-family: Pixel;
+  font-size: 1vw;
+  text-align: left;
+`;
+
+const Section = styled.div`
+  display: flex;
+  flex-flow: column nowrap;
+  margin: 0.4vw;
+`;
+
+const HeaderRow = styled.div`
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const SubHeader = styled.div`
+  color: #333;
+  padding: 0vw 0.2vw;
+  font-family: Pixel;
+  font-size: 0.75vw;
+  text-align: left;
+`;
+
+const Row = styled.div`
+  padding: 0.75vw 0.6vw;
+
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const RowContent = styled.div`
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.5vw;
+`;
+
+const Text = styled.div`
+  color: #333;
+  font-family: Pixel;
+  font-size: 0.6vw;
+  text-align: left;
+`;

--- a/packages/client/src/app/components/modals/settings/Settings.tsx
+++ b/packages/client/src/app/components/modals/settings/Settings.tsx
@@ -6,6 +6,7 @@ import { registerUIComponent } from 'app/root';
 import { settingsIcon } from 'assets/images/icons/menu';
 
 import { Account } from './Account';
+import { Debugging } from './Debugging';
 import { Volume } from './Volume';
 
 export function registerSettingsModal() {
@@ -30,6 +31,8 @@ export function registerSettingsModal() {
           <Volume />
           <Divider />
           <Account />
+          <Divider />
+          <Debugging />
         </ModalWrapper>
       );
     }


### PR DESCRIPTION
debug menu for quick (lazy) UI fixes here and there. meant to be temporary.

This one addresses loobox reveals 
> (from the ui ) theres no way of getting the commit of a failed lootbox  if you dont have anymore lootboxes to open, as you can open the modal without having the item in the inventory, right?

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GNbqbI5UVVhcZ9CWPWNY/f9405e6b-76aa-4fa7-8c53-e89e36514616.png)

