### PR TITLE
incremental loading for enemy kards

### DIFF
--- a/packages/client/src/app/components/modals/node/Node.tsx
+++ b/packages/client/src/app/components/modals/node/Node.tsx
@@ -131,10 +131,7 @@ export function registerNodeModal() {
       const refreshKami = (kami: Kami) => {
         const lastTime = utils.getLastTime(kami.entityIndex);
         const lastUpdate = KamiLastTs.get(kami.entityIndex)!;
-        if (lastTime > lastUpdate) {
-          KamiCache.set(kami.entityIndex, kami);
-          return processKami(kami.entityIndex);
-        }
+        if (lastTime > lastUpdate) kami = processKami(kami.entityIndex);
         return kami;
       };
 


### PR DESCRIPTION
further optimizes data processing for the node modal

dedicates a different set of cycle time to kami loading depending on whether the
list of enemies is visible. pulling a single kami is expensive right now, but this will
improve as we optimize the kami queries as well