### PR TITLE
LibReward for stats

### DIFF
--- a/packages/client/abi/_GoalRegistrySystem.json
+++ b/packages/client/abi/_GoalRegistrySystem.json
@@ -37,7 +37,64 @@
     },
     {
       "type": "function",
-      "name": "addReward",
+      "name": "addRewardBasic",
+      "inputs": [
+        {
+          "name": "arguments",
+          "type": "bytes",
+          "internalType": "bytes"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "addRewardDT",
+      "inputs": [
+        {
+          "name": "arguments",
+          "type": "bytes",
+          "internalType": "bytes"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "addRewardDisplay",
+      "inputs": [
+        {
+          "name": "arguments",
+          "type": "bytes",
+          "internalType": "bytes"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "addRewardStat",
       "inputs": [
         {
           "name": "arguments",
@@ -270,7 +327,10 @@
   ],
   "methodIdentifiers": {
     "addRequirement(bytes)": "7e534103",
-    "addReward(bytes)": "32007bd4",
+    "addRewardBasic(bytes)": "510b8052",
+    "addRewardDT(bytes)": "720c2ed5",
+    "addRewardDisplay(bytes)": "b47fc7ad",
+    "addRewardStat(bytes)": "071657f0",
     "cancelOwnershipHandover()": "54d1f13d",
     "completeOwnershipHandover(address)": "f04e283e",
     "create(bytes)": "cf5ba53f",

--- a/packages/client/abi/_NodeRegistrySystem.json
+++ b/packages/client/abi/_NodeRegistrySystem.json
@@ -55,7 +55,7 @@
     },
     {
       "type": "function",
-      "name": "addScavReward",
+      "name": "addScavRewardBasic",
       "inputs": [
         {
           "name": "arguments",
@@ -63,7 +63,51 @@
           "internalType": "bytes"
         }
       ],
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "addScavRewardDT",
+      "inputs": [
+        {
+          "name": "arguments",
+          "type": "bytes",
+          "internalType": "bytes"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "addScavRewardStat",
+      "inputs": [
+        {
+          "name": "arguments",
+          "type": "bytes",
+          "internalType": "bytes"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
       "stateMutability": "nonpayable"
     },
     {
@@ -283,7 +327,9 @@
   "methodIdentifiers": {
     "addRequirement(bytes)": "7e534103",
     "addScavBar(uint32,uint256)": "7ddddb19",
-    "addScavReward(bytes)": "6d8ca511",
+    "addScavRewardBasic(bytes)": "cffc49de",
+    "addScavRewardDT(bytes)": "080e18d5",
+    "addScavRewardStat(bytes)": "256ad62b",
     "cancelOwnershipHandover()": "54d1f13d",
     "completeOwnershipHandover(address)": "f04e283e",
     "create(bytes)": "cf5ba53f",

--- a/packages/client/abi/_QuestRegistrySystem.json
+++ b/packages/client/abi/_QuestRegistrySystem.json
@@ -85,7 +85,45 @@
     },
     {
       "type": "function",
-      "name": "addReward",
+      "name": "addRewardBasic",
+      "inputs": [
+        {
+          "name": "arguments",
+          "type": "bytes",
+          "internalType": "bytes"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "addRewardDT",
+      "inputs": [
+        {
+          "name": "arguments",
+          "type": "bytes",
+          "internalType": "bytes"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "addRewardStat",
       "inputs": [
         {
           "name": "arguments",
@@ -320,7 +358,9 @@
     "addAssigner(uint32,string,uint32)": "50465872",
     "addObjective(bytes)": "796c272f",
     "addRequirement(bytes)": "7e534103",
-    "addReward(bytes)": "32007bd4",
+    "addRewardBasic(bytes)": "510b8052",
+    "addRewardDT(bytes)": "720c2ed5",
+    "addRewardStat(bytes)": "071657f0",
     "cancelOwnershipHandover()": "54d1f13d",
     "completeOwnershipHandover(address)": "f04e283e",
     "create(bytes)": "cf5ba53f",

--- a/packages/client/src/network/shapes/Goals/types.ts
+++ b/packages/client/src/network/shapes/Goals/types.ts
@@ -13,6 +13,7 @@ import { getEntityByHash, hashArgs, queryChildrenOf, queryRefsWithParent } from 
 
 export interface Goal {
   id: EntityID;
+  entity: EntityIndex;
   index: number;
   name: string;
   description: string;
@@ -53,6 +54,7 @@ export const getGoal = (world: World, components: Components, entityIndex: Entit
 
   return {
     id: goalID,
+    entity: entityIndex,
     index: goalIndex,
     name: getComponentValue(Name, entityIndex)?.value || ('' as string),
     description: getComponentValue(Description, entityIndex)?.value || ('' as string),
@@ -61,7 +63,7 @@ export const getGoal = (world: World, components: Components, entityIndex: Entit
     requirements: getGoalRequirements(world, components, goalIndex),
     tiers: getGoalTiers(world, components, goalIndex),
     complete: hasComponent(IsComplete, entityIndex) || (false as boolean),
-    room: (getComponentValue(RoomIndex, entityIndex)?.value || (0 as number)) * 1,
+    room: getComponentValue(RoomIndex, entityIndex)?.value || (0 as number),
   };
 };
 
@@ -90,7 +92,7 @@ const getTier = (world: World, components: Components, entityIndex: EntityIndex)
   const { Name, Value } = components;
   const id = world.entities[entityIndex];
   return {
-    id: id,
+    id,
     name: getComponentValue(Name, entityIndex)?.value || ('' as string),
     cutoff: (getComponentValue(Value, entityIndex)?.value || (0 as number)) * 1,
     rewards: getTierRewards(world, components, id),

--- a/packages/client/types/ethers-contracts/_GoalRegistrySystem.ts
+++ b/packages/client/types/ethers-contracts/_GoalRegistrySystem.ts
@@ -31,7 +31,10 @@ import type {
 export interface _GoalRegistrySystemInterface extends utils.Interface {
   functions: {
     "addRequirement(bytes)": FunctionFragment;
-    "addReward(bytes)": FunctionFragment;
+    "addRewardBasic(bytes)": FunctionFragment;
+    "addRewardDT(bytes)": FunctionFragment;
+    "addRewardDisplay(bytes)": FunctionFragment;
+    "addRewardStat(bytes)": FunctionFragment;
     "cancelOwnershipHandover()": FunctionFragment;
     "completeOwnershipHandover(address)": FunctionFragment;
     "create(bytes)": FunctionFragment;
@@ -48,7 +51,10 @@ export interface _GoalRegistrySystemInterface extends utils.Interface {
   getFunction(
     nameOrSignatureOrTopic:
       | "addRequirement"
-      | "addReward"
+      | "addRewardBasic"
+      | "addRewardDT"
+      | "addRewardDisplay"
+      | "addRewardStat"
       | "cancelOwnershipHandover"
       | "completeOwnershipHandover"
       | "create"
@@ -67,7 +73,19 @@ export interface _GoalRegistrySystemInterface extends utils.Interface {
     values: [PromiseOrValue<BytesLike>]
   ): string;
   encodeFunctionData(
-    functionFragment: "addReward",
+    functionFragment: "addRewardBasic",
+    values: [PromiseOrValue<BytesLike>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "addRewardDT",
+    values: [PromiseOrValue<BytesLike>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "addRewardDisplay",
+    values: [PromiseOrValue<BytesLike>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "addRewardStat",
     values: [PromiseOrValue<BytesLike>]
   ): string;
   encodeFunctionData(
@@ -113,7 +131,22 @@ export interface _GoalRegistrySystemInterface extends utils.Interface {
     functionFragment: "addRequirement",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "addReward", data: BytesLike): Result;
+  decodeFunctionResult(
+    functionFragment: "addRewardBasic",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "addRewardDT",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "addRewardDisplay",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "addRewardStat",
+    data: BytesLike
+  ): Result;
   decodeFunctionResult(
     functionFragment: "cancelOwnershipHandover",
     data: BytesLike
@@ -229,7 +262,22 @@ export interface _GoalRegistrySystem extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
-    addReward(
+    addRewardBasic(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    addRewardDT(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    addRewardDisplay(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    addRewardStat(
       arguments: PromiseOrValue<BytesLike>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
@@ -288,7 +336,22 @@ export interface _GoalRegistrySystem extends BaseContract {
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
-  addReward(
+  addRewardBasic(
+    arguments: PromiseOrValue<BytesLike>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  addRewardDT(
+    arguments: PromiseOrValue<BytesLike>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  addRewardDisplay(
+    arguments: PromiseOrValue<BytesLike>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  addRewardStat(
     arguments: PromiseOrValue<BytesLike>,
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
@@ -347,7 +410,22 @@ export interface _GoalRegistrySystem extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    addReward(
+    addRewardBasic(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
+    addRewardDT(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
+    addRewardDisplay(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
+    addRewardStat(
       arguments: PromiseOrValue<BytesLike>,
       overrides?: CallOverrides
     ): Promise<BigNumber>;
@@ -427,7 +505,22 @@ export interface _GoalRegistrySystem extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
-    addReward(
+    addRewardBasic(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    addRewardDT(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    addRewardDisplay(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    addRewardStat(
       arguments: PromiseOrValue<BytesLike>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
@@ -487,7 +580,22 @@ export interface _GoalRegistrySystem extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 
-    addReward(
+    addRewardBasic(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    addRewardDT(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    addRewardDisplay(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    addRewardStat(
       arguments: PromiseOrValue<BytesLike>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;

--- a/packages/client/types/ethers-contracts/_NodeRegistrySystem.ts
+++ b/packages/client/types/ethers-contracts/_NodeRegistrySystem.ts
@@ -32,7 +32,9 @@ export interface _NodeRegistrySystemInterface extends utils.Interface {
   functions: {
     "addRequirement(bytes)": FunctionFragment;
     "addScavBar(uint32,uint256)": FunctionFragment;
-    "addScavReward(bytes)": FunctionFragment;
+    "addScavRewardBasic(bytes)": FunctionFragment;
+    "addScavRewardDT(bytes)": FunctionFragment;
+    "addScavRewardStat(bytes)": FunctionFragment;
     "cancelOwnershipHandover()": FunctionFragment;
     "completeOwnershipHandover(address)": FunctionFragment;
     "create(bytes)": FunctionFragment;
@@ -50,7 +52,9 @@ export interface _NodeRegistrySystemInterface extends utils.Interface {
     nameOrSignatureOrTopic:
       | "addRequirement"
       | "addScavBar"
-      | "addScavReward"
+      | "addScavRewardBasic"
+      | "addScavRewardDT"
+      | "addScavRewardStat"
       | "cancelOwnershipHandover"
       | "completeOwnershipHandover"
       | "create"
@@ -73,7 +77,15 @@ export interface _NodeRegistrySystemInterface extends utils.Interface {
     values: [PromiseOrValue<BigNumberish>, PromiseOrValue<BigNumberish>]
   ): string;
   encodeFunctionData(
-    functionFragment: "addScavReward",
+    functionFragment: "addScavRewardBasic",
+    values: [PromiseOrValue<BytesLike>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "addScavRewardDT",
+    values: [PromiseOrValue<BytesLike>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "addScavRewardStat",
     values: [PromiseOrValue<BytesLike>]
   ): string;
   encodeFunctionData(
@@ -121,7 +133,15 @@ export interface _NodeRegistrySystemInterface extends utils.Interface {
   ): Result;
   decodeFunctionResult(functionFragment: "addScavBar", data: BytesLike): Result;
   decodeFunctionResult(
-    functionFragment: "addScavReward",
+    functionFragment: "addScavRewardBasic",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "addScavRewardDT",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "addScavRewardStat",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
@@ -245,7 +265,17 @@ export interface _NodeRegistrySystem extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
-    addScavReward(
+    addScavRewardBasic(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    addScavRewardDT(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    addScavRewardStat(
       arguments: PromiseOrValue<BytesLike>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
@@ -310,7 +340,17 @@ export interface _NodeRegistrySystem extends BaseContract {
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
-  addScavReward(
+  addScavRewardBasic(
+    arguments: PromiseOrValue<BytesLike>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  addScavRewardDT(
+    arguments: PromiseOrValue<BytesLike>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  addScavRewardStat(
     arguments: PromiseOrValue<BytesLike>,
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
@@ -375,10 +415,20 @@ export interface _NodeRegistrySystem extends BaseContract {
       overrides?: CallOverrides
     ): Promise<void>;
 
-    addScavReward(
+    addScavRewardBasic(
       arguments: PromiseOrValue<BytesLike>,
       overrides?: CallOverrides
-    ): Promise<void>;
+    ): Promise<BigNumber>;
+
+    addScavRewardDT(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
+    addScavRewardStat(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
 
     cancelOwnershipHandover(overrides?: CallOverrides): Promise<void>;
 
@@ -461,7 +511,17 @@ export interface _NodeRegistrySystem extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
-    addScavReward(
+    addScavRewardBasic(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    addScavRewardDT(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    addScavRewardStat(
       arguments: PromiseOrValue<BytesLike>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
@@ -527,7 +587,17 @@ export interface _NodeRegistrySystem extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 
-    addScavReward(
+    addScavRewardBasic(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    addScavRewardDT(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    addScavRewardStat(
       arguments: PromiseOrValue<BytesLike>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;

--- a/packages/client/types/ethers-contracts/_QuestRegistrySystem.ts
+++ b/packages/client/types/ethers-contracts/_QuestRegistrySystem.ts
@@ -33,7 +33,9 @@ export interface _QuestRegistrySystemInterface extends utils.Interface {
     "addAssigner(uint32,string,uint32)": FunctionFragment;
     "addObjective(bytes)": FunctionFragment;
     "addRequirement(bytes)": FunctionFragment;
-    "addReward(bytes)": FunctionFragment;
+    "addRewardBasic(bytes)": FunctionFragment;
+    "addRewardDT(bytes)": FunctionFragment;
+    "addRewardStat(bytes)": FunctionFragment;
     "cancelOwnershipHandover()": FunctionFragment;
     "completeOwnershipHandover(address)": FunctionFragment;
     "create(bytes)": FunctionFragment;
@@ -52,7 +54,9 @@ export interface _QuestRegistrySystemInterface extends utils.Interface {
       | "addAssigner"
       | "addObjective"
       | "addRequirement"
-      | "addReward"
+      | "addRewardBasic"
+      | "addRewardDT"
+      | "addRewardStat"
       | "cancelOwnershipHandover"
       | "completeOwnershipHandover"
       | "create"
@@ -83,7 +87,15 @@ export interface _QuestRegistrySystemInterface extends utils.Interface {
     values: [PromiseOrValue<BytesLike>]
   ): string;
   encodeFunctionData(
-    functionFragment: "addReward",
+    functionFragment: "addRewardBasic",
+    values: [PromiseOrValue<BytesLike>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "addRewardDT",
+    values: [PromiseOrValue<BytesLike>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "addRewardStat",
     values: [PromiseOrValue<BytesLike>]
   ): string;
   encodeFunctionData(
@@ -137,7 +149,18 @@ export interface _QuestRegistrySystemInterface extends utils.Interface {
     functionFragment: "addRequirement",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "addReward", data: BytesLike): Result;
+  decodeFunctionResult(
+    functionFragment: "addRewardBasic",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "addRewardDT",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "addRewardStat",
+    data: BytesLike
+  ): Result;
   decodeFunctionResult(
     functionFragment: "cancelOwnershipHandover",
     data: BytesLike
@@ -265,7 +288,17 @@ export interface _QuestRegistrySystem extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
-    addReward(
+    addRewardBasic(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    addRewardDT(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    addRewardStat(
       arguments: PromiseOrValue<BytesLike>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
@@ -336,7 +369,17 @@ export interface _QuestRegistrySystem extends BaseContract {
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
-  addReward(
+  addRewardBasic(
+    arguments: PromiseOrValue<BytesLike>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  addRewardDT(
+    arguments: PromiseOrValue<BytesLike>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  addRewardStat(
     arguments: PromiseOrValue<BytesLike>,
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
@@ -407,7 +450,17 @@ export interface _QuestRegistrySystem extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    addReward(
+    addRewardBasic(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
+    addRewardDT(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
+    addRewardStat(
       arguments: PromiseOrValue<BytesLike>,
       overrides?: CallOverrides
     ): Promise<BigNumber>;
@@ -499,7 +552,17 @@ export interface _QuestRegistrySystem extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
-    addReward(
+    addRewardBasic(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    addRewardDT(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    addRewardStat(
       arguments: PromiseOrValue<BytesLike>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
@@ -571,7 +634,17 @@ export interface _QuestRegistrySystem extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 
-    addReward(
+    addRewardBasic(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    addRewardDT(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    addRewardStat(
       arguments: PromiseOrValue<BytesLike>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;

--- a/packages/contracts/deploy.json
+++ b/packages/contracts/deploy.json
@@ -101,6 +101,8 @@
       "writeAccess": [
         "EntityType",
         "Description",
+        "Health",
+        "Harmony",
         "IDParent",
         "IsComplete",
         "Index",
@@ -110,9 +112,13 @@
         "Keys",
         "Name",
         "Type",
+        "Power",
         "Value",
+        "Violence",
         "Weights",
-        "Subtype"
+        "Subtype",
+        "Slots",
+        "Stamina"
       ]
     },
     {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -25,7 +25,7 @@
     "deprecate:local": "pnpm deprecate:script --mode DEV",
     "deprecate:testnet": "pnpm deprecate:script --mode TEST --forgeOpts='-g=300'",
     "world:state:local": "pnpm world:state:script --mode DEV",
-    "world:state:testnet": "pnpm world:state:script --mode TEST --forgeOpts='-g=300'",
+    "world:state:testnet": "pnpm world:state:script --mode TEST --forgeOpts='-g=300 --skip-simulation'",
     "world:state:caldera": "pnpm world:state:script --mode CALDERA",
     "call:system:local": "pnpm call:system:script --mode DEV",
     "call:system:testnet": "pnpm call:system:script --mode TEST --forgeOpts='-g=300 --skip-simulation'",

--- a/packages/contracts/src/deployment/world/admin.ts
+++ b/packages/contracts/src/deployment/world/admin.ts
@@ -119,32 +119,53 @@ export function createAdminAPI(compiledCalls: string[]) {
     );
   }
 
-  async function createGoalReward(
+  async function createGoalRewardBasic(
     goalIndex: number,
     name: string,
     cutoff: number,
     type: string,
-    logic: string,
     conIndex: number,
-    keys: number[],
-    weights: number[],
     conValue: number
   ) {
     genCall(
       'system.goal.registry',
-      [goalIndex, name, cutoff, type, logic, conIndex, keys, weights, conValue],
-      'addReward',
-      [
-        'uint32',
-        'string',
-        'uint256',
-        'string',
-        'string',
-        'uint32',
-        'uint32[]',
-        'uint256[]',
-        'uint256',
-      ]
+      [goalIndex, name, cutoff, type, conIndex, conValue],
+      'addRewardBasic',
+      ['uint32', 'string', 'uint256', 'string', 'uint32', 'uint256']
+    );
+  }
+
+  async function createGoalRewardDisplay(goalIndex: number, name: string) {
+    genCall('system.goal.registry', [goalIndex, name], 'addRewardDisplay', ['uint32', 'string']);
+  }
+
+  async function createGoalRewardDT(
+    goalIndex: number,
+    keys: number[],
+    weights: number[],
+    conValue: number
+  ) {
+    genCall('system.goal.registry', [goalIndex, keys, weights, conValue], 'addRewardDT', [
+      'uint32',
+      'uint32[]',
+      'uint256[]',
+      'uint256',
+    ]);
+  }
+
+  async function createGoalRewardStat(
+    goalIndex: number,
+    statType: string,
+    base: number,
+    shift: number,
+    boost: number,
+    sync: number
+  ) {
+    genCall(
+      'system.goal.registry',
+      [goalIndex, statType, base, shift, boost, sync],
+      'addRewardStat',
+      ['uint32', 'string', 'int32', 'int32', 'int32', 'int32']
     );
   }
 
@@ -284,20 +305,32 @@ export function createAdminAPI(compiledCalls: string[]) {
     genCall('system.node.registry', [index, tierCost], 'addScavBar');
   }
 
-  async function addNodeScavReward(
+  async function addNodeScavRewardBasic(
     nodeIndex: number,
     type: string,
     index: number,
+    value: number
+  ) {
+    genCall('system.node.registry', [nodeIndex, type, index, value], 'addScavRewardBasic', [
+      'uint32',
+      'string',
+      'uint32',
+      'uint256',
+    ]);
+  }
+
+  async function addNodeScavRewardDT(
+    nodeIndex: number,
     keys: number[],
     weights: number[],
     value: number
   ) {
-    genCall(
-      'system.node.registry',
-      [nodeIndex, type, index, keys, weights, value],
-      'addScavReward',
-      ['uint32', 'string', 'uint32', 'uint32[]', 'uint256[]', 'uint256']
-    );
+    genCall('system.node.registry', [nodeIndex, keys, weights, value], 'addScavRewardDT', [
+      'uint32',
+      'uint32[]',
+      'uint256[]',
+      'uint256',
+    ]);
   }
 
   // @dev deletes node
@@ -366,22 +399,48 @@ export function createAdminAPI(compiledCalls: string[]) {
   }
 
   // creates a Reward for an existing Quest
-  async function addQuestReward(
+  async function addQuestRewardBasic(
     questIndex: number,
     type: string,
     index: number,
+    value: BigNumberish
+  ) {
+    genCall('system.quest.registry', [questIndex, type, index, value], 'addRewardBasic', [
+      'uint32',
+      'string',
+      'uint32',
+      'uint256',
+    ]);
+  }
+
+  async function addQuestRewardDT(
+    questIndex: number,
     keys: number[],
     weights: number[],
     value: BigNumberish
   ) {
-    genCall('system.quest.registry', [questIndex, type, index, keys, weights, value], 'addReward', [
-      'uint32',
-      'string',
+    genCall('system.quest.registry', [questIndex, keys, weights, value], 'addRewardDT', [
       'uint32',
       'uint32[]',
       'uint256[]',
       'uint256',
     ]);
+  }
+
+  async function addQuestRewardStat(
+    questIndex: number,
+    statType: string,
+    base: number,
+    shift: number,
+    boost: number,
+    sync: number
+  ) {
+    genCall(
+      'system.quest.registry',
+      [questIndex, statType, base, shift, boost, sync],
+      'addRewardStat',
+      ['uint32', 'string', 'int32', 'int32', 'int32', 'int32']
+    );
   }
 
   /////////////////
@@ -677,7 +736,12 @@ export function createAdminAPI(compiledCalls: string[]) {
       create: createGoal,
       add: {
         requirement: createGoalRequirement,
-        reward: createGoalReward,
+        reward: {
+          basic: createGoalRewardBasic,
+          display: createGoalRewardDisplay,
+          droptable: createGoalRewardDT,
+          stat: createGoalRewardStat,
+        },
       },
       delete: deleteGoal,
     },
@@ -693,7 +757,10 @@ export function createAdminAPI(compiledCalls: string[]) {
       add: {
         requirement: createNodeRequirement,
         scav: createNodeScav,
-        scavReward: addNodeScavReward,
+        scavReward: {
+          basic: addNodeScavRewardBasic,
+          droptable: addNodeScavRewardDT,
+        },
       },
       delete: deleteNode,
     },
@@ -737,7 +804,11 @@ export function createAdminAPI(compiledCalls: string[]) {
         add: {
           objective: addQuestObjective,
           requirement: addQuestRequirement,
-          reward: addQuestReward,
+          reward: {
+            basic: addQuestRewardBasic,
+            droptable: addQuestRewardDT,
+            stat: addQuestRewardStat,
+          },
         },
       },
       recipe: {

--- a/packages/contracts/src/deployment/world/state/goals.ts
+++ b/packages/contracts/src/deployment/world/state/goals.ts
@@ -14,13 +14,13 @@ export async function initGoals(api: AdminAPI) {
     MUSU_INDEX,
     50000
   );
-  await api.goal.add.reward(1, 'Community', 0, 'Door unlock', 'DISPLAY_ONLY', 0, [], [], 0);
-  await api.goal.add.reward(1, 'Bronze', 50, 'ITEM', 'REWARD', 11201, [], [], 1);
-  await api.goal.add.reward(1, 'Bronze', 50, 'REPUTATION', 'REWARD', 1, [], [], 5);
-  await api.goal.add.reward(1, 'Silver', 250, 'ITEM', 'REWARD', 11202, [], [], 2);
-  await api.goal.add.reward(1, 'Silver', 250, 'REPUTATION', 'REWARD', 1, [], [], 5);
-  await api.goal.add.reward(1, 'Gold', 500, 'ITEM', 'REWARD', 11203, [], [], 3);
-  await api.goal.add.reward(1, 'Gold', 500, 'REPUTATION', 'REWARD', 1, [], [], 10);
+  await api.goal.add.reward.display(1, 'Door unlock');
+  await api.goal.add.reward.basic(1, 'Bronze', 50, 'ITEM', 11201, 1);
+  await api.goal.add.reward.basic(1, 'Bronze', 50, 'REPUTATION', 1, 5);
+  await api.goal.add.reward.basic(1, 'Silver', 250, 'ITEM', 11202, 2);
+  await api.goal.add.reward.basic(1, 'Silver', 250, 'REPUTATION', 1, 5);
+  await api.goal.add.reward.basic(1, 'Gold', 500, 'ITEM', 11203, 3);
+  await api.goal.add.reward.basic(1, 'Gold', 500, 'REPUTATION', 1, 10);
 
   await api.goal.create(
     2,
@@ -34,10 +34,10 @@ export async function initGoals(api: AdminAPI) {
     MUSU_INDEX,
     500000
   );
-  await api.goal.add.reward(2, 'Community', 0, 'Door unlock', 'DISPLAY_ONLY', 0, [], [], 0);
-  await api.goal.add.reward(2, 'Bronze', 500, 'REPUTATION', 'REWARD', 1, [], [], 5);
-  await api.goal.add.reward(2, 'Silver', 2500, 'REPUTATION', 'REWARD', 1, [], [], 10);
-  await api.goal.add.reward(2, 'Gold', 5000, 'REPUTATION', 'REWARD', 1, [], [], 10);
+  await api.goal.add.reward.display(2, 'Door unlock');
+  await api.goal.add.reward.basic(2, 'Bronze', 500, 'REPUTATION', 1, 5);
+  await api.goal.add.reward.basic(2, 'Silver', 2500, 'REPUTATION', 1, 10);
+  await api.goal.add.reward.basic(2, 'Gold', 5000, 'REPUTATION', 1, 10);
 
   await api.goal.create(
     3,
@@ -51,11 +51,11 @@ export async function initGoals(api: AdminAPI) {
     MUSU_INDEX,
     1000000
   );
-  await api.goal.add.reward(3, 'Community', 0, 'Door unlock', 'DISPLAY_ONLY', 0, [], [], 0);
-  await api.goal.add.reward(3, 'Bronze', 1000, 'REPUTATION', 'REWARD', 1, [], [], 5);
-  await api.goal.add.reward(3, 'Bronze', 1000, 'ITEM', 'REWARD', 11203, [], [], 1);
-  await api.goal.add.reward(3, 'Silver', 5000, 'REPUTATION', 'REWARD', 1, [], [], 5);
-  await api.goal.add.reward(3, 'Gold', 10000, 'REPUTATION', 'REWARD', 1, [], [], 10);
+  await api.goal.add.reward.display(3, 'Door unlock');
+  await api.goal.add.reward.basic(3, 'Bronze', 1000, 'REPUTATION', 1, 5);
+  await api.goal.add.reward.basic(3, 'Bronze', 1000, 'ITEM', 11203, 1);
+  await api.goal.add.reward.basic(3, 'Silver', 5000, 'REPUTATION', 1, 5);
+  await api.goal.add.reward.basic(3, 'Gold', 10000, 'REPUTATION', 1, 10);
 
   // await api.goal.create(
   //   4,
@@ -69,12 +69,12 @@ export async function initGoals(api: AdminAPI) {
   //   11008, // pine cones
   //   1000
   // );
-  // await api.goal.add.reward(4, 'Bronze', 1, 'REPUTATION', 'REWARD', 1, [], [], 5);
-  // await api.goal.add.reward(4, 'Bronze', 1, 'ITEM', 'REWARD', 11005, [], [], 5);
-  // await api.goal.add.reward(4, 'Silver', 5, 'REPUTATION', 'REWARD', 1, [], [], 5);
-  // await api.goal.add.reward(4, 'Silver', 5, 'ITEM', 'REWARD', 20001, [], [], 1);
-  // await api.goal.add.reward(4, 'Gold', 20, 'REPUTATION', 'REWARD', 1, [], [], 5);
-  // await api.goal.add.reward(4, 'Gold', 20, 'ITEM', 'REWARD', 112, [], [], 2);
+  // await api.goal.add.reward.basic(4, 'Bronze', 1, 'REPUTATION', 1, 5);
+  // await api.goal.add.reward.basic(4, 'Bronze', 1, 'ITEM', 11005, 5);
+  // await api.goal.add.reward.basic(4, 'Silver', 5, 'REPUTATION', 1, 5);
+  // await api.goal.add.reward.basic(4, 'Silver', 5, 'ITEM', 20001, 1);
+  // await api.goal.add.reward.basic(4, 'Gold', 20, 'REPUTATION', 1, 5);
+  // await api.goal.add.reward.basic(4, 'Gold', 20, 'ITEM', 112, 2);
 
   await api.goal.create(
     5,
@@ -88,22 +88,12 @@ export async function initGoals(api: AdminAPI) {
     MUSU_INDEX,
     1500000
   );
-  await api.goal.add.reward(
-    5,
-    'Community',
-    0,
-    'Shop Inventory Expanded',
-    'DISPLAY_ONLY',
-    0,
-    [],
-    [],
-    0
-  );
-  await api.goal.add.reward(5, 'Bronze', 1000, 'REPUTATION', 'REWARD', 2, [], [], 5);
-  await api.goal.add.reward(5, 'Bronze', 1000, 'ITEM', 'REWARD', 21100, [], [], 10);
-  await api.goal.add.reward(5, 'Silver', 5000, 'REPUTATION', 'REWARD', 2, [], [], 10);
-  await api.goal.add.reward(5, 'Silver', 5000, 'ITEM', 'REWARD', 11204, [], [], 3);
-  await api.goal.add.reward(5, 'Gold', 20000, 'REPUTATION', 'REWARD', 2, [], [], 10);
+  await api.goal.add.reward.display(5, 'Shop Inventory Expanded');
+  await api.goal.add.reward.basic(5, 'Bronze', 1000, 'REPUTATION', 2, 5);
+  await api.goal.add.reward.basic(5, 'Bronze', 1000, 'ITEM', 21100, 10);
+  await api.goal.add.reward.basic(5, 'Silver', 5000, 'REPUTATION', 2, 10);
+  await api.goal.add.reward.basic(5, 'Silver', 5000, 'ITEM', 11204, 3);
+  await api.goal.add.reward.basic(5, 'Gold', 20000, 'REPUTATION', 2, 10);
 
   await api.goal.create(
     6,
@@ -115,11 +105,11 @@ export async function initGoals(api: AdminAPI) {
     MUSU_INDEX,
     2500000
   );
-  await api.goal.add.reward(6, 'Community', 0, 'Door unlock', 'DISPLAY_ONLY', 0, [], [], 0);
-  await api.goal.add.reward(6, 'Bronze', 2500, 'REPUTATION', 'REWARD', 1, [], [], 10);
-  await api.goal.add.reward(6, 'Bronze', 2500, 'ITEM', 'REWARD', 11204, [], [], 1);
-  await api.goal.add.reward(6, 'Silver', 7500, 'REPUTATION', 'REWARD', 1, [], [], 10);
-  await api.goal.add.reward(6, 'Gold', 25000, 'REPUTATION', 'REWARD', 1, [], [], 5);
+  await api.goal.add.reward.display(6, 'Door unlock');
+  await api.goal.add.reward.basic(6, 'Bronze', 2500, 'REPUTATION', 1, 10);
+  await api.goal.add.reward.basic(6, 'Bronze', 2500, 'ITEM', 11204, 1);
+  await api.goal.add.reward.basic(6, 'Silver', 7500, 'REPUTATION', 1, 10);
+  await api.goal.add.reward.basic(6, 'Gold', 25000, 'REPUTATION', 1, 5);
 
   // await api.goal.create(
   //   7,
@@ -131,9 +121,9 @@ export async function initGoals(api: AdminAPI) {
   //   MUSU_INDEX,
   //   250000
   // );
-  // await api.goal.add.reward(7, 'Bronze', 1000, 'REPUTATION', 'REWARD', 1, [], [], 5);
-  // await api.goal.add.reward(7, 'Silver', 2500, 'REPUTATION', 'REWARD', 1, [], [], 5);
-  // await api.goal.add.reward(7, 'Gold', 5000, 'REPUTATION', 'REWARD', 1, [], [], 5);
+  // await api.goal.add.reward.basic(7, 'Bronze', 1000, 'REPUTATION', 1, 5);
+  // await api.goal.add.reward.basic(7, 'Silver', 2500, 'REPUTATION', 1, 5);
+  // await api.goal.add.reward.basic(7, 'Gold', 5000, 'REPUTATION', 1, 5);
 }
 
 export async function deleteGoals(api: AdminAPI, indices: number[]) {

--- a/packages/contracts/src/deployment/world/state/nodes.ts
+++ b/packages/contracts/src/deployment/world/state/nodes.ts
@@ -78,10 +78,8 @@ async function initRequirement(api: AdminAPI, entry: any) {
 // creates both scavBar and its reward at once. assumes each scav bar only has one reward, a DT
 async function initScavBar(api: AdminAPI, entry: any) {
   await api.node.add.scav(Number(entry['Index']), Number(entry['Scav Cost']));
-  await api.node.add.scavReward(
+  await api.node.add.scavReward.droptable(
     Number(entry['Index']),
-    'ITEM_DROPTABLE',
-    0,
     textToNumberArray(entry['Item Drop Indices']),
     textToNumberArray(entry['Item Drop Weights']),
     1

--- a/packages/contracts/src/deployment/world/state/quests.ts
+++ b/packages/contracts/src/deployment/world/state/quests.ts
@@ -39,7 +39,7 @@ export async function initLocalQuests(api: AdminAPI) {
     'Was it really worth it?',
     0
   );
-  api.registry.quest.add.reward(1000000, 'ITEM', GACHA_TICKET_INDEX, [], [], 111); // 111 tickets
+  api.registry.quest.add.reward.basic(1000000, 'ITEM', GACHA_TICKET_INDEX, 111); // 111 tickets
 }
 
 export async function deleteQuests(api: AdminAPI, indices: number[]) {
@@ -77,7 +77,7 @@ async function initQuest(api: AdminAPI, entry: any) {
 
   const agencyRep = Number(entry['REPUTATION']);
   if (agencyRep || agencyRep > 0) {
-    await api.registry.quest.add.reward(Number(entry['Index']), 'REPUTATION', 1, [], [], agencyRep);
+    await api.registry.quest.add.reward.basic(Number(entry['Index']), 'REPUTATION', 1, agencyRep);
   }
 }
 
@@ -121,12 +121,10 @@ async function initQuestReward(api: AdminAPI, entry: any) {
     Number(entry['IndexFor'] ?? 0),
     Number(entry['ValueFor'] ?? 0)
   );
-  await api.registry.quest.add.reward(
+  await api.registry.quest.add.reward.basic(
     Number(entry['Index']),
     cond.type,
     cond.index,
-    [],
-    [],
     cond.value
   );
 }

--- a/packages/contracts/src/libraries/LibGoals.sol
+++ b/packages/contracts/src/libraries/LibGoals.sol
@@ -105,49 +105,6 @@ library LibGoals {
     id = LibConditional.createFor(world, components, requirement, genReqParentID(goalIndex));
   }
 
-  /// @notice adds a reward to a goal
-  /**  @dev
-   * - Rewards (e.g. coins, items, etc)
-   *   - Tiered - eg Bronze, Silver, Gold
-   *     - Higher tiers also recieve lower tier rewards (eg Gold gets Gold + Silver + Bronze)
-   *     - Uses LevelComp as the min contribution to qualify for a tier
-   *       - eg Bronze LevelComp = 100, contribution >= 100 to qualify for Bronze
-   *   - Shape: Condition + Level + Name
-   *     - Condition shape handles reward type and quantity
-   *     - Logic type is either "REWARD" or "DISPLAY_ONLY"
-   *
-   * RewardIDs override deterministic LibReward generation, to allow for differing reward levels
-   */
-  /// @param tier needed to qualify for tier; "DISPLAY_ONLY" do not have this
-  function addReward(
-    IWorld world,
-    IUintComp components,
-    uint32 goalIndex,
-    string memory name,
-    uint256 tier, // level comp
-    string memory logic,
-    string memory type_,
-    uint32 index,
-    uint32[] memory keys,
-    uint256[] memory weights,
-    uint256 value
-  ) internal returns (uint256 id) {
-    uint256 parentID = genRwdParentID(createTier(components, goalIndex, name, tier));
-    if (index == 0) {
-      // override index for deterministic ID generation if no index provided
-      // for ITEM_DROPTABLE or DISPLAY_ONLY
-      id = LibReward.genID(
-        parentID,
-        type_,
-        LibReward.getIndexOverride(components, parentID, type_) // quantity of same type
-      );
-    } else {
-      id = LibReward.genID(parentID, type_, index);
-    }
-
-    LibReward._create(components, id, parentID, type_, index, keys, weights, value);
-  }
-
   function remove(IUintComp components, uint32 index) internal {
     uint256 goalID = genGoalID(index);
     LibEntityType.remove(components, goalID);

--- a/packages/contracts/src/libraries/LibItem.sol
+++ b/packages/contracts/src/libraries/LibItem.sol
@@ -84,13 +84,7 @@ library LibItem {
   function addStat(IUintComp components, uint256 id, string memory type_, int32 value) internal {
     if (type_.eq("XP"))
       ExperienceComponent(getAddrByID(components, ExpCompID)).set(id, value.toUint256());
-    else if (type_.eq("HEALTH")) LibStat.setHealth(components, id, Stat(0, 0, 0, value));
-    else if (type_.eq("MAXHEALTH")) LibStat.setHealth(components, id, Stat(0, value, 0, 0));
-    else if (type_.eq("POWER")) LibStat.setPower(components, id, Stat(0, value, 0, 0));
-    else if (type_.eq("VIOLENCE")) LibStat.setViolence(components, id, Stat(0, value, 0, 0));
-    else if (type_.eq("HARMONY")) LibStat.setHarmony(components, id, Stat(0, value, 0, 0));
-    else if (type_.eq("STAMINA")) LibStat.setStamina(components, id, Stat(0, 0, 0, value));
-    else revert("LibItem: invalid stat");
+    else LibStat.setFor(components, id, type_, value);
   }
 
   /// @notice delete a Registry entry for an item.
@@ -105,12 +99,7 @@ library LibItem {
     TypeComponent(getAddrByID(components, TypeCompID)).remove(id);
     MediaURIComponent(getAddrByID(components, MediaURICompID)).remove(id);
 
-    LibStat.unsetHealth(components, id);
-    LibStat.unsetPower(components, id);
-    LibStat.unsetViolence(components, id);
-    LibStat.unsetHarmony(components, id);
-    LibStat.unsetSlots(components, id);
-    LibStat.unsetStamina(components, id);
+    LibStat.removeAll(components, id);
     ExperienceComponent(getAddrByID(components, ExpCompID)).remove(id);
 
     LibDroptable.remove(components, id);

--- a/packages/contracts/src/libraries/LibQuestRegistry.sol
+++ b/packages/contracts/src/libraries/LibQuestRegistry.sol
@@ -76,28 +76,6 @@ library LibQuestRegistry {
     id = LibConditional.createFor(world, components, data, genReqParentID(questIndex));
   }
 
-  /// @notice creates a basic reward entity
-  function createReward(
-    IWorld world,
-    IUintComp components,
-    uint32 questIndex,
-    string memory type_,
-    uint32 index,
-    uint32[] memory keys,
-    uint256[] memory weights,
-    uint256 value
-  ) internal returns (uint256 id) {
-    id = LibReward.create(
-      components,
-      genRwdParentID(questIndex),
-      type_,
-      index,
-      keys,
-      weights,
-      value
-    );
-  }
-
   function addAssigner(
     IUintComp components,
     uint256 questID,

--- a/packages/contracts/src/libraries/LibScavenge.sol
+++ b/packages/contracts/src/libraries/LibScavenge.sol
@@ -50,20 +50,6 @@ library LibScavenge {
     TypeComponent(getAddrByID(components, TypeCompID)).set(id, field);
   }
 
-  /// @notice reward per tier
-  function addReward(
-    IWorld world,
-    IUintComp components,
-    uint256 regID,
-    string memory type_,
-    uint32 rwdIndex,
-    uint32[] memory keys,
-    uint256[] memory weights,
-    uint256 value
-  ) internal returns (uint256 id) {
-    id = LibReward.create(components, genRwdParentID(regID), type_, rwdIndex, keys, weights, value);
-  }
-
   function remove(IUintComp components, uint256 id) internal {
     IndexComponent(getAddrByID(components, IndexCompID)).remove(id);
     IsRegistryComponent(getAddrByID(components, IsRegCompID)).remove(id);

--- a/packages/contracts/src/test/systems/Goals.t.sol
+++ b/packages/contracts/src/test/systems/Goals.t.sol
@@ -25,20 +25,17 @@ contract GoalsTest is SetupTemplate {
     uint256 goalID = _createGoal(1, 0, Condition("type", "logic", 0, 0));
     uint256 requirementID1 = _createGoalRequirement(1, Condition("type", "logic", 1, 0));
     uint256 requirementID2 = _createGoalRequirement(1, Condition("type", "logic", 2, 0));
-    uint256 rewardID1 = _createGoalReward(1, 0, Condition("type", "REWARD", 1, 0));
-    uint256 rewardID2 = _createGoalReward(1, 100, Condition("type", "REWARD", 2, 0));
-    uint256 rewardID3 = _createGoalReward(1, 200, Condition("type", "DISPLAY_ONLY", 0, 0));
-    // uint256 rewardID4 = _createGoalReward(1, 200, Condition("type", "DISPLAY_ONLY", 0, 0));
-    // uint256 rewardID5 = _createGoalReward(1, 200, Condition("type", "DISPLAY_ONLY", 0, 0));
+    uint256 rewardID1 = _createGoalRewardBasic(1, 100, "type", 1, 0);
+    uint256 rewardID2 = _createGoalRewardBasic(1, 200, "type", 2, 0);
+    uint256 rewardID3 = _createGoalRewardDisplay(1, "name");
+    uint256 rewardID4 = _createGoalRewardDisplay(1, "name");
+    uint256 rewardID5 = _createGoalRewardDisplay(1, "name");
 
     // checking tiers
     uint256[] memory tiers = LibGoals.getTiers(components, goalIndex);
     assertEq(tiers.length, 3, "wrong tier count");
-    for (uint256 i; i < tiers.length; i++) {
-      assertEq(LibReward.queryFor(components, LibGoals.genRwdParentID(tiers[i])).length, 1);
-    }
     uint256[] memory rewards = LibGoals.getRewards(components, tiers);
-    assertEq(rewards.length, 3, "wrong reward count");
+    assertEq(rewards.length, 5, "wrong reward count");
 
     vm.prank(deployer);
     __GoalRegistrySystem.remove(goalIndex);
@@ -56,10 +53,10 @@ contract GoalsTest is SetupTemplate {
       0,
       Condition("ITEM", "CURR_MIN", MUSU_INDEX, targetAmt)
     );
-    uint256 rwdBronze = _createGoalReward(goalIndex, 100, Condition("ITEM", "REWARD", 100, 1));
-    uint256 rwdSilver = _createGoalReward(goalIndex, 200, Condition("ITEM", "REWARD", 200, 1));
-    uint256 rwdGold = _createGoalReward(goalIndex, 300, Condition("ITEM", "REWARD", 300, 1));
-    uint256 rwdDisplay = _createGoalReward(goalIndex, 0, Condition("ITEM", "DISPLAY_ONLY", 3, 1));
+    uint256 rwdBronze = _createGoalRewardBasic(goalIndex, 100, "ITEM", 100, 1);
+    uint256 rwdSilver = _createGoalRewardBasic(goalIndex, 200, "ITEM", 200, 1);
+    uint256 rwdGold = _createGoalRewardBasic(goalIndex, 300, "ITEM", 300, 1);
+    uint256 rwdDisplay = _createGoalRewardDisplay(goalIndex, "name");
 
     _fundAccount(accSlacker.index, 50);
     _fundAccount(accBronze.index, 100);

--- a/packages/contracts/src/test/systems/Scavenge.t.sol
+++ b/packages/contracts/src/test/systems/Scavenge.t.sol
@@ -83,20 +83,11 @@ contract ScavengeTest is SetupTemplate {
     string memory type_,
     uint32 rwdIndex,
     uint256 value
-  ) internal returns (uint256) {
+  ) internal returns (uint256 id) {
     vm.startPrank(deployer);
-    uint256 id = LibScavenge.addReward(
-      world,
-      components,
-      scavBarID,
-      type_,
-      rwdIndex,
-      new uint32[](0),
-      new uint256[](0),
-      value
-    );
+    uint256 parentID = LibScavenge.genRwdParentID(scavBarID);
+    id = LibReward.createBasic(components, parentID, type_, rwdIndex, value);
     vm.stopPrank();
-    return id;
   }
 
   function _addReward(
@@ -105,20 +96,11 @@ contract ScavengeTest is SetupTemplate {
     uint32[] memory keys,
     uint256[] memory weights,
     uint256 value
-  ) internal returns (uint256) {
+  ) internal returns (uint256 id) {
     vm.startPrank(deployer);
-    uint256 id = LibScavenge.addReward(
-      world,
-      components,
-      scavBarID,
-      type_,
-      0,
-      keys,
-      weights,
-      value
-    );
+    uint256 parentID = LibScavenge.genRwdParentID(scavBarID);
+    id = LibReward.createDT(components, parentID, keys, weights, value);
     vm.stopPrank();
-    return id;
   }
 
   /////////////////

--- a/packages/contracts/src/test/utils/SetupTemplate.t.sol
+++ b/packages/contracts/src/test/utils/SetupTemplate.t.sol
@@ -478,41 +478,37 @@ abstract contract SetupTemplate is TestSetupImports {
   }
 
   function _createGoalRequirement(
-    uint32 index,
+    uint32 goalIndex,
     Condition memory condition
   ) internal returns (uint256) {
     vm.prank(deployer);
     return
       __GoalRegistrySystem.addRequirement(
-        abi.encode(index, condition.type_, condition.logic, condition.index, condition.value)
+        abi.encode(goalIndex, condition.type_, condition.logic, condition.index, condition.value)
       );
   }
 
-  function _createGoalReward(
-    uint32 index,
+  // basic reward only
+  function _createGoalRewardBasic(
+    uint32 goalIndex,
     uint256 minCont,
-    Condition memory condition
+    string memory type_,
+    uint32 index,
+    uint256 value
   ) internal returns (uint256) {
-    uint32[] memory keys = new uint32[](1);
-    keys[0] = 1;
-    uint256[] memory weights = new uint256[](1);
-    weights[0] = 1;
-
     vm.prank(deployer);
     return
-      __GoalRegistrySystem.addReward(
-        abi.encode(
-          index,
-          "name",
-          minCont,
-          condition.type_,
-          condition.logic,
-          condition.index,
-          keys,
-          weights,
-          condition.value
-        )
+      __GoalRegistrySystem.addRewardBasic(
+        abi.encode(goalIndex, "name", minCont, type_, index, value)
       );
+  }
+
+  function _createGoalRewardDisplay(
+    uint32 goalIndex,
+    string memory name
+  ) internal returns (uint256) {
+    vm.prank(deployer);
+    return __GoalRegistrySystem.addRewardDisplay(abi.encode(goalIndex, "name"));
   }
 
   function _createRoom(
@@ -725,21 +721,15 @@ abstract contract SetupTemplate is TestSetupImports {
       __QuestRegistrySystem.addRequirement(abi.encode(questIndex, logicType, _type, index, value));
   }
 
+  // basic reward only
   function _createQuestReward(
     uint32 questIndex,
     string memory _type,
     uint32 itemIndex, // can be empty
     uint value // can be empty
   ) public returns (uint256) {
-    uint32[] memory keys = new uint32[](1);
-    keys[0] = 1;
-    uint256[] memory weights = new uint256[](1);
-    weights[0] = 1;
     vm.prank(deployer);
-    return
-      __QuestRegistrySystem.addReward(
-        abi.encode(questIndex, _type, itemIndex, keys, weights, value)
-      );
+    return __QuestRegistrySystem.addRewardBasic(abi.encode(questIndex, _type, itemIndex, value));
   }
 
   /* RELATIONSHIP */
@@ -1137,5 +1127,12 @@ abstract contract SetupTemplate is TestSetupImports {
 
   function assertEq(Coord memory a, Coord memory b) public {
     assertTrue(a.x == b.x && a.y == b.y && a.z == b.z);
+  }
+
+  function assertEq(Stat memory a, Stat memory b) public {
+    assertEq(a.base, b.base);
+    assertEq(a.shift, b.shift);
+    assertEq(a.boost, b.boost);
+    assertEq(a.sync, b.sync);
   }
 }


### PR DESCRIPTION
- added the ability to apply stats via `LibReward`
- foundations for more general rewards

no shape changes, although we'd want to update `Goal`, `Node`, and `Quest` registry systems.

To do:
- change `LibReward` -> `LibAllocate`
- add more distribution handlers
- move item effects here