### PR TITLE
Minor client query optimisations (excluding Account)

### DIFF
--- a/packages/client/src/app/components/modals/BridgeERC721.tsx
+++ b/packages/client/src/app/components/modals/BridgeERC721.tsx
@@ -1,4 +1,3 @@
-import { HasValue, runQuery } from '@mud-classic/recs';
 import { BigNumberish } from 'ethers';
 import { useEffect, useState } from 'react';
 import { map, merge } from 'rxjs';
@@ -10,7 +9,7 @@ import { registerUIComponent } from 'app/root';
 import { useAccount, useNetwork } from 'app/stores';
 import { getAccountFromBurner } from 'network/shapes/Account';
 import { getConfigFieldValueAddress } from 'network/shapes/Config/types';
-import { Kami, getKami } from 'network/shapes/Kami';
+import { Kami, getKamiByIndex } from 'network/shapes/Kami';
 
 export function registerERC721BridgeModal() {
   registerUIComponent(
@@ -134,30 +133,20 @@ export function registerERC721BridgeModal() {
       useEffect(() => {
         const getEOAKamis = (): Kami[] => {
           // get indices of external kamis
-          const getIndices = (): bigint[] => {
-            return erc721List ? [...erc721List] : [];
+          const getIndices = (): number[] => {
+            return erc721List ? [...erc721List.map((i) => Number(i))] : [];
           };
 
           // get kamis from index
-          const getKamis = (indices: bigint[]): Kami[] => {
+          const getKamis = (indices: number[]): Kami[] => {
             let kamis: Kami[] = [];
-            let petIndex;
             for (let i = 0; i < indices.length; i++) {
-              petIndex = ('0x' + indices[i].toString(16).padStart(2, '0')) as unknown as number;
-              const entityID = Array.from(
-                runQuery([
-                  HasValue(EntityType, { value: 'KAMI' }),
-                  HasValue(KamiIndex, { value: petIndex }),
-                ])
-              )[0];
-
-              kamis.push(
-                getKami(world, components, entityID, {
-                  // deaths: true,
-                  harvest: true,
-                  traits: true,
-                })
-              );
+              const kami = getKamiByIndex(world, components, indices[i], {
+                // deaths: true,
+                harvest: true,
+                traits: true,
+              });
+              if (kami) kamis.push(kami);
             }
 
             return kamis;

--- a/packages/client/src/network/shapes/Account/queries.ts
+++ b/packages/client/src/network/shapes/Account/queries.ts
@@ -49,6 +49,7 @@ export const queryByName = (components: Components, name: string) => {
 };
 
 // query for an account entity by its operator address
+// todo: query directly with OperatorCacheComponent (operator address => accID)
 export const queryByOperator = (components: Components, operator: string) => {
   const results = query(components, { operator });
   if (results.length == 0) return;
@@ -56,6 +57,7 @@ export const queryByOperator = (components: Components, operator: string) => {
 };
 
 // query for an account entity by its owner address
+// todo: query directly! accID = formatEntityID(ownerAddr)
 export const queryByOwner = (components: Components, owner: string) => {
   const results = query(components, { owner });
   if (results.length == 0) return;

--- a/packages/client/src/network/shapes/Conditional/functions.ts
+++ b/packages/client/src/network/shapes/Conditional/functions.ts
@@ -83,9 +83,9 @@ export const checkCurrent = (
   target: Target,
   holder: Account | Kami
 ): ((opt: any) => Status) => {
-  const accVal = getBalance(world, components, holder.entityIndex, target.index, target.type) || 0;
-
   return (opt: any) => {
+    const accVal =
+      getBalance(world, components, holder.entityIndex, target.index, target.type) || 0;
     return {
       target: target.value,
       current: accVal,
@@ -100,9 +100,8 @@ export const checkBoolean = (
   target: Target,
   holder: Account | Kami
 ): ((opt: any) => Status) => {
-  const result = getBool(world, components, holder, target.index, target.value, target.type);
-
   return (opt: any) => {
+    const result = getBool(world, components, holder, target.index, target.value, target.type);
     return {
       completable: opt === 'IS' ? result : !result,
     };

--- a/packages/client/src/network/shapes/Kami/battle.ts
+++ b/packages/client/src/network/shapes/Kami/battle.ts
@@ -101,11 +101,11 @@ export const getKamiDeaths = (
 // query kill logs where a input Kamiis the victim
 export const queryKamiDeaths = (components: Components, kami: BaseKami): EntityIndex[] => {
   const { IsKill, TargetID } = components;
-  return Array.from(runQuery([Has(IsKill), HasValue(TargetID, { value: kami.id })]));
+  return Array.from(runQuery([HasValue(TargetID, { value: kami.id }), Has(IsKill)]));
 };
 
 // query kill logs where the input Kami is the aggressor
 export const queryKamiKills = (components: Components, kami: BaseKami): EntityIndex[] => {
   const { IsKill, SourceID } = components;
-  return Array.from(runQuery([Has(IsKill), HasValue(SourceID, { value: kami.id })]));
+  return Array.from(runQuery([HasValue(SourceID, { value: kami.id }), Has(IsKill)]));
 };

--- a/packages/client/src/network/shapes/Kami/getters.ts
+++ b/packages/client/src/network/shapes/Kami/getters.ts
@@ -1,18 +1,11 @@
-import {
-  EntityID,
-  EntityIndex,
-  getComponentValue,
-  HasValue,
-  runQuery,
-  World,
-} from '@mud-classic/recs';
+import { EntityID, EntityIndex, getComponentValue, World } from '@mud-classic/recs';
 import { formatEntityID } from 'engine/utils';
 import { Components } from 'network/components';
 import { getHarvest } from 'network/shapes/Harvest';
 import { getHarvestEntity } from 'network/shapes/Harvest/types';
 import { BaseAccount, getBaseAccount, NullAccount } from '../Account';
 import { query, queryByName } from './queries';
-import { getKami, Options } from './types';
+import { getKami, getKamiEntity, Options } from './types';
 
 // get all Kamis
 export const getAll = (world: World, components: Components, options?: Options) => {
@@ -65,10 +58,10 @@ export const getByState = (
 
 // get the BaseAccount entity that owns a Kami, queried by kami index
 export const getAccount = (world: World, components: Components, index: number): BaseAccount => {
-  const { EntityType, KamiIndex, OwnsKamiID } = components;
-  const kamiEntity = Array.from(
-    runQuery([HasValue(KamiIndex, { value: index }), HasValue(EntityType, { value: 'KAMI' })])
-  )[0];
+  const { OwnsKamiID } = components;
+
+  const kamiEntity = getKamiEntity(world, index);
+  if (!kamiEntity) return NullAccount;
 
   const rawAccID = getComponentValue(OwnsKamiID, kamiEntity)?.value ?? '';
   if (!rawAccID) return NullAccount;

--- a/packages/client/src/network/shapes/Kami/index.ts
+++ b/packages/client/src/network/shapes/Kami/index.ts
@@ -38,5 +38,5 @@ export {
 
 export type { KillLog } from './battle';
 export type { QueryOptions } from './queries';
-export { getBaseKami, getGachaKami, getKami } from './types';
+export { getBaseKami, getGachaKami, getKami, getKamiEntity } from './types';
 export type { BaseKami, GachaKami, Kami, Options as KamiOptions } from './types';

--- a/packages/client/src/network/shapes/Kami/types.ts
+++ b/packages/client/src/network/shapes/Kami/types.ts
@@ -13,7 +13,7 @@ import { Harvest, getHarvestForKami } from '../Harvest';
 import { Skill, getHolderSkills } from '../Skill';
 import { Stats, getStats } from '../Stats';
 import { Traits, getKamiTraits } from '../Trait';
-import { DetailedEntity } from '../utils';
+import { DetailedEntity, getEntityByHash } from '../utils';
 import { calcHealthRate } from './functions';
 
 export interface BaseKami extends DetailedEntity {
@@ -191,3 +191,10 @@ export const getKami = (
 
   return kami;
 };
+
+////////////////
+// IDs
+
+export function getKamiEntity(world: World, index: number): EntityIndex | undefined {
+  return getEntityByHash(world, ['kami.id', index], ['string', 'uint32']);
+}

--- a/packages/client/src/network/shapes/NPCs.ts
+++ b/packages/client/src/network/shapes/NPCs.ts
@@ -8,6 +8,7 @@ import {
 } from '@mud-classic/recs';
 
 import { Components } from 'network/';
+import { getEntityByHash } from './utils';
 
 // standardized shape of a FE NPC Entity
 export interface NPC {
@@ -33,10 +34,8 @@ export const getNPC = (world: World, components: Components, entityIndex: Entity
 
 // the Merchant Index here is actually an NPCIndex
 export const getNPCByIndex = (world: World, components: Components, index: number) => {
-  const { EntityType, NPCIndex } = components;
-  const entityIndex = Array.from(
-    runQuery([HasValue(EntityType, { value: 'NPC' }), HasValue(NPCIndex, { value: index })])
-  )[0];
+  const entityIndex = getNPCIndex(world, index);
+  if (!entityIndex) return;
   return getNPC(world, components, entityIndex);
 };
 
@@ -44,4 +43,8 @@ export const getAllNPCs = (world: World, components: Components) => {
   const { EntityType } = components;
   const entityIndices = Array.from(runQuery([HasValue(EntityType, { value: 'NPC' })]));
   return entityIndices.map((entityIndex) => getNPC(world, components, entityIndex));
+};
+
+const getNPCIndex = (world: World, npcIndex: number) => {
+  return getEntityByHash(world, ['NPC', npcIndex], ['string', 'uint32']);
 };

--- a/packages/client/src/network/shapes/Quest/index.ts
+++ b/packages/client/src/network/shapes/Quest/index.ts
@@ -18,7 +18,6 @@ export {
   checkObjective as checkQuestObjective,
   getObjective as getQuestObjective,
   getObjectives as getQuestObjectives,
-  querySnapshotObjective,
 } from './objective';
 export {
   queryAccepted as queryAcceptedQuests,

--- a/packages/client/src/network/shapes/Room/types.ts
+++ b/packages/client/src/network/shapes/Room/types.ts
@@ -106,8 +106,8 @@ export const getRoom = (
   if (options?.players) {
     const accountResults = Array.from(
       runQuery([
-        HasValue(EntityType, { value: 'ACCOUNT' }),
         HasValue(RoomIndex, { value: room.index }),
+        HasValue(EntityType, { value: 'ACCOUNT' }),
       ])
     );
 

--- a/packages/client/src/network/shapes/Skill/getters.ts
+++ b/packages/client/src/network/shapes/Skill/getters.ts
@@ -48,7 +48,8 @@ export const getSkillByIndex = (
   index: number,
   options?: Options
 ): Skill => {
-  const entity = querySkillByIndex(components, index, options);
+  const entity = querySkillByIndex(world, index);
+  if (!entity) return NullSkill;
   return getSkill(world, components, entity, options);
 };
 

--- a/packages/client/src/network/shapes/Skill/queries.ts
+++ b/packages/client/src/network/shapes/Skill/queries.ts
@@ -10,7 +10,7 @@ import {
 import { Components } from 'network/';
 import { queryConditionsOf } from '../Conditional/queries';
 import { queryChildrenOf } from '../utils';
-import { Options, Requirement, getBonusParentID } from './types';
+import { Options, Requirement, getBonusParentID, getRegistryEntity } from './types';
 
 /////////////////
 // GETTERS
@@ -28,16 +28,8 @@ export const queryHolderSkills = (
   return querySkillsX(components, { holder: holder }, options);
 };
 
-export const querySkillByIndex = (
-  components: Components,
-  index: number,
-  options?: Options
-): EntityIndex => {
-  const { IsRegistry, SkillIndex } = components;
-  const entityIndices = Array.from(
-    runQuery([Has(IsRegistry), HasValue(SkillIndex, { value: index })])
-  );
-  return entityIndices[0];
+export const querySkillByIndex = (world: World, index: number): EntityIndex | undefined => {
+  return getRegistryEntity(world, index);
 };
 
 /////////////////

--- a/packages/client/src/network/shapes/Skill/types.ts
+++ b/packages/client/src/network/shapes/Skill/types.ts
@@ -1,12 +1,4 @@
-import {
-  EntityID,
-  EntityIndex,
-  Has,
-  HasValue,
-  World,
-  getComponentValue,
-  runQuery,
-} from '@mud-classic/recs';
+import { EntityID, EntityIndex, World, getComponentValue } from '@mud-classic/recs';
 
 import { Components } from 'network/';
 import { getSkillBonuses } from '.';
@@ -64,28 +56,11 @@ export const getSkill = (
   entityIndex: EntityIndex,
   options?: Options
 ): Skill => {
-  const {
-    EntityType,
-    IsRegistry,
-    Cost,
-    Description,
-    Level,
-    Max,
-    MediaURI,
-    Name,
-    Type,
-    SkillIndex,
-    SkillPoint,
-  } = components;
+  const { Cost, Description, Level, Max, Name, Type, SkillIndex, SkillPoint } = components;
 
   const skillIndex = getComponentValue(SkillIndex, entityIndex)?.value || (0 as number);
-  const registryIndex = Array.from(
-    runQuery([
-      Has(IsRegistry),
-      HasValue(EntityType, { value: 'SKILL' }),
-      HasValue(SkillIndex, { value: skillIndex }),
-    ])
-  )[0];
+  const registryIndex = getRegistryEntity(world, skillIndex);
+  if (!registryIndex) return NullSkill;
 
   const name = getComponentValue(Name, registryIndex)?.value || ('' as string);
 
@@ -137,6 +112,10 @@ export const getRequirement = (
 
 //////////////////
 // IDs
+
+export const getRegistryEntity = (world: World, index: number): EntityIndex | undefined => {
+  return getEntityByHash(world, ['registry.skill', index], ['string', 'uint32']);
+};
 
 export const getInstanceEntity = (
   world: World,

--- a/packages/client/src/network/shapes/Stats.ts
+++ b/packages/client/src/network/shapes/Stats.ts
@@ -32,6 +32,15 @@ export const NullStat: Stat = {
   total: 0,
 };
 
+export const NullStats: Stats = {
+  health: NullStat,
+  power: NullStat,
+  violence: NullStat,
+  harmony: NullStat,
+  slots: NullStat,
+  stamina: NullStat,
+};
+
 // get the stats of an entity
 // get the Stats from the EnityIndex of a Kami
 export const getStats = (

--- a/packages/client/src/network/shapes/utils/IDs.ts
+++ b/packages/client/src/network/shapes/utils/IDs.ts
@@ -9,6 +9,7 @@ export const getEntityByHash = (
   args: any[],
   argTypes: string[]
 ): EntityIndex | undefined => {
+  for (let i = 0; i < args.length; i++) if (args[i] === undefined) return;
   return world.entityToIndex.get(hashArgs(args, argTypes));
 };
 

--- a/packages/contracts/deploy.json
+++ b/packages/contracts/deploy.json
@@ -5,7 +5,7 @@
     { "comp": "Affinity", "name": "Affinity", "type": "string" },
     { "comp": "Blacklist", "name": "Blacklist", "type": "uint32[]" },
     { "comp": "BlockReveal", "name": "RevealBlock", "type": "uint256" },
-    { "comp": "CacheOperator", "name": "OperatorCache", "type": "address", "FEtype": "number" },
+    { "comp": "CacheOperator", "name": "OperatorCache", "type": "address", "FEtype": "uint256" },
     { "comp": "Cost", "name": "Cost", "type": "uint256" },
     { "comp": "DescriptionAlt", "name": "DescriptionAlt", "type": "string" },
     { "comp": "Description", "name": "Description", "type": "string" },

--- a/packages/contracts/src/libraries/LibKami.sol
+++ b/packages/contracts/src/libraries/LibKami.sol
@@ -428,6 +428,7 @@ library LibKami {
   // UTILS
 
   function genID(uint32 kamiIndex) internal pure returns (uint256) {
+    // todo: change to kami.index
     return uint256(keccak256(abi.encodePacked("kami.id", kamiIndex)));
   }
 

--- a/packages/contracts/src/libraries/LibQuests.sol
+++ b/packages/contracts/src/libraries/LibQuests.sol
@@ -421,7 +421,6 @@ library LibQuests {
     string memory _type,
     uint32 index
   ) internal pure returns (uint256) {
-    // world2: flatten naming (leftover from LibHash)
     return
       uint256(
         keccak256(abi.encodePacked("quest.objective.snapshot", questID, logicType, _type, index))


### PR DESCRIPTION
mostly updating registry queries to use determinsticIDs instead of a full query

some updates on getting quest `objective snapshot`, removes its hardcode and cleans it up

still todo: change account queries from full queries to use `CacheOperator` component and take advantage of ownerAddr=accID
right now its parsing through all `accounts` each second 
@JirAcheron for visibility after cache update