### PR TITLE
prevent quest modal erroneous auto tabbing

### DIFF
--- a/packages/client/src/app/components/modals/quests/Quests.tsx
+++ b/packages/client/src/app/components/modals/quests/Quests.tsx
@@ -113,12 +113,8 @@ export function registerQuestsModal() {
         isUpdating.current = true;
 
         const raw = filterByAvailable(registry, ongoing, completed);
-
         const populated = raw.map((q) => populate(q));
         const newAvailable = filterOutBattlePass(populated);
-        console.log('available', available);
-        console.log('raw', raw);
-        console.log('newAvailable', newAvailable);
 
         setAvailable(newAvailable);
         if (newAvailable.length > available.length) setTab('AVAILABLE');


### PR DESCRIPTION
miscounting new available on the tab-back check to `Available`