### PR TITLE
scale on either orientation for iconlistbutton

### DIFF
--- a/packages/client/src/app/components/library/base/buttons/IconListButton.tsx
+++ b/packages/client/src/app/components/library/base/buttons/IconListButton.tsx
@@ -1,5 +1,5 @@
 import { Popover } from '@mui/material';
-import { clickFx, hoverFx } from 'app/styles/effects';
+import { hoverFx } from 'app/styles/effects';
 import React, { useRef, useState } from 'react';
 import styled from 'styled-components';
 
@@ -12,7 +12,8 @@ interface Props {
   balance?: number;
   disabled?: boolean;
   fullWidth?: boolean;
-  noBounce?: boolean;
+  scale?: number;
+  scalesOnHeight?: boolean;
 }
 
 export interface Option {
@@ -24,11 +25,13 @@ export interface Option {
 
 export function IconListButton(props: Props) {
   const { img, options, text, balance } = props;
-  const { disabled, fullWidth, noBounce } = props;
+  const { disabled, fullWidth } = props;
   const toggleRef = useRef<HTMLButtonElement>(null);
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
+  const scale = props.scale ?? 1.4;
+  const scaleOrientation = props.scalesOnHeight ? 'vh' : 'vw';
 
-  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const handleOpen = (event: React.MouseEvent<HTMLButtonElement>) => {
     if (!disabled) {
       playClick();
       setAnchorEl(event.currentTarget);
@@ -51,24 +54,18 @@ export function IconListButton(props: Props) {
 
   const MenuItem = (option: Option, i: number) => {
     return (
-      <Option key={i} disabled={option.disabled} onClick={() => onSelect(option)}>
-        {option.image && <Icon src={option.image} />}
+      <MenuOption key={i} disabled={option.disabled} onClick={() => onSelect(option)}>
+        {option.image && <MenuIcon src={option.image} />}
         {option.text}
-      </Option>
+      </MenuOption>
     );
   };
 
   return (
     <Wrapper>
-      <Button
-        ref={toggleRef}
-        onClick={handleClick}
-        disabled={!!disabled}
-        fullWidth={!!fullWidth}
-        noBounce={!!noBounce}
-      >
+      <Button ref={toggleRef} onClick={handleOpen} disabled={!!disabled} fullWidth={!!fullWidth}>
         {balance ? <Balance>{balance}</Balance> : <Corner />}
-        <Image src={img} isItem={!!balance} />
+        <Image src={img} scale={scale} orientation={scaleOrientation} />
         {text && <Text>{text}</Text>}
       </Button>
       <Popover
@@ -84,15 +81,14 @@ export function IconListButton(props: Props) {
   );
 }
 
+const Wrapper = styled.div`
+  width: auto;
+`;
+
 interface ButtonProps {
   disabled: boolean;
   fullWidth: boolean;
-  noBounce: boolean;
 }
-
-const Wrapper = styled.div<{ fullWidth?: boolean }>`
-  width: ${({ fullWidth }) => (fullWidth ? '100%' : 'auto')};
-`;
 
 const Button = styled.button<ButtonProps>`
   position: relative;
@@ -115,9 +111,16 @@ const Button = styled.button<ButtonProps>`
     animation: ${() => hoverFx()} 0.2s;
     transform: scale(1.05);
   }
-  &:active {
-    animation: ${() => clickFx()} 0.3s;
-  }
+`;
+
+const Image = styled.img<{ scale: number; orientation: string }>`
+  width: ${({ scale }) => scale}${({ orientation }) => orientation};
+  height: ${({ scale }) => scale}${({ orientation }) => orientation};
+  ${({ scale }) => (scale > 2.4 ? 'image-rendering: pixelated;' : '')}
+`;
+
+const Text = styled.div`
+  font-size: 0.8vw;
 `;
 
 const Corner = styled.div`
@@ -139,35 +142,20 @@ const Balance = styled.div`
   bottom: 0;
   right: 0;
 
-  font-size: 9px;
+  font-size: 0.75vw;
   align-items: center;
   justify-content: center;
   padding: 0.2vw;
 `;
 
-const Icon = styled.img`
-  height: 1.4vw;
-`;
-
-const Image = styled.img<{ isItem?: boolean }>`
-  width: ${({ isItem }) => (isItem ? '60px' : '1.4vw')};
-  height: ${({ isItem }) => (isItem ? '60px' : '1.4vw')};
-  ${({ isItem }) => (isItem ? 'image-rendering: pixelated;' : '')}
-`;
-
-const Text = styled.div`
-  font-family: Pixel;
-  font-size: 0.8vw;
-`;
-
 const Menu = styled.div`
   border: solid black 0.15vw;
-  border-radius: 3.5px;
+  border-radius: 0.6vw;
   color: black;
   min-width: 6vw;
 `;
 
-const Option = styled.div<{ disabled?: boolean }>`
+const MenuOption = styled.div<{ disabled?: boolean }>`
   display: flex;
   align-items: center;
   gap: 0.4vw;
@@ -187,4 +175,8 @@ const Option = styled.div<{ disabled?: boolean }>`
   &:active {
     background-color: #bbb;
   }
+`;
+
+const MenuIcon = styled.img`
+  height: 1.4vw;
 `;

--- a/packages/client/src/app/components/modals/inventory/ItemGrid.tsx
+++ b/packages/client/src/app/components/modals/inventory/ItemGrid.tsx
@@ -75,20 +75,6 @@ export const ItemGrid = (props: Props) => {
 
   const ItemIcon = (inv: Inventory) => {
     const item = inv.item;
-    // let options: Option[] = [];
-
-    // if (item.type === 'LOOTBOX') {
-    //   options = getLootboxActions(item, inv.balance);
-    // } else if (item.for && item.for === 'ACCOUNT') {
-    //   options = [{ text: 'Consume', onClick: () => feedAccount(inv.item) }];
-    // } else if (item.for && item.for === 'KAMI') {
-    //   let kamis = getAccessibleKamis(account);
-    //   if (item.type === 'REVIVE') kamis = kamis.filter((kami) => kami.state === 'DEAD');
-    //   if (item.type === 'FOOD') kamis = kamis.filter((kami) => kami.state !== 'DEAD');
-    //   if (item.type === 'RENAME_POTION') kamis = kamis.filter((kami) => !kami.flags?.namable);
-    //   options = kamis.map((kami) => ({ text: kami.name, onClick: () => feedKami(kami, inv.item) }));
-    // }
-
     const options = getActions(item, inv.balance);
 
     return (
@@ -96,6 +82,7 @@ export const ItemGrid = (props: Props) => {
         <IconListButton
           key={item.index}
           img={item.image}
+          scale={4.8}
           balance={inv.balance}
           options={options}
           disabled={options.length == 0}
@@ -115,6 +102,6 @@ export const ItemGrid = (props: Props) => {
 const Container = styled.div`
   display: flex;
   flex-flow: row wrap;
-  justify-content: flex-start;
+  justify-content: center;
   gap: 0.3vw;
 `;

--- a/packages/client/src/app/components/modals/node/header/Banner.tsx
+++ b/packages/client/src/app/components/modals/node/header/Banner.tsx
@@ -94,7 +94,6 @@ export const Banner = (props: Props) => {
           text='Add Kami to Node'
           disabled={options.length == 0 || account.roomIndex !== node.roomIndex}
           fullWidth
-          noBounce
         />
       </Tooltip>
     );
@@ -201,7 +200,6 @@ const Details = styled.div`
 `;
 
 const Name = styled.div`
-  font-family: Pixel;
   font-size: 1.2vw;
   padding: 0.5vw 0;
 `;
@@ -231,7 +229,6 @@ const Icon = styled.img`
 
 const Description = styled.div`
   font-size: 0.75vw;
-  font-family: Pixel;
   line-height: 1.1vw;
   text-align: left;
   padding: 0.45vw 0.3vw;


### PR DESCRIPTION
consolidating crayoning over some previously contested ui components
(inventory modal item grid) with this one. but imo it really does feel good
maintaining 5 items per row regardless of screen sizing. afaict there are
no issues with vw scaling across our supported aspect ratios (2:1 to 1:1)

@chlwys 

denominating scale in pixels feels a bit bad bc
1. we dont have any control over users' screen resolutions
2. it's inconsistent with our modal scaling (vw) which Just Works (usually..)

the consistency and generalizability of our components is what i'm 
primarily concerned with here, as it determines the complexity of ui
implementation. and this component in particular i have strong
opinions on due to its widespread usage across the codebase

as a compromise, i introduced the ability to scale this component on
view height as well. primarily in preparation for the new dropdown
menu button we plan to support. lmk if you have any objections here.
as tempting as it is, i don't want to just shove this one in as it has been
a point of contention in the past

![Screenshot 2024-10-10 at 6 22 40 AM](https://github.com/user-attachments/assets/4fb38e49-cd16-45cb-8b16-ab872b7cceb8)
