### PR TITLE
fix health max caps

### DIFF
--- a/packages/client/src/network/shapes/Kami/functions.ts
+++ b/packages/client/src/network/shapes/Kami/functions.ts
@@ -157,7 +157,7 @@ const calcStrainBountyCap = (kami: Kami): number => {
   const ratio = strainConfig.ratio.value;
   const boost = strainConfig.boost.value + kami.bonuses.harvest.strain.boost;
   const harmony = kami.stats.harmony.total;
-  return Math.floor((healthBudget * harmony) / ratio / boost);
+  return Math.floor((healthBudget * (harmony + 10)) / ratio / boost);
 };
 
 ////////////////////

--- a/packages/contracts/src/libraries/LibPet.sol
+++ b/packages/contracts/src/libraries/LibPet.sol
@@ -225,7 +225,7 @@ library LibPet {
     uint256 boost = uint(config[6].toInt256() + bonusBoost);
     uint256 harmony = calcTotalHarmony(components, id).toUint256(); // prec 0
     uint256 precision = 10 ** uint(config[3] + config[7]);
-    return (healthBudget * precision * harmony) / (core * boost);
+    return (healthBudget * precision * (harmony + 10)) / (core * boost);
   }
 
   /////////////////


### PR DESCRIPTION
this is where we start talking about how jirach was right and kamis get killed
before hitting 0 hp and all these max caps have done is make it harder to
keep the harvesting calcs up to date..