### PR TITLE
fixed foundry tests remapping

### DIFF
--- a/packages/contracts/.gitignore
+++ b/packages/contracts/.gitignore
@@ -20,5 +20,5 @@ src/deployment/contracts/GodSystem.s.sol
 src/deployment/contracts/InitWorld.s.sol
 src/deployment/contracts/LibDeploy.sol
 src/deployment/contracts/Imports.sol
-src/test/utils/TestSetupImports.sol
+src/test/utils/TestSetupImports.t.sol
 /types/

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -51,7 +51,7 @@
     "codegen:clear": "ts-node src/deployment/commands/clearAutogen.ts",
     "codegen:imports": "pnpm ejs src/deployment/contracts/Imports.ejs -f deploy.json -o src/deployment/contracts/Imports.sol",
     "codegen:deploy": "pnpm ejs src/deployment/contracts/LibDeploy.ejs -f deploy.json -o src/deployment/contracts/LibDeploy.sol",
-    "codegen:tests": "pnpm ejs src/test/utils/TestSetupImports.ejs -f deploy.json -o src/test/utils/TestSetupImports.sol"
+    "codegen:tests": "pnpm ejs src/test/utils/TestSetupImports.t.ejs -f deploy.json -o src/test/utils/TestSetupImports.t.sol"
   },
   "devDependencies": {
     "@typechain/ethers-v5": "^10.1.1",

--- a/packages/contracts/remappings.txt
+++ b/packages/contracts/remappings.txt
@@ -4,7 +4,7 @@ components/=src/components
 deployment/=src/deployment/contracts
 libraries/=src/libraries
 systems/=src/systems
-test/=src/test
+tests/=src/test
 utils/=src/utils
 tokens/=src/tokens
 

--- a/packages/contracts/src/test/libs/Bonus.t.sol
+++ b/packages/contracts/src/test/libs/Bonus.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import { LibSort } from "solady/utils/LibSort.sol";
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 contract BonusTest is SetupTemplate {
   uint256 constant regParentEntity = uint256(keccak256(abi.encodePacked("parent")));

--- a/packages/contracts/src/test/libs/Cooldown.t.sol
+++ b/packages/contracts/src/test/libs/Cooldown.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import { SafeCastLib } from "solady/utils/SafeCastLib.sol";
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 contract LibCooldownTest is SetupTemplate {
   using SafeCastLib for int256;

--- a/packages/contracts/src/test/libs/Getter.t.sol
+++ b/packages/contracts/src/test/libs/Getter.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 contract LibGetterTest is SetupTemplate {
   uint256 defaultAccIndex = 0;

--- a/packages/contracts/src/test/libs/Reward.t.sol
+++ b/packages/contracts/src/test/libs/Reward.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 contract AlloTest is SetupTemplate {
   uint256 constant parentID1 = uint256(keccak256(abi.encodePacked("parent")));

--- a/packages/contracts/src/test/systems/AccItems.t.sol
+++ b/packages/contracts/src/test/systems/AccItems.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 contract AccItemsTest is SetupTemplate {
   uint32 petFoodIndex = 998;

--- a/packages/contracts/src/test/systems/Account.t.sol
+++ b/packages/contracts/src/test/systems/Account.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 // this test experience gain, leveling and all expected effects due to leveling
 contract AccountTest is SetupTemplate {

--- a/packages/contracts/src/test/systems/Assigner.t.sol
+++ b/packages/contracts/src/test/systems/Assigner.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 // this test experience gain, leveling and all expected effects due to leveling
 contract AssignerTest is SetupTemplate {

--- a/packages/contracts/src/test/systems/Auth.t.sol
+++ b/packages/contracts/src/test/systems/Auth.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 import { AuthRoles } from "libraries/utils/AuthRoles.sol";
 

--- a/packages/contracts/src/test/systems/Crafting.t.sol
+++ b/packages/contracts/src/test/systems/Crafting.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 // this test experience gain, leveling and all expected effects due to leveling
 contract CraftingTest is SetupTemplate {

--- a/packages/contracts/src/test/systems/Experience.t.sol
+++ b/packages/contracts/src/test/systems/Experience.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 // this test experience gain, leveling and all expected effects due to leveling
 contract ExperienceTest is SetupTemplate {

--- a/packages/contracts/src/test/systems/Faction.t.sol
+++ b/packages/contracts/src/test/systems/Faction.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 contract FactionTest is SetupTemplate {
   function testRegistryFaction() public {

--- a/packages/contracts/src/test/systems/Feeding.t.sol
+++ b/packages/contracts/src/test/systems/Feeding.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 // this includes the feeding of both food and revives
 contract FeedingTest is SetupTemplate {

--- a/packages/contracts/src/test/systems/Friend.t.sol
+++ b/packages/contracts/src/test/systems/Friend.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 contract FriendTest is SetupTemplate {
   function setUp() public override {

--- a/packages/contracts/src/test/systems/Goals.t.sol
+++ b/packages/contracts/src/test/systems/Goals.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 contract GoalsTest is SetupTemplate {
   PlayerAccount accLurker;

--- a/packages/contracts/src/test/systems/Harvest/Harvest.t.sol
+++ b/packages/contracts/src/test/systems/Harvest/Harvest.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 contract HarvestTest is SetupTemplate {
   uint256 aKamiID;

--- a/packages/contracts/src/test/systems/Harvest/HarvestTracker.t.sol
+++ b/packages/contracts/src/test/systems/Harvest/HarvestTracker.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 // this test experience gain, leveling and all expected effects due to leveling
 contract HarvestTrackerTest is SetupTemplate {

--- a/packages/contracts/src/test/systems/Inventory.t.sol
+++ b/packages/contracts/src/test/systems/Inventory.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 contract InventoryTest is SetupTemplate {
   Reverter reverter = new Reverter();

--- a/packages/contracts/src/test/systems/Items/ItemBurner.t.sol
+++ b/packages/contracts/src/test/systems/Items/ItemBurner.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 // this test experience gain, leveling and all expected effects due to leveling
 contract ItemBurnerTest is SetupTemplate {

--- a/packages/contracts/src/test/systems/Items/Lootbox.t.sol
+++ b/packages/contracts/src/test/systems/Items/Lootbox.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 // this test experience gain, leveling and all expected effects due to leveling
 contract LootboxTest is SetupTemplate {

--- a/packages/contracts/src/test/systems/Kami/KamiStats.t.sol
+++ b/packages/contracts/src/test/systems/Kami/KamiStats.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 // this test experience gain, leveling and all expected effects due to leveling
 contract KamiStatsTest is SetupTemplate {

--- a/packages/contracts/src/test/systems/Merchant.t.sol
+++ b/packages/contracts/src/test/systems/Merchant.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 contract NPCTest is SetupTemplate {
   // structure of Listing data for test purposes

--- a/packages/contracts/src/test/systems/Minting/BatchMinter.t.sol
+++ b/packages/contracts/src/test/systems/Minting/BatchMinter.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 import { TraitWeights, TraitStats } from "systems/_721BatchMinterSystem.sol";
 import { ID as IndexBackgroundCompID } from "components/IndexBackgroundComponent.sol";

--- a/packages/contracts/src/test/systems/Minting/Gacha.t.sol
+++ b/packages/contracts/src/test/systems/Minting/Gacha.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import { GACHA_ID } from "libraries/LibGacha.sol";
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 /** @dev
  * this focuses on the gacha, with a strong emphasis on checking invarients

--- a/packages/contracts/src/test/systems/Minting/Pet721Mint.t.sol
+++ b/packages/contracts/src/test/systems/Minting/Pet721Mint.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-// import "test/utils/SetupTemplate.t.sol";
+// import "tests/utils/SetupTemplate.t.sol";
 
 // /// @dev DEPRECIATED
 

--- a/packages/contracts/src/test/systems/Minting/Traits.t.sol
+++ b/packages/contracts/src/test/systems/Minting/Traits.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 import { ID as IndexBackgroundCompID } from "components/IndexBackgroundComponent.sol";
 import { ID as IndexBodyCompID } from "components/IndexBodyComponent.sol";

--- a/packages/contracts/src/test/systems/Misc.t.sol
+++ b/packages/contracts/src/test/systems/Misc.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 /// @notice basic system testing for systems that are not directly tested elsewhere
 /** @dev

--- a/packages/contracts/src/test/systems/Murder/HiredHitman.t.sol
+++ b/packages/contracts/src/test/systems/Murder/HiredHitman.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 import { LibQuery, QueryFragment, QueryType } from "solecs/LibQuery.sol";
 import { getAddrByID, getCompByID } from "solecs/utils.sol";

--- a/packages/contracts/src/test/systems/Murder/Murder.t.sol
+++ b/packages/contracts/src/test/systems/Murder/Murder.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 import { LibQuery, QueryFragment, QueryType } from "solecs/LibQuery.sol";
 import { getAddrByID, getCompByID } from "solecs/utils.sol";

--- a/packages/contracts/src/test/systems/Naming.t.sol
+++ b/packages/contracts/src/test/systems/Naming.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 import { ROOM as NAMING_ROOM } from "systems/KamiNameSystem.sol";
 

--- a/packages/contracts/src/test/systems/Node.t.sol
+++ b/packages/contracts/src/test/systems/Node.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 contract NodeTest is SetupTemplate {
   uint internal aKamiID;

--- a/packages/contracts/src/test/systems/Pet721Stake.t.sol
+++ b/packages/contracts/src/test/systems/Pet721Stake.t.sol
@@ -1,7 +1,7 @@
 // // SPDX-License-Identifier: Unlicense
 // pragma solidity ^0.8.0;
 
-// import "test/utils/SetupTemplate.t.sol";
+// import "tests/utils/SetupTemplate.t.sol";
 
 // contract Kami721StakeTest is SetupTemplate {
 //   function setUp() public override {

--- a/packages/contracts/src/test/systems/Quests.t.sol
+++ b/packages/contracts/src/test/systems/Quests.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 import { LibQuery, QueryFragment, QueryType } from "solecs/LibQuery.sol";
 import { getAddrByID, getCompByID } from "solecs/utils.sol";

--- a/packages/contracts/src/test/systems/Relationship.t.sol
+++ b/packages/contracts/src/test/systems/Relationship.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 import { LibRelationshipRegistry as LibRegRel } from "libraries/LibRelationshipRegistry.sol";
 

--- a/packages/contracts/src/test/systems/Room.t.sol
+++ b/packages/contracts/src/test/systems/Room.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 contract RoomTest is SetupTemplate {
   function setUp() public override {

--- a/packages/contracts/src/test/systems/Scavenge.t.sol
+++ b/packages/contracts/src/test/systems/Scavenge.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 
 struct ScavBarData {
   uint256 id; // registry id

--- a/packages/contracts/src/test/systems/Skill.t.sol
+++ b/packages/contracts/src/test/systems/Skill.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/SetupTemplate.t.sol";
+import "tests/utils/SetupTemplate.t.sol";
 import { Stat } from "solecs/components/types/Stat.sol";
 
 contract SkillTest is SetupTemplate {

--- a/packages/contracts/src/test/utils/SetupTemplate.t.sol
+++ b/packages/contracts/src/test/utils/SetupTemplate.t.sol
@@ -9,7 +9,7 @@ import { Condition } from "libraries/LibConditional.sol";
 import { Coord } from "libraries/LibRoom.sol";
 import { MUSU_INDEX, GACHA_TICKET_INDEX } from "libraries/LibInventory.sol";
 
-import "./TestSetupImports.sol";
+import "./TestSetupImports.t.sol";
 import { LibDeployTokens } from "src/deployment/contracts/LibDeployTokens.s.sol";
 
 import { LibEntityType } from "libraries/utils/LibEntityType.sol";

--- a/packages/contracts/src/test/utils/Struct.t.sol
+++ b/packages/contracts/src/test/utils/Struct.t.sol
@@ -12,7 +12,7 @@ import { StatComponent } from "solecs/components/StatComponent.sol";
 
 import { Coord } from "components/LocationComponent.sol";
 
-import { EmptyWorld } from "test/utils/EmptyWorld.t.sol";
+import { EmptyWorld } from "tests/utils/EmptyWorld.t.sol";
 
 contract StructTest is EmptyWorld {
   Uint256BareComponent uintComp;

--- a/packages/contracts/src/test/utils/TestSetupImports.t.ejs
+++ b/packages/contracts/src/test/utils/TestSetupImports.t.ejs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "test/utils/MudTest.t.sol";
+import "tests/utils/MudTest.t.sol";
 import "deployment/Imports.sol";
 
 // Utils
-import { WrapCaller } from "test/utils/WrapCaller.sol";
+import { WrapCaller } from "tests/utils/WrapCaller.sol";
 
 abstract contract TestSetupImports is MudTest {
   // Components vars


### PR DESCRIPTION
its kinda weird. not sure why it broke, but new foundry update specifically couldnt work with `test/` remappings. this fixes it ig?
