### PR TITLE
Made background images not draggable

### DIFF
--- a/packages/client/src/app/components/canvas/Room.tsx
+++ b/packages/client/src/app/components/canvas/Room.tsx
@@ -88,7 +88,7 @@ export const Room = (props: Props) => {
   return (
     <Wrapper>
       <Container>
-        <Background src={getBackground()} />
+        <Background draggable='false' src={getBackground()} />
         {room.objects.map((object) => getClickbox(object))}
       </Container>
     </Wrapper>


### PR DESCRIPTION
Added draggable='false' to background images to avoid this:

https://github.com/user-attachments/assets/5d2f6d5c-f1e1-4e7c-b3b2-64a2970d314b


