### PR TITLE
fix node modal kami owner cache

### DIFF
--- a/packages/client/src/app/components/modals/node/Node.tsx
+++ b/packages/client/src/app/components/modals/node/Node.tsx
@@ -196,19 +196,18 @@ export function registerNodeModal() {
           truncate
           noPadding
         >
-          {node.kamis.length > 0 ? (
-            <Kards
-              account={account}
-              kamis={node.kamis}
-              actions={{ collect, feed, liquidate, stop }}
-              utils={utils}
-            />
-          ) : (
+          {node.kamis.length === 0 && (
             <EmptyText
               text={['There are no Kamis on this node.', "Maybe that's an opportunity.."]}
               size={1}
             />
           )}
+          <Kards
+            account={account}
+            kamis={node.kamis}
+            actions={{ collect, feed, liquidate, stop }}
+            utils={utils}
+          />
         </ModalWrapper>
       );
     }

--- a/packages/client/src/app/components/modals/node/kards/Kards.tsx
+++ b/packages/client/src/app/components/modals/node/kards/Kards.tsx
@@ -43,11 +43,12 @@ export const Kards = (props: Props) => {
   /////////////////
   // INTERPRETATION
 
-  // get and cache owner lookups
+  // get and cache owner lookups. if owner is null, update the cache
   const getOwner = (kami: Kami) => {
-    if (!ownerCache.has(kami.index)) {
-      const owner = utils.getOwner(kami.index);
-      ownerCache.set(kami.index, owner);
+    const owner = ownerCache.get(kami.index);
+    if (!owner || !owner.index) {
+      const updatedOwner = utils.getOwner(kami.index);
+      ownerCache.set(kami.index, updatedOwner);
     }
     return ownerCache.get(kami.index)!;
   };


### PR DESCRIPTION
issue: caching null owners on incomplete state causes persistence of faulty data 
fix: update cache whenever the retrieved owner is detected as a `NullAccount`