### PR TITLE
partially split up explorer endpoints

### DIFF
--- a/packages/client/src/network/explorer/accounts.ts
+++ b/packages/client/src/network/explorer/accounts.ts
@@ -1,0 +1,46 @@
+import { EntityID, World } from '@mud-classic/recs';
+
+import { Components } from 'network/';
+import {
+  AccountOptions,
+  getAccountByID,
+  getAccountByIndex,
+  getAccountByName,
+  getAccountByOwner,
+  getAccountItemStats,
+  getAccountRepStats,
+  getAllAccounts,
+} from 'network/shapes/Account';
+import { getByOperator } from 'network/shapes/Account/getters';
+
+const fullAccountOptions: AccountOptions = {
+  kamis: true,
+  friends: true,
+  inventory: true,
+  stats: true,
+};
+
+export const accounts = (world: World, components: Components) => {
+  return {
+    all: (options?: AccountOptions) => getAllAccounts(world, components, options),
+    get: (index: number) => getAccountByIndex(world, components, index, fullAccountOptions),
+    getByID: (id: EntityID) => getAccountByID(world, components, id, fullAccountOptions),
+    getByOwner: (owner: string) =>
+      getAccountByOwner(world, components, owner.toLowerCase(), fullAccountOptions),
+    getByOperator: (operator: string) =>
+      getByOperator(world, components, operator.toLowerCase(), fullAccountOptions),
+    getByName: (name: string) => getAccountByName(world, components, name, fullAccountOptions),
+    entities: () => Array.from(components.IsAccount.entities()),
+    indices: () => Array.from(components.AccountIndex.values.value.values()),
+    rankings: {
+      musu: (limit?: number) => getAccountItemStats(world, components, limit),
+      reputation: (limit?: number) => getAccountRepStats(world, components, limit),
+    },
+    stats: {
+      item: (index?: number, limit?: number) =>
+        getAccountItemStats(world, components, index, limit),
+      musu: (limit?: number) => getAccountItemStats(world, components, limit),
+      reputation: (limit?: number) => getAccountRepStats(world, components, limit),
+    },
+  };
+};

--- a/packages/client/src/network/explorer/configs.ts
+++ b/packages/client/src/network/explorer/configs.ts
@@ -1,0 +1,16 @@
+import { World } from '@mud-classic/recs';
+
+import { Components } from 'network/';
+import {
+  getConfigFieldValue,
+  getConfigFieldValueAddress,
+  getConfigFieldValueArray,
+} from 'network/shapes/Config';
+
+export const configs = (world: World, components: Components) => {
+  return {
+    get: (name: string) => getConfigFieldValue(world, components, name),
+    getArray: (name: string) => getConfigFieldValueArray(world, components, name),
+    getAddress: (name: string) => getConfigFieldValueAddress(world, components, name),
+  };
+};

--- a/packages/client/src/network/explorer/factions.ts
+++ b/packages/client/src/network/explorer/factions.ts
@@ -1,0 +1,12 @@
+import { World } from '@mud-classic/recs';
+
+import { Components } from 'network/';
+import { getAllFactions, getFactionByIndex } from 'network/shapes/Faction';
+
+export const factions = (world: World, components: Components) => {
+  return {
+    all: () => getAllFactions(world, components),
+    get: (index: number) => getFactionByIndex(world, components, index),
+    indices: () => Array.from(components.FactionIndex.values.value.values()),
+  };
+};

--- a/packages/client/src/network/explorer/goals.ts
+++ b/packages/client/src/network/explorer/goals.ts
@@ -1,0 +1,11 @@
+import { World } from '@mud-classic/recs';
+
+import { Components } from 'network/';
+import { getAllGoals, getGoalByIndex } from 'network/shapes/Goal';
+
+export const goals = (world: World, components: Components) => {
+  return {
+    all: () => getAllGoals(world, components),
+    get: (index: number) => getGoalByIndex(world, components, index),
+  };
+};

--- a/packages/client/src/network/explorer/index.ts
+++ b/packages/client/src/network/explorer/index.ts
@@ -1,35 +1,19 @@
 import { Component, EntityID, EntityIndex, World, getComponentValue } from '@mud-classic/recs';
 
 import { Components } from 'network/';
