### PR TITLE
LibConditional Subtypes & TargetTypes

### DIFF
--- a/packages/contracts/deploy.json
+++ b/packages/contracts/deploy.json
@@ -163,7 +163,8 @@
         "NameComponent",
         "TypeComponent",
         "ValueComponent",
-        "WeightsComponent"
+        "WeightsComponent",
+        "SubtypeComponent"
       ]
     },
     {
@@ -204,7 +205,8 @@
         "IndexNPCComponent",
         "LogicTypeComponent",
         "TypeComponent",
-        "ValueComponent"
+        "ValueComponent",
+        "SubtypeComponent"
       ]
     },
     {
@@ -224,7 +226,8 @@
         "NameComponent",
         "TypeComponent",
         "ValueComponent",
-        "WeightsComponent"
+        "WeightsComponent",
+        "SubtypeComponent"
       ]
     },
     {
@@ -249,6 +252,7 @@
         "LogicTypeComponent",
         "KeysComponent",
         "StaminaComponent",
+        "SubtypeComponent",
         "ValuesComponent",
         "ValueComponent",
         "TypeComponent"
@@ -280,6 +284,7 @@
         "LogicTypeComponent",
         "NameComponent",
         "TypeComponent",
+        "SubtypeComponent",
         "ValueComponent"
       ]
     },

--- a/packages/contracts/src/libraries/LibAssigner.sol
+++ b/packages/contracts/src/libraries/LibAssigner.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.0;
 
 import { IUint256Component as IUintComp } from "solecs/interfaces/IUint256Component.sol";
 import { IWorld } from "solecs/interfaces/IWorld.sol";
-import { LibQuery, QueryFragment, QueryType } from "solecs/LibQuery.sol";
 import { getAddressById, getComponentById } from "solecs/utils.sol";
 
 import { Uint32BareComponent } from "components/base/Uint32BareComponent.sol"; // for index comps

--- a/packages/contracts/src/libraries/LibBonus.sol
+++ b/packages/contracts/src/libraries/LibBonus.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.0;
 
 import { IUint256Component as IUintComp } from "solecs/interfaces/IUint256Component.sol";
 import { IWorld } from "solecs/interfaces/IWorld.sol";
-import { LibQuery, QueryFragment, QueryType } from "solecs/LibQuery.sol";
 import { getAddressById, getComponentById } from "solecs/utils.sol";
 
 import { ValueSignedComponent as SignedValComp, ID as SignedValCompID } from "components/ValueSignedComponent.sol";

--- a/packages/contracts/src/libraries/LibConfig.sol
+++ b/packages/contracts/src/libraries/LibConfig.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.0;
 
 import { IUint256Component as IUintComp } from "solecs/interfaces/IUint256Component.sol";
 import { IWorld } from "solecs/interfaces/IWorld.sol";
-import { LibQuery, QueryFragment, QueryType } from "solecs/LibQuery.sol";
 import { getAddressById, getComponentById } from "solecs/utils.sol";
 
 import { LibString } from "solady/utils/LibString.sol";

--- a/packages/contracts/src/libraries/LibFriend.sol
+++ b/packages/contracts/src/libraries/LibFriend.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.0;
 import { IComponent } from "solecs/interfaces/IComponent.sol";
 import { IUint256Component as IUintComp } from "solecs/interfaces/IUint256Component.sol";
 import { IWorld } from "solecs/interfaces/IWorld.sol";
-import { LibQuery, QueryFragment, QueryType } from "solecs/LibQuery.sol";
 import { getAddressById, getComponentById } from "solecs/utils.sol";
 import { LibString } from "solady/utils/LibString.sol";
 

--- a/packages/contracts/src/libraries/LibHarvest.sol
+++ b/packages/contracts/src/libraries/LibHarvest.sol
@@ -5,7 +5,6 @@ import { LibString } from "solady/utils/LibString.sol";
 import { SafeCastLib } from "solady/utils/SafeCastLib.sol";
 import { IUint256Component as IUintComp } from "solecs/interfaces/IUint256Component.sol";
 import { IWorld } from "solecs/interfaces/IWorld.sol";
-import { LibQuery, QueryFragment, QueryType } from "solecs/LibQuery.sol";
 import { getAddressById, getComponentById } from "solecs/utils.sol";
 
 import { IdNodeComponent, ID as IdNodeCompID } from "components/IdNodeComponent.sol";

