### PR TITLE
Reduce kami queries

### DIFF
--- a/packages/client/src/app/components/modals/gacha/Gacha.tsx
+++ b/packages/client/src/app/components/modals/gacha/Gacha.tsx
@@ -18,7 +18,7 @@ import { useAccount as useKamiAccount, useNetwork, useVisibility } from 'app/sto
 import { getAccountFromBurner } from 'network/shapes/Account';
 import { GACHA_ID, calcRerollCost } from 'network/shapes/Gacha';
 import { Kami } from 'network/shapes/Kami';
-import { filterRevealable } from 'network/shapes/utils';
+import { Commit, filterRevealable } from 'network/shapes/utils';
 import { playVend } from 'utils/sounds';
 import { erc20Abi, formatUnits } from 'viem';
 import { Commits } from './Commits';
@@ -37,7 +37,7 @@ export function registerGachaModal() {
       rowEnd: 90,
     },
     (layers) =>
-      interval(1000).pipe(
+      interval(3333).pipe(
         map(() => {
           const { network } = layers;
           const { world, components } = network;

--- a/packages/client/src/app/components/modals/gacha/Pool.tsx
+++ b/packages/client/src/app/components/modals/gacha/Pool.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { ActionButton, InputSingleNumberForm } from 'app/components/library';
 import { KamiGrid } from './components/KamiGrid';
 
+import { useVisibility } from 'app/stores';
 import { Kami } from 'network/shapes/Kami';
 import { GachaTicket } from 'network/shapes/utils/EntityTypes';
 import { SideBalance } from './components/SideBalance';
@@ -21,8 +22,16 @@ interface Props {
 }
 
 export const Pool = (props: Props) => {
+  const { modals } = useVisibility();
+
   const [mintAmt, setMintAmt] = useState<number>(0);
-  const [numShown, setNumShown] = useState<number>(49);
+  const [numShown, setNumShown] = useState<number>(0);
+
+  // prevent loading of kami when modal is closed
+  useEffect(() => {
+    if (modals.gacha) setNumShown(49);
+    else setNumShown(0);
+  }, [modals.gacha]);
 
   const {
     account: { balance: accBal },

--- a/packages/client/src/app/components/modals/kami/battles/KillLogs.tsx
+++ b/packages/client/src/app/components/modals/kami/battles/KillLogs.tsx
@@ -21,7 +21,7 @@ export const KillLogs = (props: Props) => {
   logs = logs.sort((a, b) => b.time - a.time);
 
   const getPnLString = (log: Kill): string => {
-    if (log.target?.index) {
+    if (log.target !== undefined) {
       return `+${log.bounty}`;
     } else {
       return `-${log.balance}`;
@@ -43,8 +43,8 @@ export const KillLogs = (props: Props) => {
   const Row = (log: Kill, index: number) => {
     const killStyle = { ...cellStyle, color: 'green' };
     const deathStyle = { ...cellStyle, color: 'red' };
-    const type = log.source?.index === undefined ? 'kill' : 'death';
-    const adversary = log.source?.index === undefined ? log.target : log.source;
+    const type = log.source === undefined ? 'kill' : 'death';
+    const adversary = log.source === undefined ? log.target : log.source;
     const date = new Date(log.time * 1000);
     const dateString = date.toLocaleString('default', {
       month: 'short',

--- a/packages/client/src/app/components/modals/party/Kards.tsx
+++ b/packages/client/src/app/components/modals/party/Kards.tsx
@@ -81,7 +81,7 @@ export const Kards = (props: Props) => {
     } else if (isDead(kami)) {
       description = [`Murdered`];
       if (kami.deaths && kami.deaths.length > 0) {
-        description.push(`by ${kami.deaths[0].source!.name}`);
+        description.push(`by ${kami.deaths[0].source}`);
         description.push(`on ${kami.deaths[0].node.name} `);
       }
     } else if (isHarvesting(kami) && kami.production) {

--- a/packages/client/src/network/shapes/Kami/index.ts
+++ b/packages/client/src/network/shapes/Kami/index.ts
@@ -17,7 +17,13 @@ export {
   isWithAccount,
   onCooldown,
 } from './functions';
-export { getAllKamis, getKamiByIndex, queryKamiEntitiesX, queryKamisX } from './queries';
+export {
+  getAllKamis,
+  getKamiByIndex,
+  getKamiName,
+  queryKamiEntitiesX,
+  queryKamisX,
+} from './queries';
 export type { QueryOptions } from './queries';
 export { getKami } from './types';
 export type { Kami, Options as KamiOptions } from './types';

--- a/packages/client/src/network/shapes/Kami/queries.ts
+++ b/packages/client/src/network/shapes/Kami/queries.ts
@@ -5,6 +5,7 @@ import {
   HasValue,
   QueryFragment,
   World,
+  getComponentValue,
   runQuery,
 } from '@mud-classic/recs';
 
@@ -15,6 +16,12 @@ import { Kami, Options, getKami } from './types';
 export type QueryOptions = {
   account?: EntityID;
   state?: string;
+};
+
+// gets a kami name (and only name)
+export const getKamiName = (components: Components, index: EntityIndex): string => {
+  const { Name } = components;
+  return (getComponentValue(Name, index)?.value as string) || '';
 };
 
 export const queryKamisX = (

--- a/packages/client/src/network/shapes/Kill.ts
+++ b/packages/client/src/network/shapes/Kill.ts
@@ -2,7 +2,7 @@ import { EntityID, EntityIndex, World, getComponentValue } from '@mud-classic/re
 
 import { formatEntityID } from 'engine/utils';
 import { Components } from 'network/';
-import { Kami, getKami } from './Kami';
+import { getKamiName } from './Kami';
 import { Node, getNode } from './Node';
 import { getDataArray } from './utils';
 
@@ -10,8 +10,8 @@ import { getDataArray } from './utils';
 export interface Kill {
   id: EntityID;
   entityIndex: EntityIndex;
-  source?: Kami;
-  target?: Kami;
+  source?: string; // source name
+  target?: string; // target name
   node: Node;
   balance: number;
   bounty: number;
@@ -56,14 +56,14 @@ export const getKill = (
   if (options?.source) {
     const sourceID = formatEntityID(getComponentValue(SourceID, entityIndex)?.value ?? '');
     const sourceEntityIndex = world.entityToIndex.get(sourceID) as EntityIndex;
-    killLog.source = getKami(world, components, sourceEntityIndex);
+    killLog.source = getKamiName(components, sourceEntityIndex);
   }
 
   // populate the target kami
   if (options?.target) {
     const targetID = formatEntityID(getComponentValue(TargetID, entityIndex)?.value ?? '');
     const targetEntityIndex = world.entityToIndex.get(targetID) as EntityIndex;
-    killLog.target = getKami(world, components, targetEntityIndex);
+    killLog.target = getKamiName(components, targetEntityIndex);
   }
 
   return killLog;


### PR DESCRIPTION
removes redundant kami queries. impact not as heavy as previous account fix, but decent nonetheless

Realised we've got easy ways to increase FE performance
- stop querying info for closed modals !! pretty big here
- slightly more target data retrieval - no need to fetch the entire shape each time
- general optimisations - we grossly overquery, really