### PR TITLE
strong wait for embed wallet ready

### DIFF
--- a/packages/client/src/app/components/validators/WalletConnector.tsx
+++ b/packages/client/src/app/components/validators/WalletConnector.tsx
@@ -1,5 +1,10 @@
 import { ExternalProvider } from '@ethersproject/providers';
-import { ConnectedWallet, usePrivy, useWallets } from '@privy-io/react-auth';
+import {
+  ConnectedWallet,
+  getEmbeddedConnectedWallet,
+  usePrivy,
+  useWallets,
+} from '@privy-io/react-auth';
 import { switchChain } from '@wagmi/core';
 import { isEqual } from 'lodash';
 import { useEffect, useState } from 'react';
@@ -51,7 +56,7 @@ export function registerWalletConnecter() {
       // update network settings/validations on relevant network updates
       useEffect(() => {
         console.log({ walletsReady, wallets });
-        if (!ready) return;
+        if (!ready || !walletsReady) return;
         const chainMatches = chain?.id === DefaultChain.id;
         if (!isConnected) {
           setState('disconnected');
@@ -164,7 +169,7 @@ export function registerWalletConnecter() {
 
       // get the wallet labeled as 'embedded' from the list of privy ConnectedWallets
       const getEmbeddedWallet = (wallets: ConnectedWallet[]) => {
-        return wallets.find((w) => w.connectorType === 'embedded');
+        return getEmbeddedConnectedWallet(wallets);
       };
 
       const getTitle = () => {


### PR DESCRIPTION
hypothesis: embed wallet issue is a race condition, somehow

privy has two wallet hooks - `usePrivy`, and `useWallet`. `usePrivy` detects wallet addresses (providers), and `useWallet` signers. `useWallet` might take a bit more time to set up, but we're loading the network immediately after `usePrivy`. The embed wallet might be somehow lost in this process

Could have been possibly caused by the reverse map (speed update), which takes more compute initially. Maybe caused havok in some weaker puters? idk pls work