-import {
-  AccountOptions,
-  getAccountByID,
-  getAccountByIndex,
-  getAccountByName,
-  getAccountByOwner,
-  getAccountMusuRankings,
-  getAccountRepRankings,
-  getAllAccounts,
-  queryAccountByIndex,
-} from 'network/shapes/Account';
-import { getByOperator } from 'network/shapes/Account/getters';
-import { getConfigFieldValue, getConfigFieldValueArray } from 'network/shapes/Config';
-import { getConfigFieldValueAddress } from 'network/shapes/Config/types';
-import { getAllFactions, getFactionByIndex } from 'network/shapes/Faction';
-import { getAllGoals, getGoalByIndex } from 'network/shapes/Goal';
+import { AccountOptions } from 'network/shapes/Account';
 import { getAllItems, getItemByIndex } from 'network/shapes/Item';
 import { KamiOptions, getAllKamis, getKamiByIndex } from 'network/shapes/Kami';
 import { NodeOptions, getAllNodes, getNodeByIndex } from 'network/shapes/Node';
 import { getAllNPCs, getNPCByIndex } from 'network/shapes/NPCs';
-import {
-  getQuest,
-  getQuestByIndex,
-  queryAcceptedQuests,
-  queryRegistryQuests,
-} from 'network/shapes/Quest';
 import { getAllRooms, getRoomByIndex } from 'network/shapes/Room';
 import { getRegistrySkills, getSkillByIndex } from 'network/shapes/Skill';
 import { getRegistryTraits, getTraitByIndex } from 'network/shapes/Trait';
