### PR TITLE
FE account shape optimisations

### DIFF
--- a/packages/client/src/app/components/library/AccountCard.tsx
+++ b/packages/client/src/app/components/library/AccountCard.tsx
@@ -2,13 +2,13 @@ import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { useSelected, useVisibility } from 'app/stores';
-import { Account } from 'network/shapes/Account';
+import { BareAccount } from 'network/shapes/Account';
 import { playClick } from 'utils/sounds';
 import { Card } from './Card';
 import { Tooltip } from './Tooltip';
 
 interface Props {
-  account: Account;
+  account: BareAccount;
   description: string[];
   descriptionOnClick?: () => void;
   subtext?: string;

--- a/packages/client/src/app/components/modals/account/Account.tsx
+++ b/packages/client/src/app/components/modals/account/Account.tsx
@@ -7,10 +7,11 @@ import { useSelected } from 'app/stores';
 import { operatorIcon } from 'assets/images/icons/menu';
 import {
   Account,
+  BareAccount,
   getAccountByIndex,
   getAccountFromBurner,
-  getAllAccounts,
 } from 'network/shapes/Account';
+import { getAllAccountsBare } from 'network/shapes/Account/queries';
 import { Friendship } from 'network/shapes/Friendship';
 import { Bottom } from './Bottom';
 import { Tabs } from './Tabs';
@@ -48,7 +49,6 @@ export function registerAccountModal() {
     },
     // Render
     ({ data, network }) => {
-      // console.log('AccountM: data', data);
       const { actions, api, components, world } = network;
       const { accountIndex } = useSelected();
       const [account, setAccount] = useState<Account | null>(
@@ -92,7 +92,7 @@ export function registerAccountModal() {
       };
 
       // block an account
-      const blockFren = (account: Account) => {
+      const blockFren = (account: BareAccount) => {
         actions.add({
           action: 'BlockFriend',
           params: [account.ownerEOA],
@@ -116,7 +116,7 @@ export function registerAccountModal() {
       };
 
       // send a friend request
-      const requestFren = (account: Account) => {
+      const requestFren = (account: BareAccount) => {
         actions.add({
           action: 'RequestFriend',
           params: [account.ownerEOA],
@@ -153,7 +153,7 @@ export function registerAccountModal() {
             tab={tab}
             data={{
               account,
-              accounts: getAllAccounts(world, components),
+              getAllAccs: () => getAllAccountsBare(world, components),
             }}
             actions={{ acceptFren, blockFren, cancelFren, requestFren }}
           />

--- a/packages/client/src/app/components/modals/account/Bottom.tsx
+++ b/packages/client/src/app/components/modals/account/Bottom.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
-import { Account } from 'network/shapes/Account';
+import { useVisibility } from 'app/stores';
+import { Account, BareAccount } from 'network/shapes/Account';
 import { Friendship } from 'network/shapes/Friendship';
 import { Blocked } from './blocked/Blocked';
 import { Friends } from './friends/Friends';
@@ -11,18 +12,25 @@ interface Props {
   tab: string;
   data: {
     account: Account;
-    accounts: Account[];
+    getAllAccs: () => BareAccount[];
   };
   actions: {
     acceptFren: (friendship: Friendship) => void;
-    blockFren: (account: Account) => void;
+    blockFren: (account: BareAccount) => void;
     cancelFren: (friendship: Friendship) => void;
-    requestFren: (account: Account) => void;
+    requestFren: (account: BareAccount) => void;
   };
 }
 
 export const Bottom = (props: Props) => {
   const { tab, data, actions } = props;
+  const { modals } = useVisibility();
+
+  // only update account list if modal is open
+  const allAccs = () => {
+    if (modals.account) return data.getAllAccs();
+    else return [];
+  };
 
   // NOTE: any child components that maintain their own state need to be inlined below, to
   // re-render and persist their state, rather than remounting
@@ -43,7 +51,7 @@ export const Bottom = (props: Props) => {
         <Requests
           key='requests'
           account={data.account}
-          accounts={data.accounts}
+          accounts={allAccs()}
           requests={{
             inbound: data.account.friends?.incomingReqs ?? [],
             outbound: data.account.friends?.outgoingReqs ?? [],

--- a/packages/client/src/app/components/modals/account/requests/Inbound.tsx
+++ b/packages/client/src/app/components/modals/account/requests/Inbound.tsx
@@ -1,14 +1,14 @@
 import styled from 'styled-components';
 
 import { AccountCard, ActionListButton } from 'app/components/library';
-import { Account } from 'network/shapes/Account';
+import { BareAccount } from 'network/shapes/Account';
 import { Friendship } from 'network/shapes/Friendship';
 
 interface Props {
   requests: Friendship[];
   actions: {
     acceptFren: (friendship: Friendship) => void;
-    blockFren: (account: Account) => void;
+    blockFren: (account: BareAccount) => void;
     cancelFren: (friendship: Friendship) => void;
   };
 }

--- a/packages/client/src/app/components/modals/account/requests/Requests.tsx
+++ b/packages/client/src/app/components/modals/account/requests/Requests.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { ActionButton, Tooltip } from 'app/components/library';
-import { Account } from 'network/shapes/Account';
+import { Account, BareAccount } from 'network/shapes/Account';
 import { Friendship } from 'network/shapes/Friendship';
 import { Inbound } from './Inbound';
 import { Outbound } from './Outbound';
@@ -10,16 +10,16 @@ import { Searched } from './Searched';
 
 interface Props {
   account: Account;
-  accounts: Account[];
+  accounts: BareAccount[];
   requests: {
     inbound: Friendship[];
     outbound: Friendship[];
   };
   actions: {
     acceptFren: (friendship: Friendship) => void;
-    blockFren: (account: Account) => void;
+    blockFren: (account: BareAccount) => void;
     cancelFren: (friendship: Friendship) => void;
-    requestFren: (account: Account) => void;
+    requestFren: (account: BareAccount) => void;
   };
 }
 
@@ -27,7 +27,7 @@ export const Requests = (props: Props) => {
   const { account, requests, actions } = props;
   const [mode, setMode] = useState('inbound');
   const [search, setSearch] = useState('');
-  const [searchResults, setSearchResults] = useState([] as Account[]);
+  const [searchResults, setSearchResults] = useState([] as BareAccount[]);
   const [knownAccIndices, setKnownAccIndices] = useState([] as number[]);
 
   // keep track of which accounts are already friends, requested or blocked
@@ -59,11 +59,12 @@ export const Requests = (props: Props) => {
   //////////////////
   // INTERPRETATION
 
+  // TODO:  implement a lazy query or something less compute heavy
   // filters the list of accounts by whether their name/ownerEOA contains a substring
   const filterAccounts = (value: string) => {
     const accounts = props.accounts.filter((account) => !knownAccIndices.includes(account.index));
 
-    if (value.length < 2) return accounts;
+    if (value.length < 2) accounts;
 
     return accounts.filter(
       (account) =>

--- a/packages/client/src/app/components/modals/account/requests/Searched.tsx
+++ b/packages/client/src/app/components/modals/account/requests/Searched.tsx
@@ -1,19 +1,19 @@
 import { AccountCard, ActionListButton } from 'app/components/library';
-import { Account } from 'network/shapes/Account';
+import { BareAccount } from 'network/shapes/Account';
 import styled from 'styled-components';
 
 interface Props {
-  accounts: Account[];
+  accounts: BareAccount[];
   actions: {
-    blockFren: (account: Account) => void;
-    requestFren: (account: Account) => void;
+    blockFren: (account: BareAccount) => void;
+    requestFren: (account: BareAccount) => void;
   };
 }
 
 export const Searched = (props: Props) => {
   const { accounts, actions } = props;
 
-  const Actions = (account: Account) => {
+  const Actions = (account: BareAccount) => {
     return (
       <ActionListButton
         id={`options-${account.entityIndex}`}

--- a/packages/client/src/network/shapes/Account/index.ts
+++ b/packages/client/src/network/shapes/Account/index.ts
@@ -10,6 +10,6 @@ export {
   getAccountFromBurner,
   getAllAccounts,
 } from './queries';
-export { getAccount } from './types';
+export { getAccount, getBareAccount } from './types';
 
-export type { Account, Friends as AccountFriends, AccountOptions } from './types';
+export type { Account, Friends as AccountFriends, AccountOptions, BareAccount } from './types';


### PR DESCRIPTION
increases performance quite a bit
- prevents undefined account querying when not logged in 
  - in particular, fixed very long privy logins and general lag upon entering
- introduced a `BareAccount` shape to reduce data ops 
  - replaced it in `friend request` modals (we were getting every account each frame!) 
- removed excessive querying in `friend request` modal. big performance boost here, though more work could be done to improve this particular modal