### PR TITLE
temp 0-pruning fix: prune everything on FE

### DIFF
--- a/packages/client/src/network/setup/utils.ts
+++ b/packages/client/src/network/setup/utils.ts
@@ -16,13 +16,14 @@ import {
 import { Component as SolecsComponent } from '@mud-classic/solecs';
 import ComponentAbi from '@mud-classic/solecs/abi/Component.json';
 import { toEthAddress } from '@mud-classic/utils';
-import { BigNumber, Contract, Signer } from 'ethers';
+import { Contract, Signer } from 'ethers';
 import { compact, toLower } from 'lodash';
 import { IComputedValue } from 'mobx';
 import { filter, map, Observable, Subject, timer } from 'rxjs';
 
 import { createEncoder } from 'engine/encoders';
 import { Mappings } from 'engine/types';
+import { formatEntityID } from 'engine/utils';
 import { Ack, ack } from 'workers/sync';
 import {
   isNetworkComponentUpdateEvent,
@@ -81,9 +82,7 @@ export function createSystemCallStreams<
     decodeAndEmitSystemCall: (systemCall: SystemCall<C>) => {
       const { tx } = systemCall;
 
-      const systemEntityIndex = world.entityToIndex.get(
-        toLower(BigNumber.from(tx.to).toHexString()) as EntityID
-      );
+      const systemEntityIndex = world.entityToIndex.get(toLower(formatEntityID(tx.to)) as EntityID);
       if (!systemEntityIndex) return;
 
       const hashedSystemId = getComponentValue(systemsRegistry, systemEntityIndex)?.value;

--- a/packages/client/src/network/shapes/Bonus/types.ts
+++ b/packages/client/src/network/shapes/Bonus/types.ts
@@ -1,4 +1,5 @@
 import { EntityID, EntityIndex, World, getComponentValue } from '@mud-classic/recs';
+import { formatEntityID } from 'engine/utils';
 import { BigNumber, utils } from 'ethers';
 import { Components } from 'network/';
 
@@ -29,5 +30,5 @@ const getEntityIndex = (
     ['string', 'uint256', 'string'],
     ['bonus', holderID ?? 0, field]
   );
-  return world.entityToIndex.get(id as EntityID);
+  return world.entityToIndex.get(formatEntityID(id));
 };

--- a/packages/client/src/network/shapes/Config/types.ts
+++ b/packages/client/src/network/shapes/Config/types.ts
@@ -1,6 +1,7 @@
-import { EntityID, EntityIndex, World, getComponentValue } from '@mud-classic/recs';
-import { BigNumber, utils } from 'ethers';
+import { EntityIndex, World, getComponentValue } from '@mud-classic/recs';
+import { utils } from 'ethers';
 
+import { formatEntityID } from 'engine/utils';
 import { Components } from 'network/';
 import { unpackArray32 } from '../utils/data';
 
@@ -48,6 +49,5 @@ export const getConfigFieldValueWei = (
 
 const getEntityIndex = (world: World, field: string): EntityIndex | undefined => {
   const id = utils.solidityKeccak256(['string', 'string'], ['is.config', field]);
-  const formattedID = BigNumber.from(id).toHexString() as EntityID;
-  return world.entityToIndex.get(formattedID);
+  return world.entityToIndex.get(formatEntityID(id));
 };

--- a/packages/client/src/network/shapes/Faction.ts
+++ b/packages/client/src/network/shapes/Faction.ts
@@ -10,6 +10,7 @@ import {
 import { utils } from 'ethers';
 
 import PlaceholderIcon from 'assets/images/icons/placeholder.png';
+import { formatEntityID } from 'engine/utils';
 import { Components } from 'network/';
 import { DetailedEntity } from './utils';
 
@@ -114,7 +115,7 @@ export const getFaction = (world: World, components: Components, index: EntityIn
 
 const getEntityIndex = (world: any, index: number): EntityIndex | undefined => {
   const id = utils.solidityKeccak256(['string', 'uint32'], ['faction', index]);
-  return world.entityToIndex.get(id as EntityID);
+  return world.entityToIndex.get(formatEntityID(id));
 };
 
 const getRepEntityIndex = (
@@ -127,5 +128,5 @@ const getRepEntityIndex = (
     ['string', 'uint256', 'uint32'],
     ['faction.reputation', holderID, index]
   );
-  return world.entityToIndex.get(id as EntityID);
+  return world.entityToIndex.get(formatEntityID(id));
 };

--- a/packages/client/src/network/shapes/Flag.ts
+++ b/packages/client/src/network/shapes/Flag.ts
@@ -7,6 +7,7 @@ import {
   getComponentValue,
   runQuery,
 } from '@mud-classic/recs';
+import { formatEntityID } from 'engine/utils';
 import { utils } from 'ethers';
 
 import { Components } from 'network/';
@@ -51,7 +52,7 @@ export const getFlag = (components: Components, index: EntityIndex): Flag => {
   const { HolderID, Type } = components;
   return {
     has: _has(components, index),
-    holder: getComponentValue(HolderID, index)?.value as EntityID,
+    holder: formatEntityID(getComponentValue(HolderID, index)?.value ?? ''),
     type: getComponentValue(Type, index)?.value as string,
   };
 };
@@ -91,7 +92,7 @@ const getEntityIndex = (
     ['string', 'uint256', 'string'],
     ['has.flag', holderID, field]
   );
-  return world.entityToIndex.get(id as EntityID);
+  return world.entityToIndex.get(formatEntityID(id));
 };
 
 const _has = (components: Components, index: EntityIndex | undefined): boolean => {

--- a/packages/client/src/network/shapes/Friendship.ts
+++ b/packages/client/src/network/shapes/Friendship.ts
@@ -9,6 +9,7 @@ import {
   runQuery,
 } from '@mud-classic/recs';
 
+import { formatEntityID } from 'engine/utils';
 import { Components } from 'network/';
 import { Account, getAccountByID } from './Account';
 
@@ -31,14 +32,14 @@ export const getFriendship = (
   const account = getAccountByID(
     world,
     components,
-    getComponentValue(AccountID, entityIndex)?.value as EntityID,
+    formatEntityID(getComponentValue(AccountID, entityIndex)?.value ?? ''),
     accountOptions
   );
 
   const target = getAccountByID(
     world,
     components,
-    getComponentValue(TargetID, entityIndex)?.value as EntityID,
+    formatEntityID(getComponentValue(TargetID, entityIndex)?.value ?? ''),
     accountOptions
   );
 

--- a/packages/client/src/network/shapes/Gacha.ts
+++ b/packages/client/src/network/shapes/Gacha.ts
@@ -10,12 +10,13 @@ import {
 } from '@mud-classic/recs';
 import { utils } from 'ethers';
 
+import { formatEntityID } from 'engine/utils';
 import { Components } from 'network/';
 import { getConfigFieldValueWei } from './Config';
 import { Kami, KamiOptions, queryKamisX } from './Kami';
 import { Commit } from './utils';
 
-export const GACHA_ID = utils.solidityKeccak256(['string'], ['gacha.id']);
+export const GACHA_ID = formatEntityID(utils.solidityKeccak256(['string'], ['gacha.id']));
 
 export const getCommit = (world: World, components: Components, index: EntityIndex): Commit => {
   const { RevealBlock } = components;
@@ -49,7 +50,7 @@ export const queryGachaKamis = (
   components: Components,
   kamiOptions?: KamiOptions
 ): Kami[] => {
-  return queryKamisX(world, components, { account: GACHA_ID as EntityID }, kamiOptions);
+  return queryKamisX(world, components, { account: GACHA_ID }, kamiOptions);
 };
 
 export const calcRerollCost = (world: World, components: Components, kami: Kami): bigint => {

--- a/packages/client/src/network/shapes/Goal.ts
+++ b/packages/client/src/network/shapes/Goal.ts
@@ -9,6 +9,7 @@ import {
   runQuery,
 } from '@mud-classic/recs';
 
+import { formatEntityID } from 'engine/utils';
 import { utils } from 'ethers';
 import { Components } from 'network/';
 import { Account } from './Account';
@@ -227,7 +228,7 @@ export const getGoalID = (index: number) => {
 
 const getGoalEntityIndex = (world: World, goalIndex: number): EntityIndex | undefined => {
   const id = getGoalID(goalIndex);
-  return world.entityToIndex.get(id as EntityID);
+  return world.entityToIndex.get(formatEntityID(id));
 };
 
 const getContributionEntityIndex = (
@@ -239,20 +240,20 @@ const getContributionEntityIndex = (
     ['string', 'uint256', 'uint256'],
     ['goal.contribution', goalID, accountID]
   );
-  return world.entityToIndex.get(id as EntityID);
+  return world.entityToIndex.get(formatEntityID(id));
 };
 
 const getObjEntityIndex = (world: World, goalID: EntityID): EntityIndex | undefined => {
   const id = utils.solidityKeccak256(['string', 'uint256'], ['goal.objective', goalID]);
-  return world.entityToIndex.get(id as EntityID);
+  return world.entityToIndex.get(formatEntityID(id));
 };
 
 const getReqPtr = (goalIndex: number): EntityID => {
   const id = utils.solidityKeccak256(['string', 'uint32'], ['goal.requirement', goalIndex]);
-  return id as EntityID;
+  return formatEntityID(id);
 };
 
 const getRwdPtr = (goalIndex: number): EntityID => {
   const id = utils.solidityKeccak256(['string', 'uint32'], ['goal.reward', goalIndex]);
-  return id as EntityID;
+  return formatEntityID(id);
 };

--- a/packages/client/src/network/shapes/Harvest/types.ts
+++ b/packages/client/src/network/shapes/Harvest/types.ts
@@ -1,5 +1,6 @@
 import { EntityID, EntityIndex, World, getComponentValue } from '@mud-classic/recs';
 
+import { formatEntityID } from 'engine/utils';
 import { Components } from 'network/';
 import { getMusuBalance } from '../Item';
 import { Kami, getKami } from '../Kami';
@@ -51,7 +52,7 @@ export const getHarvest = (
 
   // populate Node
   if (options?.node) {
-    const nodeID = getComponentValue(NodeID, index)?.value as EntityID;
+    const nodeID = formatEntityID(getComponentValue(NodeID, index)?.value ?? '');
     const nodeIndex = world.entityToIndex.get(nodeID);
     if (nodeIndex) production.node = getNode(world, components, nodeIndex);
   }
@@ -62,7 +63,7 @@ export const getHarvest = (
   // retrieve the kami if it's not passed in
   // NOTE: rate calcs only work if the node is set
   if (!kami) {
-    const kamiID = getComponentValue(PetID, index)?.value as EntityID;
+    const kamiID = formatEntityID(getComponentValue(PetID, index)?.value ?? '');
     const kamiEntityIndex = world.entityToIndex.get(kamiID) ?? (0 as EntityIndex);
     kami = getKami(world, components, kamiEntityIndex, { account: true, traits: true });
   }

--- a/packages/client/src/network/shapes/Item/utils.ts
+++ b/packages/client/src/network/shapes/Item/utils.ts
@@ -2,6 +2,7 @@ import { EntityID, EntityIndex, getComponentValue, World } from '@mud-classic/re
 import { utils } from 'ethers';
 
 import { MUSU_INDEX } from 'constants/indices';
+import { formatEntityID } from 'engine/utils';
 import { Components } from 'network/components';
 import { Inventory } from './types';
 
@@ -27,7 +28,7 @@ export const getInventoryEntityIndex = (
     ['string', 'uint256', 'uint32'],
     ['inventory.instance', holderID ?? 0, itemIndex]
   );
-  return world.entityToIndex.get(id as EntityID);
+  return world.entityToIndex.get(formatEntityID(id));
 };
 
 export interface For {

--- a/packages/client/src/network/shapes/Kami/types.ts
+++ b/packages/client/src/network/shapes/Kami/types.ts
@@ -9,6 +9,7 @@ import {
   runQuery,
 } from '@mud-classic/recs';
 
+import { formatEntityID } from 'engine/utils';
 import { Components } from 'network/';
 import { Account, getAccount } from '../Account';
 import { KamiBonuses, getKamiBonuses } from '../Bonus';
@@ -146,7 +147,7 @@ export const getKami = (
 
   // populate Account
   if (options?.account) {
-    const accountID = getComponentValue(OwnsPetID, entityIndex)?.value as EntityID;
+    const accountID = formatEntityID(getComponentValue(OwnsPetID, entityIndex)?.value ?? '');
     const accountIndex = world.entityToIndex.get(accountID);
     if (accountIndex) kami.account = getAccount(world, components, accountIndex);
   }

--- a/packages/client/src/network/shapes/Kill.ts
+++ b/packages/client/src/network/shapes/Kill.ts
@@ -1,5 +1,6 @@
 import { EntityID, EntityIndex, World, getComponentValue } from '@mud-classic/recs';
 
+import { formatEntityID } from 'engine/utils';
 import { Components } from 'network/';
 import { Kami, getKami } from './Kami';
 import { Node, getNode } from './Node';
@@ -34,7 +35,7 @@ export const getKill = (
   const id = world.entities[entityIndex];
 
   // populate the Node
-  const nodeID = getComponentValue(NodeID, entityIndex)?.value as EntityID;
+  const nodeID = formatEntityID(getComponentValue(NodeID, entityIndex)?.value ?? '');
   const nodeEntityIndex = world.entityToIndex.get(nodeID) as EntityIndex;
   const node = getNode(world, components, nodeEntityIndex);
   const bounties = getDataArray(world, components, id, 'KILL_BOUNTIES');
@@ -53,14 +54,14 @@ export const getKill = (
 
   // populate the source kami
   if (options?.source) {
-    const sourceID = getComponentValue(SourceID, entityIndex)?.value as EntityID;
+    const sourceID = formatEntityID(getComponentValue(SourceID, entityIndex)?.value ?? '');
     const sourceEntityIndex = world.entityToIndex.get(sourceID) as EntityIndex;
     killLog.source = getKami(world, components, sourceEntityIndex);
   }
 
   // populate the target kami
   if (options?.target) {
-    const targetID = getComponentValue(TargetID, entityIndex)?.value as EntityID;
+    const targetID = formatEntityID(getComponentValue(TargetID, entityIndex)?.value ?? '');
     const targetEntityIndex = world.entityToIndex.get(targetID) as EntityIndex;
     killLog.target = getKami(world, components, targetEntityIndex);
   }

--- a/packages/client/src/network/shapes/Node/types.ts
+++ b/packages/client/src/network/shapes/Node/types.ts
@@ -8,6 +8,7 @@ import {
   runQuery,
 } from '@mud-classic/recs';
 
+import { formatEntityID } from 'engine/utils';
 import { Components } from 'network/';
 import { Kami, getKami } from '../Kami';
 
@@ -82,7 +83,9 @@ export const getNode = (
 
     // get list of kamis from list of productions
     for (let i = 0; i < productionEntityIndices.length; i++) {
-      const kamiID = getComponentValue(PetID, productionEntityIndices[i])?.value as EntityID;
+      const kamiID = formatEntityID(
+        getComponentValue(PetID, productionEntityIndices[i])?.value ?? ''
+      );
       const kamiEntityIndex = world.entityToIndex.get(kamiID);
       if (kamiEntityIndex) {
         kamis.push(

--- a/packages/client/src/network/shapes/Room/types.ts
+++ b/packages/client/src/network/shapes/Room/types.ts
@@ -14,6 +14,7 @@ import { Components } from 'network/';
 import { Account, getAccount } from '../Account';
 import { Condition, passesConditions } from '../utils';
 
+import { formatEntityID } from 'engine/utils';
 import { getGatesBetween } from './functions';
 import { queryRoomsEntitiesX } from './queries';
 
@@ -99,7 +100,7 @@ export const getRoom = (
 
   // if the room has an owner, include their name
   if (options?.owner && hasComponent(AccountID, index)) {
-    const accountID = getComponentValue(AccountID, index)?.value as EntityID;
+    const accountID = formatEntityID(getComponentValue(AccountID, index)?.value ?? '');
     const accountEntityIndex = world.entityToIndex.get(accountID) as EntityIndex;
     room.owner = getAccount(world, components, accountEntityIndex);
   }
@@ -140,11 +141,11 @@ const getLocation = (components: Components, index: EntityIndex): Coord => {
 // UTILS
 
 export const getGateToPtr = (index: number): EntityID => {
-  return utils.solidityKeccak256(['string', 'uint32'], ['room.gate.to', index]) as EntityID;
+  return formatEntityID(utils.solidityKeccak256(['string', 'uint32'], ['room.gate.to', index]));
 };
 
 export const getGateFromPtr = (index: number): EntityID => {
-  return utils.solidityKeccak256(['string', 'uint32'], ['room.gate.from', index]) as EntityID;
+  return formatEntityID(utils.solidityKeccak256(['string', 'uint32'], ['room.gate.from', index]));
 };
 
 const getAdjacentIndices = (components: Components, location: Coord): number[] => {

--- a/packages/client/src/network/shapes/Score.ts
+++ b/packages/client/src/network/shapes/Score.ts
@@ -9,6 +9,7 @@ import {
 } from '@mud-classic/recs';
 import { utils } from 'ethers';
 
+import { formatEntityID } from 'engine/utils';
 import { Components } from 'network/';
 import { Account, getAccount } from './Account';
 
@@ -48,7 +49,7 @@ export const getScore = (world: World, components: Components, index: EntityInde
   const { HolderID, Value } = components;
 
   // populate the holder
-  const accountID = getComponentValue(HolderID, index)?.value as EntityID;
+  const accountID = formatEntityID(getComponentValue(HolderID, index)?.value ?? '');
   const accountEntityIndex = world.entityToIndex.get(accountID) as EntityIndex;
   const account = getAccount(world, components, accountEntityIndex);
 
@@ -90,10 +91,10 @@ const getEntityIndex = (
     ['string', 'uint256', 'uint32', 'string'],
     [holderID, index, index, field]
   );
-  return world.entityToIndex.get(id as EntityID);
+  return world.entityToIndex.get(formatEntityID(id));
 };
 
 const getType = (type: string, epoch: number): EntityID => {
   const id = utils.solidityKeccak256(['string', 'string', 'uint256'], ['score.type', type, epoch]);
-  return id as EntityID;
+  return formatEntityID(id);
 };

--- a/packages/client/src/network/shapes/utils/conditional.ts
+++ b/packages/client/src/network/shapes/utils/conditional.ts
@@ -1,6 +1,7 @@
 import { EntityID, EntityIndex, World, getComponentValue, hasComponent } from '@mud-classic/recs';
 
 import { MUSU_INDEX } from 'constants/indices';
+import { formatEntityID } from 'engine/utils';
 import { Components } from 'network/';
 import { numberToHex } from 'utils/hex';
 import { Account } from '../Account';
@@ -185,7 +186,7 @@ export const getBool = (
   // universal gets - account and kami shape compatible
   if (type === 'COMPLETE_COMP') {
     // converted
-    const rawEntityID = numberToHex(value ?? 0) as EntityID;
+    const rawEntityID = formatEntityID(numberToHex(value ?? 0));
     const entityIndex = world.entityToIndex.get(rawEntityID);
     return entityIndex !== undefined && hasComponent(IsComplete, entityIndex);
   }

--- a/packages/client/src/network/shapes/utils/data.ts
+++ b/packages/client/src/network/shapes/utils/data.ts
@@ -1,4 +1,5 @@
 import { EntityID, EntityIndex, World, getComponentValue } from '@mud-classic/recs';
+import { formatEntityID } from 'engine/utils';
 import { BigNumber, utils } from 'ethers';
 
 import { Components } from 'network/';
@@ -68,5 +69,5 @@ const getEntityIndex = (
     ['string', 'uint256', 'uint32', 'string'],
     ['is.data', holderID ? holderID : ('0x00' as EntityID), index, field]
   );
-  return world.entityToIndex.get(id as EntityID);
+  return world.entityToIndex.get(formatEntityID(id));
 };


### PR DESCRIPTION
addresses the preceding 0-pruning behaviour in RECS. Does this by *forcing* every entityID on FE to be pruned. A horrible solution from a motherless developer.

Snapshot seems to store and deliver pruned IDs. Fixing that rn would be decently heavy lift, and this is a quite impactful bug because of DeterministicIDs - caused 3 accounts out of 888 could not detect their reputation. This is likely the cause of many persistent issues for a minority of players

Snapshot long overdue for another upgrade. Ideally, it shouldn't prune IDs. Until then, this maybe a stopgap