### PR TITLE
load privy before mm

### DIFF
--- a/packages/client/src/app/components/validators/WalletConnector.tsx
+++ b/packages/client/src/app/components/validators/WalletConnector.tsx
@@ -121,9 +121,8 @@ export function registerWalletConnecter() {
         if (isUpdating || !injectedWallet || !embeddedWallet) return;
 
         // setIsUpdating(true);
-        // await new Promise((resolve) => setTimeout(resolve, 2000));
-        await addNetworkAPI(injectedWallet);
         await updateBaseNetwork(embeddedWallet);
+        await addNetworkAPI(injectedWallet);
         // setIsUpdating(false);
       };
 


### PR DESCRIPTION
new hypothesis: metamask provider dont resolve good. problem has been with injected wallets all this round, but we were focusing on embed. `create base layer` doesnt call at all - looks like injected connection lasts forever

if load embed first, maybe we can restore most functionality