### PR TITLE
LibReference

### DIFF
--- a/packages/client/src/network/shapes/utils/index.ts
+++ b/packages/client/src/network/shapes/utils/index.ts
@@ -6,6 +6,7 @@ export { getBalance, getBool, getInventoryBalance } from './getter';
 export { getEntityByHash, hashArgs } from './IDs';
 export { getAffinityImage, getItemImage } from './images';
 export { getDescribedEntity, parseQuantity } from './parse';
+export { queryRefChildren, queryRefsWithParent } from './references';
 
 export type { Commit } from './commits';
 export type { ForShapeOptions, ForType } from './for';

--- a/packages/client/src/network/shapes/utils/references.ts
+++ b/packages/client/src/network/shapes/utils/references.ts
@@ -1,0 +1,47 @@
+import { EntityID, EntityIndex, HasValue, runQuery } from '@mud-classic/recs';
+import { BigNumberish } from 'ethers';
+import { Components } from 'network/';
+import { hashArgs } from './IDs';
+
+/////////////////
+// QUERIES
+
+export const queryRefsWithParent = (
+  components: Components,
+  field: string,
+  parentID: EntityID
+): EntityIndex[] => {
+  const { ParentID } = components;
+
+  const id = genParentRefID(field, parentID);
+  return Array.from(runQuery([HasValue(ParentID, { value: id })]));
+};
+
+export const queryRefChildren = (
+  components: Components,
+  field: string,
+  parentID: EntityID,
+  key?: BigNumberish
+): EntityIndex[] => {
+  const { ParentID } = components;
+
+  const id = genID(field, parentID, key);
+  return Array.from(runQuery([HasValue(ParentID, { value: id })]));
+};
+
+/////////////////
+// UTILS
+
+const genID = (field: string, parentID: EntityID, key?: BigNumberish): EntityID => {
+  const args = key
+    ? ['reference.instance', field, key, parentID]
+    : ['reference.instance', field, parentID];
+  const argTypes = key
+    ? ['string', 'uint256', 'uint256', 'uint256']
+    : ['string', 'uint256', 'uint256'];
+  return hashArgs(args, argTypes);
+};
+
+const genParentRefID = (field: string, parentID: EntityID): EntityID => {
+  return hashArgs(['reference.parent', field, parentID], ['string', 'uint256'], true);
+};

--- a/packages/contracts/src/deployment/contracts/Imports.ejs
+++ b/packages/contracts/src/deployment/contracts/Imports.ejs
@@ -20,6 +20,7 @@ import { <%=library%> } from "libraries/<%= library %>.sol";
 <% }); -%>
 import { LibGetter } from "libraries/utils/LibGetter.sol";
 import { LibPack } from "libraries/utils/LibPack.sol";
+import { LibReference } from "libraries/utils/LibReference.sol";
 import { LibRandom } from "libraries/utils/LibRandom.sol";
 import { LibCooldown } from "libraries/utils/LibCooldown.sol";
 

--- a/packages/contracts/src/libraries/utils/LibReference.sol
+++ b/packages/contracts/src/libraries/utils/LibReference.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { IUint256Component as IUintComp } from "solecs/interfaces/IUint256Component.sol";
+import { getAddrByID, getCompByID } from "solecs/utils.sol";
+
+import { IDParentComponent, ID as IDParentCompID } from "components/IDParentComponent.sol";
+
+import { LibEntityType } from "libraries/utils/LibEntityType.sol";
+
+/** @notice
+ * References act as null entities that link to their parent entity
+ *  they are used when an intemediary between parent and child is needed
+ *
+ * Shape: id: hash("reference.instance", FIELD, key [optional], parentID)
+ *   - EntityType: REFERENCE
+ *   - ParentID: hash("reference.parent", FIELD, parentID)
+ */
+library LibReference {
+  ////////////////
+  // SHAPES
+
+  function create(
+    IUintComp components,
+    string memory field,
+    uint256 parentID
+  ) internal returns (uint256 id) {
+    id = genID(field, parentID);
+    _create(components, id, field, parentID);
+  }
+
+  function create(
+    IUintComp components,
+    string memory field,
+    uint256 key, // additional identifier
+    uint256 parentID
+  ) internal returns (uint256 id) {
+    id = genID(field, key, parentID);
+    _create(components, id, field, parentID);
+  }
+
+  function _create(
+    IUintComp components,
+    uint256 id,
+    string memory field,
+    uint256 parentID
+  ) internal {
+    LibEntityType.set(components, id, "REFERENCE");
+
+    uint256 parentRefID = genParentRefID(field, parentID);
+    IDParentComponent(getAddrByID(components, IDParentCompID)).set(id, parentRefID);
+  }
+
+  function remove(IUintComp components, uint256 id) internal {
+    LibEntityType.remove(components, id);
+    IDParentComponent(getAddrByID(components, IDParentCompID)).remove(id);
+  }
+
+  function remove(IUintComp components, uint256[] memory ids) internal {
+    LibEntityType.remove(components, ids);
+    IDParentComponent(getAddrByID(components, IDParentCompID)).remove(ids);
+  }
+
+  ////////////////
+  // QUERIES
+
+  function queryByParent(
+    IUintComp components,
+    string memory field,
+    uint256 parentID
+  ) internal view returns (uint256[] memory) {
+    uint256 id = genParentRefID(field, parentID);
+    return IDParentComponent(getAddrByID(components, IDParentCompID)).getEntitiesWithValue(id);
+  }
+
+  ////////////////
+  // IDs
+
+  function genID(string memory field, uint256 parentID) internal pure returns (uint256) {
+    return uint256(keccak256(abi.encodePacked("reference.instance", field, parentID)));
+  }
+
+  function genID(
+    string memory field,
+    uint256 key,
+    uint256 parentID
+  ) internal pure returns (uint256) {
+    return uint256(keccak256(abi.encodePacked("reference.instance", field, key, parentID)));
+  }
+
+  function genParentRefID(string memory field, uint256 parentID) internal pure returns (uint256) {
+    return uint256(keccak256(abi.encodePacked("reference.parent", field, parentID)));
+  }
+}


### PR DESCRIPTION
LibProxy, replaces the clunky `tier` generation in the next pr.

this one will be useful over time, and much more readable