### PR TITLE
Bonus Registry

### DIFF
--- a/packages/contracts/deploy.json
+++ b/packages/contracts/deploy.json
@@ -733,6 +733,7 @@
     "LibAccount",
     "LibAssigner",
     "LibBonus",
+    "LibBonusOld",
     "LibConditional",
     "LibCommit",
     "LibConfig",

--- a/packages/contracts/src/libraries/LibBonusOld.sol
+++ b/packages/contracts/src/libraries/LibBonusOld.sol
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { IUint256Component as IUintComp } from "solecs/interfaces/IUint256Component.sol";
+import { IWorld } from "solecs/interfaces/IWorld.sol";
+import { getAddrByID, getCompByID } from "solecs/utils.sol";
+
+import { ValueSignedComponent as SignedValComp, ID as SignedValCompID } from "components/ValueSignedComponent.sol";
+import { IsBonusComponent, ID as IsBonusCompID } from "components/IsBonusComponent.sol";
+import { IdHolderComponent, ID as IdHolderCompID } from "components/IdHolderComponent.sol";
+import { TypeComponent, ID as TypeCompID } from "components/TypeComponent.sol";
+
+import { LibStat } from "libraries/LibStat.sol";
+
+/**
+ * @notice Library for managing bonuses - modifiers that affect specific calcs
+ */
+library LibBonusOld {
+  /////////////////
+  // INTERACTIONS
+
+  function inc(IUintComp components, uint256 holderID, string memory type_, int256 amt) internal {
+    uint256 id = genID(holderID, type_);
+    SignedValComp comp = SignedValComp(getAddrByID(components, SignedValCompID));
+    int256 curr = comp.has(id) ? comp.get(id) : int256(0);
+    comp.set(id, curr + amt);
+  }
+
+  function dec(IUintComp components, uint256 holderID, string memory type_, int256 amt) internal {
+    uint256 id = genID(holderID, type_);
+    SignedValComp comp = SignedValComp(getAddrByID(components, SignedValCompID));
+    int256 curr = comp.has(id) ? comp.get(id) : int256(0);
+    comp.set(id, curr - amt);
+  }
+
+  /////////////////
+  // GETTERS
+
+  /// @notice gets a bonus in percent form. default is 1000 (100.0%)
+  function getPercent(
+    IUintComp components,
+    uint256 holderID,
+    string memory type_
+  ) internal view returns (uint256) {
+    int256 bonus = getRaw(components, holderID, type_);
+    if (bonus == 0) return 1000;
+    // max change is 0.1%
+    else if (bonus <= -1000) return 1;
+    else return uint256(1000 + bonus); // overflow alr checked
+  }
+
+  /// @notice adjust base value based on bonus
+  function processBonus(
+    IUintComp components,
+    uint256 holderID,
+    string memory type_,
+    uint256 base
+  ) internal view returns (uint256) {
+    int256 bonus = getRaw(components, holderID, type_);
+    return calcSigned(base, bonus);
+  }
+
+  function getRaw(
+    IUintComp components,
+    uint256 holderID,
+    string memory type_
+  ) internal view returns (int256) {
+    uint256 id = genID(holderID, type_);
+    SignedValComp comp = SignedValComp(getAddrByID(components, SignedValCompID));
+    return comp.has(id) ? comp.get(id) : int256(0);
+  }
+
+  //////////////
+  // UTILS
+
+  function genID(uint256 holderID, string memory type_) internal pure returns (uint256) {
+    return uint256(keccak256(abi.encodePacked("bonus", holderID, type_)));
+  }
+
+  /// @notice handles a custom signed/unsigned calculation
+  /// @dev recieves the signed bonus value, calculates, and spits out unsigned for other systems
+  function calcSigned(uint256 base, int256 bonus) internal pure returns (uint256) {
+    // avoid converting base in case of overflow
+    if (bonus == 0) return base;
+    if (bonus > 0) return base + uint256(bonus);
+
+    uint256 delta = uint256(-bonus);
+    return (delta >= base) ? 0 : base - delta;
+  }
+}

--- a/packages/contracts/src/libraries/LibHarvest.sol
+++ b/packages/contracts/src/libraries/LibHarvest.sol
@@ -20,7 +20,7 @@ import { TimeResetComponent, ID as TimeResetCompID } from "components/TimeResetC
 import { TimeStartComponent, ID as TimeStartCompID } from "components/TimeStartComponent.sol";
 
 import { LibAffinity } from "libraries/utils/LibAffinity.sol";
