### PR TITLE
unhardcode room move gas

### DIFF
--- a/packages/client/src/network/api/player.ts
+++ b/packages/client/src/network/api/player.ts
@@ -81,7 +81,7 @@ export function createPlayerAPI(systems: any) {
 
   function moveAccount(roomIndex: number) {
     // hardcode gas limit to 1.2m; approx upper bound for moving room with 1 gate
-    return systems['system.account.move'].executeTyped(roomIndex, { gasLimit: 1200000 });
+    return systems['system.account.move'].executeTyped(roomIndex); //, { gasLimit: 1200000 });
   }
 
   // @dev registers an account. should be called by Owner wallet

--- a/packages/client/src/network/systems/ActionSystem/createActionSystem.ts
+++ b/packages/client/src/network/systems/ActionSystem/createActionSystem.ts
@@ -87,7 +87,8 @@ export function createActionSystem<M = undefined>(
       updateAction({ state: ActionState.WaitingForTxEvents }); // pending
 
       if (tx) {
-        const txConfirmed = await tx.wait().catch((e: any) => handleError(e, request));
+        // const txConfirmed = await tx.wait().catch((e: any) => handleError(e, request));
+        const txConfirmed = await tx.wait();
         if (request.awaitConfirmation) await txConfirmed;
       }
 


### PR DESCRIPTION
reverted txs don't properly display the error during live execution, but is fine when estimatingGas. temp reverting the room move hardcoded gas till we figure out how to properly display revert() errors without pre-simulation.
