### PR TITLE
quest button interactions

### DIFF
--- a/packages/client/src/app/components/fixtures/menu/buttons/Quests.tsx
+++ b/packages/client/src/app/components/fixtures/menu/buttons/Quests.tsx
@@ -12,9 +12,7 @@ export const QuestMenuButton = () => {
     emaBoard: false,
     help: false,
     inventory: false,
-    kami: false,
     leaderboard: false,
-    nameKami: false,
     settings: false,
   };
 


### PR DESCRIPTION
stop hiding kami and name kami modals when clicking quest modal