### PR TITLE
remove account optimization block

### DIFF
--- a/packages/client/src/app/components/modals/account/Bottom.tsx
+++ b/packages/client/src/app/components/modals/account/Bottom.tsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
 
-import { useVisibility } from 'app/stores';
 import { Account, BareAccount } from 'network/shapes/Account';
 import { Friendship } from 'network/shapes/Friendship';
 import { Blocked } from './blocked/Blocked';
@@ -24,13 +23,6 @@ interface Props {
 
 export const Bottom = (props: Props) => {
   const { tab, data, actions } = props;
-  const { modals } = useVisibility();
-
-  // only update account list if modal is open
-  const allAccs = () => {
-    if (modals.account) return data.getAllAccs();
-    else return [];
-  };
 
   // NOTE: any child components that maintain their own state need to be inlined below, to
   // re-render and persist their state, rather than remounting
@@ -51,7 +43,7 @@ export const Bottom = (props: Props) => {
         <Requests
           key='requests'
           account={data.account}
-          accounts={allAccs()}
+          accounts={data.getAllAccs()}
           requests={{
             inbound: data.account.friends?.incomingReqs ?? [],
             outbound: data.account.friends?.outgoingReqs ?? [],


### PR DESCRIPTION
another smol lesson. because the `Requests` react component is rendered
conditionally, any data we pull will only trigger when it's visible. basically, the DOM 
tree preemptively parses out any logic to process based on what needs to be rendered

the only time we actually have this issue is when we process data Prior to the root
rendering of a modal (i.e. directly on the main modal components)