### PR TITLE
LibFlag refactor

### DIFF
--- a/packages/contracts/deploy.json
+++ b/packages/contracts/deploy.json
@@ -117,7 +117,7 @@
     { "name": "_AdminGiveSystem", "writeAccess": ["*"] },
     {
       "name": "_AuthManageRoleSystem",
-      "writeAccess": ["HasFlagComponent", "IdHolderComponent", "TypeComponent"]
+      "writeAccess": ["HasFlagComponent", "IDPointerComponent", "TypeComponent", "SubtypeComponent"]
     },
     {
       "name": "_ConfigSetSystem",
@@ -163,7 +163,7 @@
         "ForComponent",
         "HasFlagComponent",
         "IDFromComponent",
-        "IdHolderComponent",
+        "IDPointerComponent",
         "IDToComponent",
         "IsRegistryComponent",
         "IndexItemComponent",
@@ -178,6 +178,7 @@
         "TypeComponent",
         "SlotsComponent",
         "StaminaComponent",
+        "SubtypeComponent",
         "ViolenceComponent"
       ]
     },


### PR DESCRIPTION
Light flags refactor. Backwards compatible

- HolderId -> PointerID for contract based reverse queries
- Introduce subtype pattern for additional context
