### PR TITLE
streamline tx.wait() resolver

### DIFF
--- a/packages/client/src/network/systems/ActionSystem/createActionSystem.ts
+++ b/packages/client/src/network/systems/ActionSystem/createActionSystem.ts
@@ -9,7 +9,6 @@ import {
   setComponent,
   updateComponent,
 } from '@mud-classic/recs';
-import { awaitStreamValue } from '@mud-classic/utils';
 import { Observable } from 'rxjs';
 import { v4 as uuid } from 'uuid';
 import { defineActionComponent } from './ActionComponent';
@@ -85,32 +84,13 @@ export function createActionSystem<M = undefined>(
     try {
       // Execute the action
       const tx = await request.execute();
+      updateAction({ state: ActionState.WaitingForTxEvents }); // pending
 
       if (tx) {
-        // Wait for all tx events to be reduced
-        updateAction({ state: ActionState.WaitingForTxEvents, txHash: tx.hash });
-
-        // NOTE: this logic should be baked into the network layer and we should be better handling the
-        // other confirmation statuses
-        async function waitFor(tx: any) {
-          // perform regular wait
-          const txConfirmed = await provider
-            .waitForTransaction(tx.hash, 1, 8000)
-            .catch((e) => handleError(e, request!));
-          if (txConfirmed?.status === 0) {
-            // if tx did not complete, initiate tx.wait() to throw regular error
-            await tx.wait().catch((e: any) => handleError(e, request!));
-          }
-          return txConfirmed;
-        }
-
-        // const txConfirmed = await tx.wait().catch((e: any) => handleError(e, request));
-        // const txConfirmed = await provider.waitForTransaction(tx.hash, 1, 8000).catch((e) => handleError(e, action));
-        const txConfirmed = waitFor(tx);
-        await awaitStreamValue(txReduced$, (v) => v === tx.hash);
-        updateAction({ state: ActionState.TxReduced });
+        const txConfirmed = await tx.wait().catch((e: any) => handleError(e, request));
         if (request.awaitConfirmation) await txConfirmed;
       }
+
       updateAction({ state: ActionState.Complete });
     } catch (e) {
       handleError(e, request);

--- a/packages/client/src/workers/sync/utils.ts
+++ b/packages/client/src/workers/sync/utils.ts
@@ -292,7 +292,7 @@ export function createLatestEventStreamRPC(
       const to = blockNumber;
       lastSyncedBlockNumber = to;
       const events = await fetchWorldEvents(from, to);
-      console.log(`[rpc] fetched ${events.length} events from block range ${from} -> ${to}`);
+      // console.log(`[rpc] fetched ${events.length} events from block range ${from} -> ${to}`);
 
       if (fetchSystemCallsFromEvents && events.length > 0) {
         const systemCalls = await fetchSystemCallsFromEvents(events, blockNumber);


### PR DESCRIPTION
updates tx.wait() for transaction away from hardcoded 45s poll. This change was originally because one of our previous chains did not play nice with tx.wait().

now waits for 0 block confirmations - slightly faster, no impact (because state is based on events, not tx completition) but faster tx queue processing. Also helps avoid forever pending transactions.
