### PR TITLE
introduce spoils cap [KILL EVENTS FIX TOO]

### DIFF
--- a/packages/client/src/network/shapes/Harvest/liquidations.ts
+++ b/packages/client/src/network/shapes/Harvest/liquidations.ts
@@ -93,7 +93,7 @@ const calcSpoils = (attacker: Kami, defender: Kami): number => {
   const salvage = calcSalvage(defender, balance);
   const powerTuning = power / 100 + config.nudge.value;
   const spoilsRatio = config.ratio.value + powerTuning + bonus.ratio;
-  const spoils = (balance - salvage) * spoilsRatio;
+  const spoils = (balance - salvage) * Math.min(1, spoilsRatio);
   return spoils;
 };
 

--- a/packages/contracts/src/deployment/world/state/configs.ts
+++ b/packages/contracts/src/deployment/world/state/configs.ts
@@ -88,7 +88,7 @@ async function initLiquidation(api: AdminAPI) {
   await api.config.set.array('KAMI_LIQ_ANIMOSITY', [0, 0, 400, 3]); // nontraditional AST node
   await api.config.set.array('KAMI_LIQ_THRESHOLD', [0, 3, 1000, 3, 0, 3, 0, 0]);
   await api.config.set.array('KAMI_LIQ_SALVAGE', [0, 2, 0, 3, 0, 0, 0, 0]); // hijacked nudge for power tuning (REQUIRED: config[3] >= config[1])
-  await api.config.set.array('KAMI_LIQ_SPOILS', [35, 2, 0, 3, 0, 0, 0, 0]); // hijacked nudge for power tuning (REQUIRED: config[3] >= config[1])
+  await api.config.set.array('KAMI_LIQ_SPOILS', [45, 2, 0, 3, 0, 0, 0, 0]); // hijacked nudge for power tuning (REQUIRED: config[3] >= config[1])
   await api.config.set.array('KAMI_LIQ_KARMA', [0, 0, 3000, 3, 0, 0, 0, 0]);
 }
 

--- a/packages/contracts/src/libraries/LibKill.sol
+++ b/packages/contracts/src/libraries/LibKill.sol
@@ -196,7 +196,7 @@ library LibKill {
 
     uint256 ratio = uint(config[2]);
     uint256 precision = 10 ** uint(config[3]);
-    return (uint256(v2 - h1) * ratio) / precision;
+    return (uint32(v2 - h1) * ratio) / precision;
   }
 
   // Calculate the amount of MUSU salvaged by a target from a given balance. Round down.
@@ -228,6 +228,7 @@ library LibKill {
     uint256 powerTuning = (config[0] + power) * 10 ** (config[3] - config[1]); // scale to Ratio precision
     uint256 ratio = config[2] + powerTuning + ratioBonus.toUint256();
     uint256 precision = 10 ** uint256(config[3]);
+    if (ratio / precision > 1) return amt;
     return (amt * ratio) / precision;
   }
 
@@ -302,10 +303,10 @@ library LibKill {
     emit KamiLiquidated(
       LibKami.getIndex(components, killerID),
       killerHp.sync,
-      StatLib.deprecatedCalcTotal(killerHp),
+      LibStat.getTotal(components, "HEALTH", killerID),
       LibKami.getIndex(components, victimID),
       victimHp.sync,
-      StatLib.deprecatedCalcTotal(victimHp),
+      LibStat.getTotal(components, "HEALTH", victimID),
       bals.bounty.toUint32(),
       bals.salvage.toUint32(),
       bals.spoils.toUint32(),


### PR DESCRIPTION
caps spoils at 100% of leftover after salvage
also fixes kill event logs (correct total HPs) 
why didnt i create separate PRs? (lazy)