--- a/packages/contracts/src/libraries/LibItem.sol
+++ b/packages/contracts/src/libraries/LibItem.sol
@@ -5,7 +5,6 @@ import { LibString } from "solady/utils/LibString.sol";
 import { SafeCastLib } from "solady/utils/SafeCastLib.sol";
 import { IUint256Component as IUintComp } from "solecs/interfaces/IUint256Component.sol";
 import { IWorld } from "solecs/interfaces/IWorld.sol";
-import { LibQuery, QueryFragment, QueryType } from "solecs/LibQuery.sol";
 import { IComponent } from "solecs/interfaces/IComponent.sol";
 import { getAddressById, getComponentById } from "solecs/utils.sol";
 import { Stat } from "components/types/Stat.sol";

--- a/packages/contracts/src/libraries/LibListing.sol
+++ b/packages/contracts/src/libraries/LibListing.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.0;
 
 import { IUint256Component as IUintComp } from "solecs/interfaces/IUint256Component.sol";
 import { IWorld } from "solecs/interfaces/IWorld.sol";
-import { LibQuery, QueryFragment, QueryType } from "solecs/LibQuery.sol";
 import { getAddressById, getComponentById } from "solecs/utils.sol";
 
 import { IndexItemComponent, ID as IndexItemCompID } from "components/IndexItemComponent.sol";

--- a/packages/contracts/src/libraries/LibNode.sol
+++ b/packages/contracts/src/libraries/LibNode.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.0;
 import { LibString } from "solady/utils/LibString.sol";
 import { IUint256Component as IUintComp } from "solecs/interfaces/IUint256Component.sol";
 import { IWorld } from "solecs/interfaces/IWorld.sol";
-import { LibQuery, QueryFragment, QueryType } from "solecs/LibQuery.sol";
 import { getAddressById, getComponentById } from "solecs/utils.sol";
 
 import { IsNodeComponent, ID as IsNodeCompID } from "components/IsNodeComponent.sol";

--- a/packages/contracts/src/libraries/LibReward.sol
+++ b/packages/contracts/src/libraries/LibReward.sol
@@ -5,7 +5,6 @@ import { LibString } from "solady/utils/LibString.sol";
 import { IUint256Component as IUintComp } from "solecs/interfaces/IUint256Component.sol";
 import { IWorld } from "solecs/interfaces/IWorld.sol";
 import { getAddressById, getComponentById } from "solecs/utils.sol";
-import { LibQuery } from "solecs/LibQuery.sol";
 
 import { IDPointerComponent, ID as IDPointerCompID } from "components/IDPointerComponent.sol";
 import { IndexComponent, ID as IndexCompID } from "components/IndexComponent.sol";

--- a/packages/contracts/src/libraries/LibSkill.sol
+++ b/packages/contracts/src/libraries/LibSkill.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.0;
 import { IWorld } from "solecs/interfaces/IWorld.sol";
 import { IUint256Component as IUintComp } from "solecs/interfaces/IUint256Component.sol";
 import { getAddressById, getComponentById, addressToEntity } from "solecs/utils.sol";
-import { LibQuery, QueryFragment, QueryType } from "solecs/LibQuery.sol";
 import { LibString } from "solady/utils/LibString.sol";
 
 import { CostComponent, ID as CostCompID } from "components/CostComponent.sol";

--- a/packages/contracts/src/libraries/utils/LibAffinity.sol
+++ b/packages/contracts/src/libraries/utils/LibAffinity.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.0;
 import { LibString } from "solady/utils/LibString.sol";
 import { IUint256Component as IUintComp } from "solecs/interfaces/IUint256Component.sol";
 import { IWorld } from "solecs/interfaces/IWorld.sol";
-import { LibQuery, QueryFragment, QueryType } from "solecs/LibQuery.sol";
 import { getAddressById, getComponentById } from "solecs/utils.sol";
 
 import { LibBonus } from "libraries/LibBonus.sol";


### PR DESCRIPTION
adds subtypes to conditionals for additional context

adds targetTypes via `For` to differentiate conditions meant for kamis/accounts/others. Upgrades `LibNode` to match the new pattern.