+import { accounts } from './accounts';
+import { configs } from './configs';
+import { factions } from './factions';
+import { goals } from './goals';
+import { quests } from './quests';
 
 // explorer for our 'shapes', exposed on the window object @ network.explorer
 export const initExplorer = (world: World, components: Components) => {
@@ -57,39 +41,10 @@ export const initExplorer = (world: World, components: Components) => {
   }
 
   return {
-    accounts: {
-      all: (options?: AccountOptions) => getAllAccounts(world, components, options),
-      get: (index: number) => getAccountByIndex(world, components, index, fullAccountOptions),
-      getByID: (id: EntityID) => getAccountByID(world, components, id, fullAccountOptions),
-      getByOwner: (owner: string) =>
-        getAccountByOwner(world, components, owner.toLowerCase(), fullAccountOptions),
-      getByOperator: (operator: string) =>
-        getByOperator(world, components, operator.toLowerCase(), fullAccountOptions),
-      getByName: (name: string) => getAccountByName(world, components, name, fullAccountOptions),
-      entities: () => Array.from(components.IsAccount.entities()),
-      indices: () => Array.from(components.AccountIndex.values.value.values()),
-      rankings: {
-        musu: (limit?: number) => getAccountMusuRankings(world, components, limit),
-        reputation: (limit?: number) => getAccountRepRankings(world, components, limit),
-      },
-    },
-
-    config: {
-      get: (name: string) => getConfigFieldValue(world, components, name),
-      getArray: (name: string) => getConfigFieldValueArray(world, components, name),
-      getAddress: (name: string) => getConfigFieldValueAddress(world, components, name),
-    },
-
-    goals: {
-      all: () => getAllGoals(world, components),
-      get: (index: number) => getGoalByIndex(world, components, index),
-    },
-
-    factions: {
-      all: () => getAllFactions(world, components),
-      get: (index: number) => getFactionByIndex(world, components, index),
-      indices: () => Array.from(components.FactionIndex.values.value.values()),
-    },
+    accounts: accounts(world, components),
+    configs: configs(world, components),
+    factions: factions(world, components),
+    goals: goals(world, components),
 
     kamis: {
       all: (options?: KamiOptions) => getAllKamis(world, components, options),
@@ -136,23 +91,7 @@ export const initExplorer = (world: World, components: Components) => {
       indices: () => [...new Set(Array.from(components.ItemIndex.values.value.values()))],
     },
 
-    quests: {
-      all: () => {
-        const entities = queryRegistryQuests(components);
-        const quests = entities.map((entity) => getQuest(world, components, entity));
-        return quests.sort((a, b) => a.index - b.index);
-      },
-      get: (index: number) => getQuestByIndex(world, components, index),
-      getForAccount: (accountIndex: number) => {
-        const accEntity = queryAccountByIndex(components, accountIndex) as EntityIndex;
-        const accountID = world.entities[accEntity];
-        const entities = queryAcceptedQuests(components, accountID);
-        const quests = entities.map((entity) => getQuest(world, components, entity));
-        return quests.sort((a, b) => a.index - b.index);
-      },
-      indices: () => [...new Set(Array.from(components.QuestIndex.values.value.values()))],
-    },
-
+    quests: quests(world, components),
     skills: {
       all: () => getRegistrySkills(world, components),
       get: (index: number, options?: {}) => getSkillByIndex(world, components, index, options),

--- a/packages/client/src/network/explorer/quests.ts
+++ b/packages/client/src/network/explorer/quests.ts
@@ -1,0 +1,29 @@
+import { EntityIndex, World } from '@mud-classic/recs';
+
+import { Components } from 'network/';
+import { queryAccountByIndex } from 'network/shapes/Account';
+import {
+  getQuest,
+  getQuestByIndex,
+  queryAcceptedQuests,
+  queryRegistryQuests,
+} from 'network/shapes/Quest';
+
+export const quests = (world: World, components: Components) => {
+  return {
+    all: () => {
+      const entities = queryRegistryQuests(components);
+      const quests = entities.map((entity) => getQuest(world, components, entity));
+      return quests.sort((a, b) => a.index - b.index);
+    },
+    get: (index: number) => getQuestByIndex(world, components, index),
+    getForAccount: (accountIndex: number) => {
+      const accEntity = queryAccountByIndex(components, accountIndex) as EntityIndex;
+      const accountID = world.entities[accEntity];
+      const entities = queryAcceptedQuests(components, accountID);
+      const quests = entities.map((entity) => getQuest(world, components, entity));
+      return quests.sort((a, b) => a.index - b.index);
+    },
+    indices: () => [...new Set(Array.from(components.QuestIndex.values.value.values()))],
+  };
+};

--- a/packages/client/src/network/shapes/Account/index.ts
+++ b/packages/client/src/network/shapes/Account/index.ts
@@ -17,8 +17,8 @@ export {
   queryFromBurner as queryAccountFromBurner,
 } from './queries';
 export {
-  getMusuRankings as getAccountMusuRankings,
-  getReputationRankings as getAccountRepRankings,
+  getItemStats as getAccountItemStats,
+  getReputationStats as getAccountRepStats,
 } from './stats';
 
 export { NullAccount, getAccount, getBaseAccount } from './types';

--- a/packages/client/src/network/shapes/Account/stats.ts
+++ b/packages/client/src/network/shapes/Account/stats.ts
@@ -2,11 +2,11 @@ import { World, getComponentValue } from '@mud-classic/recs';
 
 import { Components } from 'network/';
 import { getReputation } from '../Faction';
-import { getMusuBalance } from '../Item';
+import { getItemBalance } from '../Item';
 import { queryAll } from './queries';
 
 // return the ranked reputation values of all accounts
-export const getReputationRankings = (
+export const getReputationStats = (
   world: World,
   components: Components,
   limit?: number,
@@ -40,10 +40,11 @@ export const getReputationRankings = (
 };
 
 // return the ranked musu balances of all accounts
-export const getMusuRankings = (
+export const getItemStats = (
   world: World,
   components: Components,
-  limit?: number,
+  index = 1,
+  limit = 200,
   flatten = true
 ) => {
   const { AccountIndex, Name } = components;
@@ -53,17 +54,17 @@ export const getMusuRankings = (
     return {
       index: getComponentValue(AccountIndex, entityIndex)?.value as number,
       name: getComponentValue(Name, entityIndex)?.value as string,
-      coin: getMusuBalance(world, components, id),
+      amt: getItemBalance(world, components, id, index),
     };
   });
 
   // sort and filter
-  const ranked = raw.sort((a, b) => b.coin - a.coin);
+  const ranked = raw.sort((a, b) => b.amt - a.amt);
   const truncated = ranked.slice(0, limit ?? raw.length);
 
   // optionally flatten and return
   if (flatten) {
-    return truncated.map((result, ranking) => `${ranking + 1}. ${result.name}: ${result.coin}`);
+    return truncated.map((result, ranking) => `${ranking + 1}. ${result.name}: ${result.amt}`);
   }
   return truncated;
 };

--- a/packages/client/src/network/shapes/Config/index.ts
+++ b/packages/client/src/network/shapes/Config/index.ts
@@ -1,4 +1,9 @@
 export { getConfig as getKamiConfig } from './kami';
-export { getConfigFieldValue, getConfigFieldValueArray, getConfigFieldValueWei } from './types';
+export {
+  getConfigFieldValue,
+  getConfigFieldValueAddress,
+  getConfigFieldValueArray,
+  getConfigFieldValueWei,
+} from './types';
 
 export type { Config as KamiConfig } from './kami';


### PR DESCRIPTION
also introduces item stats on the accounts route
will split up the rest After the recs migration