-import { LibBonus } from "libraries/LibBonus.sol";
+import { LibBonusOld } from "libraries/LibBonusOld.sol";
 import { LibConfig } from "libraries/LibConfig.sol";
 import { LibData } from "libraries/LibData.sol";
 import { LibInventory, MUSU_INDEX } from "libraries/LibInventory.sol";
@@ -122,7 +122,7 @@ library LibHarvest {
     if (!isActive(components, id)) return 0;
     uint256 petID = getPet(components, id);
     uint32[8] memory config = LibConfig.getArray(components, "KAMI_HARV_BOUNTY");
-    int256 boostBonus = LibBonus.getRaw(components, petID, "HARV_BOUNTY_BOOST");
+    int256 boostBonus = LibBonusOld.getRaw(components, petID, "HARV_BOUNTY_BOOST");
 
     uint256 base = calcFertility(components, id);
     uint256 nudge = calcIntensity(components, id);
@@ -156,7 +156,7 @@ library LibHarvest {
     // pull the bonus efficacy shifts from the pet
     LibAffinity.Shifts memory bonusEfficacyShifts = LibAffinity.Shifts({
       base: int(0),
-      up: LibBonus.getRaw(components, petID, "HARV_FERTILITY_BOOST"),
+      up: LibBonusOld.getRaw(components, petID, "HARV_FERTILITY_BOOST"),
       down: int(0)
     });
 
@@ -197,7 +197,7 @@ library LibHarvest {
     uint256 nudge = calcIntensityDuration(components, id) / 60; // minutes, rounded down
     uint256 ratio = config[2]; // period, in minutes. scaled to accomodate current skill balancing
     uint256 boost = config[6];
-    boost += LibBonus.getRaw(components, petID, "HARV_INTENSITY_NUDGE").toUint256();
+    boost += LibBonusOld.getRaw(components, petID, "HARV_INTENSITY_NUDGE").toUint256();
     uint256 precision = 10 ** (RATE_PREC - config[7] + config[3]); // ratio is inverted
     return (precision * (base + nudge) * boost) / (ratio * 3600);
   }

--- a/packages/contracts/src/libraries/LibKill.sol
+++ b/packages/contracts/src/libraries/LibKill.sol
@@ -18,7 +18,7 @@ import { TimeComponent, ID as TimeCompID } from "components/TimeComponent.sol";
 
 import { LibAccount } from "libraries/LibAccount.sol";
 import { LibAffinity } from "libraries/utils/LibAffinity.sol";
-import { LibBonus } from "libraries/LibBonus.sol";
+import { LibBonusOld } from "libraries/LibBonusOld.sol";
 import { LibConfig } from "libraries/LibConfig.sol";
 import { LibData } from "libraries/LibData.sol";
 import { LibInventory, MUSU_INDEX } from "libraries/LibInventory.sol";
@@ -120,8 +120,8 @@ library LibKill {
     });
 
     // pull the bonus efficacy shifts from the pets
-    int256 atkBonus = LibBonus.getRaw(components, sourceID, "ATK_THRESHOLD_RATIO");
-    int256 defBonus = LibBonus.getRaw(components, targetID, "DEF_THRESHOLD_RATIO");
+    int256 atkBonus = LibBonusOld.getRaw(components, sourceID, "ATK_THRESHOLD_RATIO");
+    int256 defBonus = LibBonusOld.getRaw(components, targetID, "DEF_THRESHOLD_RATIO");
     LibAffinity.Shifts memory bonusEfficacyShifts = LibAffinity.Shifts({
       base: int(0),
       up: atkBonus + defBonus,
@@ -154,8 +154,8 @@ library LibKill {
 
     // apply attack and defense shifts
     uint256 shiftPrec = 10 ** (ANIMOSITY_PREC + config[3] - config[5]);
-    int256 shiftAttBonus = LibBonus.getRaw(components, sourceID, "ATK_THRESHOLD_SHIFT");
-    int256 shiftDefBonus = LibBonus.getRaw(components, targetID, "DEF_THRESHOLD_SHIFT");
+    int256 shiftAttBonus = LibBonusOld.getRaw(components, sourceID, "ATK_THRESHOLD_SHIFT");
+    int256 shiftDefBonus = LibBonusOld.getRaw(components, targetID, "DEF_THRESHOLD_SHIFT");
     int256 shift = (shiftAttBonus + shiftDefBonus) * int(shiftPrec);
 
     int256 postShiftVal = int(base * ratio) + shift;
@@ -188,7 +188,7 @@ library LibKill {
     uint256 amt
   ) internal view returns (uint256) {
     uint32[8] memory config = LibConfig.getArray(components, "KAMI_LIQ_SALVAGE");
-    int256 ratioBonus = LibBonus.getRaw(components, id, "DEF_SALVAGE_RATIO");
+    int256 ratioBonus = LibBonusOld.getRaw(components, id, "DEF_SALVAGE_RATIO");
     uint256 power = LibPet.calcTotalPower(components, id).toUint256();
     uint256 powerTuning = (config[0] + power) * 10 ** (config[3] - config[1]); // scale to Ratio precision
     uint256 ratio = config[2] + powerTuning + ratioBonus.toUint256();
@@ -204,7 +204,7 @@ library LibKill {
     uint256 amt
   ) internal view returns (uint256) {
     uint32[8] memory config = LibConfig.getArray(components, "KAMI_LIQ_SPOILS");
-    int256 ratioBonus = LibBonus.getRaw(components, id, "ATK_SPOILS_RATIO");
+    int256 ratioBonus = LibBonusOld.getRaw(components, id, "ATK_SPOILS_RATIO");
     uint256 power = LibPet.calcTotalPower(components, id).toUint256();
     uint256 powerTuning = (config[0] + power) * 10 ** (config[3] - config[1]); // scale to Ratio precision
     uint256 ratio = config[2] + powerTuning + ratioBonus.toUint256();

--- a/packages/contracts/src/libraries/LibPet.sol
+++ b/packages/contracts/src/libraries/LibPet.sol
@@ -26,7 +26,7 @@ import { TimeStartComponent, ID as TimeStartCompID } from "components/TimeStartC
 
 import { LibAccount } from "libraries/LibAccount.sol";
 import { LibAffinity } from "libraries/utils/LibAffinity.sol";
-import { LibBonus } from "libraries/LibBonus.sol";
+import { LibBonusOld } from "libraries/LibBonusOld.sol";
 import { LibComp } from "libraries/utils/LibComp.sol";
 import { LibCooldown } from "libraries/utils/LibCooldown.sol";
 import { LibConfig } from "libraries/LibConfig.sol";
@@ -152,7 +152,7 @@ library LibPet {
   // Calculate resting recovery rate (HP/s) of a Kami. (1e9 precision)
   function calcMetabolism(IUintComp components, uint256 id) internal view returns (uint256) {
     uint32[8] memory config = LibConfig.getArray(components, "KAMI_REST_METABOLISM");
-    uint256 boostBonus = LibBonus.getRaw(components, id, "REST_METABOLISM_BOOST").toUint256();
+    uint256 boostBonus = LibBonusOld.getRaw(components, id, "REST_METABOLISM_BOOST").toUint256();
     uint256 base = calcTotalHarmony(components, id).toUint256();
     uint256 ratio = config[2]; // metabolism core
     uint256 boost = config[6] + boostBonus;
@@ -175,7 +175,7 @@ library LibPet {
     uint256 amt
   ) internal view returns (uint256) {
     uint32[8] memory config = LibConfig.getArray(components, "KAMI_HARV_STRAIN");
-    int256 bonusBoost = LibBonus.getRaw(components, id, "STND_STRAIN_BOOST");
+    int256 bonusBoost = LibBonusOld.getRaw(components, id, "STND_STRAIN_BOOST");
     uint256 core = config[2];
     uint256 boost = uint(config[6].toInt256() + bonusBoost);
 

--- a/packages/contracts/src/libraries/LibSkill.sol
+++ b/packages/contracts/src/libraries/LibSkill.sol
@@ -18,7 +18,7 @@ import { TypeComponent, ID as TypeCompID } from "components/TypeComponent.sol";
 import { LibAccount } from "libraries/LibAccount.sol";
 import { LibConditional } from "libraries/LibConditional.sol";
 import { LibConfig } from "libraries/LibConfig.sol";
-import { LibBonus } from "libraries/LibBonus.sol";
+import { LibBonusOld } from "libraries/LibBonusOld.sol";
 import { LibData } from "libraries/LibData.sol";
 import { LibFor } from "libraries/utils/LibFor.sol";
 import { LibPet } from "libraries/LibPet.sol";
@@ -83,7 +83,7 @@ library LibSkill {
     else bonusType = LibString.concat(LibString.concat(type_, "_"), subtype);
     int256 value = LibSkillRegistry.getBalanceSigned(components, effectID);
 
-    LibBonus.inc(components, holderID, bonusType, value);
+    LibBonusOld.inc(components, holderID, bonusType, value);
   }
 
   // processes the upgrade of a stat increment/decrement effect

--- a/packages/contracts/src/libraries/utils/LibAffinity.sol
+++ b/packages/contracts/src/libraries/utils/LibAffinity.sol
@@ -6,7 +6,7 @@ import { IUint256Component as IUintComp } from "solecs/interfaces/IUint256Compon
 import { IWorld } from "solecs/interfaces/IWorld.sol";
 import { getAddrByID, getCompByID } from "solecs/utils.sol";
 
-import { LibBonus } from "libraries/LibBonus.sol";
+import { LibBonusOld } from "libraries/LibBonusOld.sol";
 import { LibConfig } from "libraries/LibConfig.sol";
 
 /*

--- a/packages/contracts/src/libraries/utils/LibCooldown.sol
+++ b/packages/contracts/src/libraries/utils/LibCooldown.sol
@@ -8,7 +8,7 @@ import { getAddrByID, getCompByID } from "solecs/utils.sol";
 
 import { TimeLastActionComponent, ID as TimeLastActCompID } from "components/TimeLastActionComponent.sol";
 
-import { LibBonus } from "libraries/LibBonus.sol";
+import { LibBonusOld } from "libraries/LibBonusOld.sol";
 import { LibConfig } from "libraries/LibConfig.sol";
 import { LibComp } from "libraries/utils/LibComp.sol";
 
@@ -52,7 +52,7 @@ library LibCooldown {
   /// @notice get cooldown for entity, including bonus
   function getCooldown(IUintComp components, uint256 id) internal view returns (int256) {
     int256 base = LibConfig.get(components, "KAMI_STANDARD_COOLDOWN").toInt256();
-    int256 shift = LibBonus.getRaw(components, id, "STND_COOLDOWN_SHIFT");
+    int256 shift = LibBonusOld.getRaw(components, id, "STND_COOLDOWN_SHIFT");
     int256 cooldown = base + shift;
     return cooldown < int256(0) ? int256(0) : cooldown;
   }

--- a/packages/contracts/src/libraries/utils/LibEntityType.sol
+++ b/packages/contracts/src/libraries/utils/LibEntityType.sol
@@ -24,6 +24,14 @@ library LibEntityType {
     EntityTypeComponent(getAddrByID(components, EntityTypeCompID)).remove(id);
   }
 
+  function has(IUintComp components, uint256 id) internal view returns (bool) {
+    return EntityTypeComponent(getAddrByID(components, EntityTypeCompID)).has(id);
+  }
+
+  function get(IUintComp components, uint256 id) internal view returns (string memory) {
+    return EntityTypeComponent(getAddrByID(components, EntityTypeCompID)).get(id);
+  }
+
   function isShape(
     IUintComp components,
     uint256 id,

--- a/packages/contracts/src/systems/FriendAcceptSystem.sol
+++ b/packages/contracts/src/systems/FriendAcceptSystem.sol
@@ -6,7 +6,7 @@ import { IWorld } from "solecs/interfaces/IWorld.sol";
 import { LibString } from "solady/utils/LibString.sol";
 
 import { LibAccount } from "libraries/LibAccount.sol";
-import { LibBonus } from "libraries/LibBonus.sol";
+import { LibBonusOld } from "libraries/LibBonusOld.sol";
 import { LibConfig } from "libraries/LibConfig.sol";
 import { LibFriend } from "libraries/LibFriend.sol";
 
@@ -30,7 +30,7 @@ contract FriendAcceptSystem is System {
     require(LibFriend.getTarget(components, requestID) == accID, "FriendAccept: not for you");
 
     // check number of friends limit
-    uint256 frenLimit = LibBonus.processBonus(
+    uint256 frenLimit = LibBonusOld.processBonus(
       components,
       accID,
       "FRIENDS_LIMIT",
@@ -38,7 +38,7 @@ contract FriendAcceptSystem is System {
     );
     require(LibFriend.getFriendCount(components, accID) < frenLimit, "Friend limit reached");
 
-    uint256 senderLimit = LibBonus.processBonus(
+    uint256 senderLimit = LibBonusOld.processBonus(
       components,
       accID,
       "FRIENDS_LIMIT",

--- a/packages/contracts/src/systems/FriendRequestSystem.sol
+++ b/packages/contracts/src/systems/FriendRequestSystem.sol
@@ -6,7 +6,6 @@ import { IWorld } from "solecs/interfaces/IWorld.sol";
 import { LibString } from "solady/utils/LibString.sol";
 
 import { LibAccount } from "libraries/LibAccount.sol";
-import { LibBonus } from "libraries/LibBonus.sol";
 import { LibConfig } from "libraries/LibConfig.sol";
 import { LibFriend } from "libraries/LibFriend.sol";
 

--- a/packages/contracts/src/systems/ProductionCollectSystem.sol
+++ b/packages/contracts/src/systems/ProductionCollectSystem.sol
@@ -6,7 +6,6 @@ import { IWorld } from "solecs/interfaces/IWorld.sol";
 import { getAddrByID } from "solecs/utils.sol";
 
 import { LibAccount } from "libraries/LibAccount.sol";
-import { LibBonus } from "libraries/LibBonus.sol";
 import { LibData } from "libraries/LibData.sol";
 import { LibExperience } from "libraries/LibExperience.sol";
 import { LibInventory, MUSU_INDEX } from "libraries/LibInventory.sol";

--- a/packages/contracts/src/systems/ProductionLiquidateSystem.sol
+++ b/packages/contracts/src/systems/ProductionLiquidateSystem.sol
@@ -7,7 +7,6 @@ import { getAddrByID } from "solecs/utils.sol";
 import { SafeCastLib } from "solady/utils/SafeCastLib.sol";
 
 import { LibAccount } from "libraries/LibAccount.sol";
-import { LibBonus } from "libraries/LibBonus.sol";
 import { LibData } from "libraries/LibData.sol";
 import { LibExperience } from "libraries/LibExperience.sol";
 import { LibInventory, MUSU_INDEX } from "libraries/LibInventory.sol";

--- a/packages/contracts/src/systems/ProductionStartSystem.sol
+++ b/packages/contracts/src/systems/ProductionStartSystem.sol
@@ -6,7 +6,6 @@ import { IWorld } from "solecs/interfaces/IWorld.sol";
 import { getAddrByID } from "solecs/utils.sol";
 
 import { LibAccount } from "libraries/LibAccount.sol";
-import { LibBonus } from "libraries/LibBonus.sol";
 import { LibHarvest } from "libraries/LibHarvest.sol";
 import { LibNode } from "libraries/LibNode.sol";
 import { LibPet } from "libraries/LibPet.sol";

--- a/packages/contracts/src/systems/ProductionStopSystem.sol
+++ b/packages/contracts/src/systems/ProductionStopSystem.sol
@@ -6,7 +6,6 @@ import { IWorld } from "solecs/interfaces/IWorld.sol";
 import { getAddrByID } from "solecs/utils.sol";
 
 import { LibAccount } from "libraries/LibAccount.sol";
-import { LibBonus } from "libraries/LibBonus.sol";
 import { LibData } from "libraries/LibData.sol";
 import { LibExperience } from "libraries/LibExperience.sol";
 import { LibInventory, MUSU_INDEX } from "libraries/LibInventory.sol";

--- a/packages/contracts/src/test/libs/Bonus.t.sol
+++ b/packages/contracts/src/test/libs/Bonus.t.sol
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+import { LibSort } from "solady/utils/LibSort.sol";
+
+import "test/utils/SetupTemplate.t.sol";
+
+contract BonusTest is SetupTemplate {
+  uint256 constant regParentEntity = uint256(keccak256(abi.encodePacked("parent")));
+  uint256 constant regParentEntity2 = uint256(keccak256(abi.encodePacked("parent2")));
+  uint256 constant holderEntity = uint256(keccak256(abi.encodePacked("holder")));
+  uint256 constant holderEntity2 = uint256(keccak256(abi.encodePacked("holder2")));
+
+  uint256 internal parentCounter;
+
+  function setUp() public override {
+    setUpWorld();
+    vm.startPrank(deployer);
+  }
+
+  function testBonusShape() public {
+    uint256 regID = LibBonus.registryCreate(components, regParentEntity, "BONUS_TYPE", 1);
+
+    // assigning to holder
+    uint256 instanceID = LibBonus.assign(components, regID, "BONUS_TYPE", holderEntity);
+    LibBonus.incBy(components, regParentEntity, holderEntity, 1);
+    assertEq(LibBonus.getFor(components, "BONUS_TYPE", holderEntity), 1);
+
+    // assigning to holder2
+    LibBonus.incBy(components, regParentEntity, holderEntity2, 2);
+    assertEq(LibBonus.getFor(components, "BONUS_TYPE", holderEntity2), 2);
+  }
+
+  function testBonusQuery() public {
+    uint256[] memory ofParent1 = new uint256[](3);
+    uint256[] memory ofParent2 = new uint256[](2);
+    uint256[] memory ofType1 = new uint256[](2);
+    uint256[] memory ofType2 = new uint256[](1);
+    uint256 localParent = uint256(keccak256(abi.encode(regParentEntity))); // insntance parent, eg. skill instance
+    uint256 localParent2 = uint256(keccak256(abi.encode(regParentEntity2))); // insntance parent, eg. skill instance
+    uint256 regParent = uint256(keccak256(abi.encode("registry.1"))); // registry parent, eg. skill registry
+    uint256 regParent2 = uint256(keccak256(abi.encode("registry.2"))); // registry parent, eg. skill registry
+
+    uint256 tempID = LibBonus.registryCreate(components, regParent, _genType(1), 1);
+    ofParent1[0] = tempID;
+    ofType1[0] = tempID;
+    tempID = LibBonus.registryCreate(components, regParent, _genType(3), 2);
+    ofParent1[1] = tempID;
+    // not checking for type 3
+    tempID = LibBonus.registryCreate(components, regParent, _genType(4), 3);
+    ofParent1[2] = tempID;
+    // not checking for type 4
+    tempID = LibBonus.registryCreate(components, regParent2, _genType(1), 4);
+    ofParent2[0] = tempID;
+    ofType1[1] = tempID;
+    tempID = LibBonus.registryCreate(components, regParent2, _genType(2), 5);
+    ofParent2[1] = tempID;
+    ofType2[0] = tempID;
+    LibSort.insertionSort(ofParent1);
+    LibSort.insertionSort(ofParent2);
+    LibSort.insertionSort(ofType1);
+    LibSort.insertionSort(ofType2);
+
+    // check registry queries
+    {
+      uint256[] memory regQueriedParent1 = LibBonus.queryByParent(components, regParent);
+      uint256[] memory regQueriedParent2 = LibBonus.queryByParent(components, regParent2);
+      assertEq(ofParent1.length, regQueriedParent1.length, "reg parent1 length mismatch");
+      assertEq(ofParent2.length, regQueriedParent2.length, "reg parent2 length mismatch");
+      LibSort.insertionSort(regQueriedParent1);
+      LibSort.insertionSort(regQueriedParent2);
+      for (uint256 i; i < regQueriedParent1.length; i++)
+        assertEq(regQueriedParent1[i], ofParent1[i], "reg parent1 mismatch");
+      for (uint256 i; i < regQueriedParent2.length; i++)
+        assertEq(regQueriedParent2[i], ofParent2[i], "reg parent2 mismatch");
+    }
+
+    // assigning
+    LibBonus.incBy(components, regParent, localParent, holderEntity, 1);
+    LibBonus.incBy(components, regParent2, localParent2, holderEntity, 1);
+
+    // querying
+    {
+      uint256[] memory queriedParent1 = _getSource(LibBonus.queryByParent(components, localParent));
+      uint256[] memory queriedParent2 = _getSource(
+        LibBonus.queryByParent(components, localParent2)
+      );
+      uint256[] memory queriedType1 = _getSource(
+        LibBonus.queryByType(components, _genType(1), holderEntity)
+      );
+      uint256[] memory queriedType2 = _getSource(
+        LibBonus.queryByType(components, _genType(2), holderEntity)
+      );
+      LibSort.insertionSort(queriedParent1);
+      LibSort.insertionSort(queriedParent2);
+      LibSort.insertionSort(queriedType1);
+      LibSort.insertionSort(queriedType2);
+
+      // assertions
+      assertEq(ofParent1.length, queriedParent1.length, "parent1 length mismatch");
+      assertEq(ofParent2.length, queriedParent2.length, "parent2 length mismatch");
+      assertEq(ofType1.length, queriedType1.length, "type1 length mismatch");
+      assertEq(ofType2.length, queriedType2.length, "type2 length mismatch");
+      for (uint256 i; i < ofParent1.length; i++)
+        assertEq(ofParent1[i], queriedParent1[i], "parent1 mismatch");
+      for (uint256 i; i < ofParent2.length; i++)
+        assertEq(ofParent2[i], queriedParent2[i], "parent2 mismatch");
+      for (uint256 i; i < ofType1.length; i++)
+        assertEq(ofType1[i], queriedType1[i], "type1 mismatch");
+      for (uint256 i; i < ofType2.length; i++)
+        assertEq(ofType2[i], queriedType2[i], "type2 mismatch");
+    }
+  }
+
+  function testBonusDiffTypesSameParent() public {
+    int256[] memory values = new int256[](6);
+    values[0] = 2;
+    values[1] = 7;
+    values[2] = 11;
+    values[3] = 0;
+    values[4] = -3;
+    values[5] = -5;
+    uint256[] memory levels = new uint256[](6);
+    levels[0] = 1;
+    levels[1] = 1;
+    levels[2] = 2;
+    levels[3] = 3;
+    levels[4] = 3;
+    levels[5] = 1;
+    uint256[] memory regIDs = new uint256[](6);
+    for (uint256 i; i < 6; i++)
+      regIDs[i] = LibBonus.registryCreate(components, regParentEntity, _genType(i), values[i]);
+
+    // asserting parent query
+    {
+      uint256[] memory childIDs = LibBonus.queryByParent(components, regParentEntity);
+      assertEq(childIDs.length, regIDs.length, "parent query mismatch");
+      for (uint256 i; i < childIDs.length; i++)
+        assertEq(childIDs[i], regIDs[i], "individual parent query mismatch");
+    }
+
+    // assigning one to holder prior
+    _createAndSetBonus(regIDs[0], _genType(0), holderEntity, 1);
+    assertEq(LibBonus.getFor(components, _genType(0), holderEntity), 2, "type 0 mismatch");
+    assertEq(
+      LibBonus.queryByType(components, _genType(0), holderEntity).length,
+      1,
+      "type 0 length"
+    );
+    assertEq(
+      LibBonus.queryByType(components, _genType(1), holderEntity).length,
+      0,
+      "type 1 length"
+    );
+
+    // assigning to holder
+    LibBonus.incBy(components, regParentEntity, holderEntity, 1);
+
+    // setting levels
+    for (uint256 i; i < regIDs.length; i++)
+      _setBonusLevel(LibBonus.genInstanceID(regIDs[i], holderEntity), levels[i]);
+
+    // checking total
+    for (uint256 i; i < regIDs.length; i++) {
+      assertEq(
+        LibBonus.getFor(components, _genType(i), holderEntity),
+        LibBonus.calcSingle(uint256(values[i]), levels[i]),
+        LibString.concat(_genType(i), " total mismatch")
+      );
+    }
+  }
+
+  function testBonusDiffParentSameType() public {
+    int256[] memory values = new int256[](6);
+    values[0] = 2;
+    values[1] = 7;
+    values[2] = 11;
+    values[3] = 0;
+    values[4] = -3;
+    values[5] = -5;
+    uint256[] memory levels = new uint256[](6);
+    levels[0] = 1;
+    levels[1] = 1;
+    levels[2] = 2;
+    levels[3] = 3;
+    levels[4] = 3;
+    levels[5] = 1;
+    uint256[] memory regParentIDs = new uint256[](6);
+    for (uint256 i; i < 6; i++) {
+      regParentIDs[i] = _genParentEntity();
+      LibBonus.registryCreate(components, regParentIDs[i], "BONUS_TYPE", values[i]);
+    }
+
+    // assigning from parents
+    for (uint256 i; i < 6; i++)
+      LibBonus.incBy(components, regParentIDs[i], holderEntity, levels[i]);
+
+    // asserting total
+    assertEq(
+      LibBonus.getFor(components, "BONUS_TYPE", holderEntity),
+      _sum(values, levels),
+      "total mismatch"
+    );
+  }
+
+  /////////////////
+  // UTILS
+
+  function _genParentEntity() internal returns (uint256) {
+    return uint256(keccak256(abi.encodePacked("parent", parentCounter++)));
+  }
+
+  function _genType(uint256 index) internal pure returns (string memory) {
+    return LibString.concat("BONUS_TYPE_", LibString.toString(index));
+  }
+
+  function _getSource(uint256 id) internal view returns (uint256) {
+    return _IdSourceComponent.get(id);
+  }
+
+  function _getSource(uint256[] memory ids) internal view returns (uint256[] memory) {
+    return _IdSourceComponent.getBatch(ids);
+  }
+
+  function _setBonusLevel(uint256 id, uint256 level) internal {
+    _LevelComponent.set(id, level);
+  }
+
+  function _createAndSetBonus(
+    uint256 regID,
+    string memory type_,
+    uint256 holderID,
+    uint256 level
+  ) internal returns (uint256 id) {
+    id = LibBonus.assign(components, regID, type_, holderID);
+    _setBonusLevel(id, level);
+  }
+
+  function _sum(
+    int256[] memory values,
+    uint256[] memory levels
+  ) internal pure returns (int256 total) {
+    for (uint256 i; i < values.length; i++)
+      total += LibBonus.calcSingle(uint256(values[i]), levels[i]);
+  }
+}

--- a/packages/contracts/src/test/systems/Harvest.t.sol
+++ b/packages/contracts/src/test/systems/Harvest.t.sol
@@ -70,9 +70,9 @@ pragma solidity ^0.8.0;
 //     uint256 multAffinity = _calcAffinityMultiplier(
 //       prodID,
 //       petID,
-//       LibBonus.getRaw(components, petID, "HARVEST_AFFINITY_MULT")
+//       LibBonusOld.getRaw(components, petID, "HARVEST_AFFINITY_MULT")
 //     );
-//     uint256 multBonus = _calcBonusMultiplier(LibBonus.getRaw(components, petID, "HARVEST_OUTPUT"));
+//     uint256 multBonus = _calcBonusMultiplier(LibBonusOld.getRaw(components, petID, "HARVEST_OUTPUT"));
 //     uint256 multPrec = 10 ** uint256(configs[3]);
 //     uint256 rfMultiplier = multAffinity * multBonus;
 //     precision *= multPrec;
@@ -234,7 +234,7 @@ pragma solidity ^0.8.0;
 //      *   normal & weak: 7 * 5 = 35
 //      */
 //     vm.startPrank(deployer);
-//     LibBonus.inc(components, petID, "HARVEST_AFFINITY_MULT", 2);
+//     LibBonusOld.inc(components, petID, "HARVEST_AFFINITY_MULT", 2);
 //     vm.stopPrank();
 //     if (nodeAff.eq("NORMAL") || nodeAff.eq("") || bodyAff.eq("NORMAL"))
 //       expected = 7; // mid

--- a/packages/contracts/src/test/systems/Skill.t.sol
+++ b/packages/contracts/src/test/systems/Skill.t.sol
@@ -170,9 +170,9 @@ contract SkillTest is SetupTemplate {
     uint256 regEffID = _createSkillEffect(1, "HARVEST", "DRAIN", 10);
     uint256 petID = _mintPet(alice.index);
 
-    int256 ogDrain = LibBonus.getRaw(components, petID, "HARVEST_DRAIN");
+    int256 ogDrain = LibBonusOld.getRaw(components, petID, "HARVEST_DRAIN");
     _upgradeSkill(alice.index, petID, 1);
-    int256 newDrain = LibBonus.getRaw(components, petID, "HARVEST_DRAIN");
+    int256 newDrain = LibBonusOld.getRaw(components, petID, "HARVEST_DRAIN");
 
     assertEq(ogDrain + 10, newDrain);
   }


### PR DESCRIPTION
(does not touch current deployment. no need for proper review, but keep in loop for shapes)

Bonuses consists of a registry entry and local instance.
   - Ensures updatability via Registry pattern
   - Allows removal for specific/all bonuses of type, eg. when respecing skill
 To get a bonus value for a given entity (acc/pet),
   1. query all relevant bonus instances
   2. get values from registry, sum

 Registry shape: ID = hash("registry.bonus", parentID, type)
 - IsRegistry
 - EntityType: BONUS
 - IDParent: for reverse map to parent registry (parentID)
 - Type (FE only)
 - Value (used as Int256, but stored as uint256)

 Instance shape: ID = hash("bonus.instance", registryID, holderID)
 - IdSource: relevant BonusRegistryID
 - IDParent: (optional - but assume have) for querying child bonuses from a parent (eg. skill) [hash("bonus.parent", parentID)]
 - IDType: type, used to query all bonuses of type [hash("bonus.type", type, holderID)]
 - Level: bonus level, acts as a multiplier