### PR TITLE
Update kill calcs

### DIFF
--- a/packages/client/src/network/shapes/Harvest/liquidations.ts
+++ b/packages/client/src/network/shapes/Harvest/liquidations.ts
@@ -110,7 +110,7 @@ export const calcStrain = (attacker: Kami, defender: Kami): number => {
 // calculate liquidation hp recoil due to violence
 export const calcKarma = (attacker: Kami, defender: Kami): number => {
   const karmaConfig = attacker.config.liquidation.karma;
-  const totalViolence = attacker.stats.violence.total + defender.stats.violence.total;
+  const totalViolence = defender.stats.violence.total;
   const karma = totalViolence * karmaConfig.ratio.value;
   return Math.floor(karma);
 };

--- a/packages/contracts/src/deployment/world/state/configs.ts
+++ b/packages/contracts/src/deployment/world/state/configs.ts
@@ -57,7 +57,7 @@ export async function initConfigs(api: AdminAPI) {
   await api.config.set.array('KAMI_LIQ_THRESHOLD', [0, 3, 1000, 3, 0, 3, 0, 0]);
   await api.config.set.array('KAMI_LIQ_SALVAGE', [0, 2, 0, 3, 0, 0, 0, 0]); // hijacked nudge for power tuning (REQUIRED: config[3] >= config[1])
   await api.config.set.array('KAMI_LIQ_SPOILS', [35, 2, 0, 3, 0, 0, 0, 0]); // hijacked nudge for power tuning (REQUIRED: config[3] >= config[1])
-  await api.config.set.array('KAMI_LIQ_KARMA', [0, 0, 300, 3, 0, 0, 0, 0]);
+  await api.config.set.array('KAMI_LIQ_KARMA', [0, 0, 2000, 3, 0, 0, 0, 0]);
 }
 
 // local config settings for faster testing

--- a/packages/contracts/src/libraries/LibKill.sol
+++ b/packages/contracts/src/libraries/LibKill.sol
@@ -172,11 +172,10 @@ library LibKill {
     uint256 targetID
   ) internal view returns (uint256) {
     uint32[8] memory config = LibConfig.getArray(components, "KAMI_LIQ_KARMA");
-    uint256 violence1 = LibKami.calcTotalViolence(components, sourceID).toUint256();
-    uint256 violence2 = LibKami.calcTotalViolence(components, targetID).toUint256();
+    uint256 violence = LibKami.calcTotalViolence(components, targetID).toUint256();
     uint256 ratio = uint(config[2]);
     uint256 precision = 10 ** uint(config[3]);
-    return ((violence1 + violence2) * ratio) / precision;
+    return (violence * ratio) / precision;
   }
 
   // Calculate the amount of MUSU salvaged by a target from a given balance. Round down.


### PR DESCRIPTION
updates some calcs to line up with more recent discussions
- apply atk/def threshold ratios to all matchups
- update karma calc and config `.3(v1+v2)` => `2(v2)` 
- update intensity config (not calcs)

requires redeploy of liquidation system and various configs