### PR TITLE
skip gas estimates

### DIFF
--- a/packages/client/src/engine/queue/create.ts
+++ b/packages/client/src/engine/queue/create.ts
@@ -103,9 +103,10 @@ export function create<C extends Contracts>(
     const fragment = target.interface.fragments.find((fragment) => fragment.name === prop);
     const stateMutability = fragment && (fragment as { stateMutability?: string }).stateMutability;
 
-    // Create a function that estimates gas
+    // skip gas estimation if gasLimit is set
     const estGasFunction = target.estimateGas[prop as string];
-    const estimateGas = () => estGasFunction(...args);
+    const estimateGas = () =>
+      callOverrides.gasLimit ? Promise.resolve(callOverrides.gasLimit) : estGasFunction(...args);
 
     // Create a function that executes the tx when called
     const execute = async (txData: Overrides) => {

--- a/packages/client/src/engine/queue/utils.ts
+++ b/packages/client/src/engine/queue/utils.ts
@@ -50,6 +50,10 @@ export async function getTxGasData(
 export function isOverrides(obj: any): obj is Overrides {
   if (typeof obj !== 'object' || Array.isArray(obj) || obj === null) return false;
   return (
+    'gasLimit' in obj ||
+    'gasPrice' in obj ||
+    'maxFeePerGas' in obj ||
+    'maxPriorityFeePerGas' in obj ||
     'nonce' in obj ||
     'type' in obj ||
     'accessList' in obj ||

--- a/packages/client/src/network/api/player.ts
+++ b/packages/client/src/network/api/player.ts
@@ -79,10 +79,9 @@ export function createPlayerAPI(systems: any) {
     return systems['system.account.use.teleport'].executeTyped(itemIndex);
   }
 
-  // @dev moves the account to another room from their current roomIndex
-  // @param roomIndex  destination room roomIndex
   function moveAccount(roomIndex: number) {
-    return systems['system.account.move'].executeTyped(roomIndex);
+    // hardcode gas limit to 1.2m; approx upper bound for moving room with 1 gate
+    return systems['system.account.move'].executeTyped(roomIndex, { gasLimit: 1200000 });
   }
 
   // @dev registers an account. should be called by Owner wallet


### PR DESCRIPTION
hardcode gas limits to skip estimateGas for certain transactions (eg move).

Performance increase isn't that much, unfortunately. but pushing in anyway for potential groundworks for future improvements

@JirAcheron should we add this in dyt