### PR TITLE
Allo bonuses

### DIFF
--- a/packages/client/abi/_ItemRegistrySystem.json
+++ b/packages/client/abi/_ItemRegistrySystem.json
@@ -37,6 +37,25 @@
     },
     {
       "type": "function",
+      "name": "addAlloBonus",
+      "inputs": [
+        {
+          "name": "arguments",
+          "type": "bytes",
+          "internalType": "bytes"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
       "name": "addAlloDT",
       "inputs": [
         {
@@ -359,6 +378,7 @@
   ],
   "methodIdentifiers": {
     "addAlloBasic(bytes)": "b39bdf22",
+    "addAlloBonus(bytes)": "eb04c569",
     "addAlloDT(bytes)": "59ce910b",
     "addAlloStat(bytes)": "b452abd4",
     "addRequirement(bytes)": "7e534103",

--- a/packages/client/types/ethers-contracts/_ItemRegistrySystem.ts
+++ b/packages/client/types/ethers-contracts/_ItemRegistrySystem.ts
@@ -31,6 +31,7 @@ import type {
 export interface _ItemRegistrySystemInterface extends utils.Interface {
   functions: {
     "addAlloBasic(bytes)": FunctionFragment;
+    "addAlloBonus(bytes)": FunctionFragment;
     "addAlloDT(bytes)": FunctionFragment;
     "addAlloStat(bytes)": FunctionFragment;
     "addRequirement(bytes)": FunctionFragment;
@@ -53,6 +54,7 @@ export interface _ItemRegistrySystemInterface extends utils.Interface {
   getFunction(
     nameOrSignatureOrTopic:
       | "addAlloBasic"
+      | "addAlloBonus"
       | "addAlloDT"
       | "addAlloStat"
       | "addRequirement"
@@ -74,6 +76,10 @@ export interface _ItemRegistrySystemInterface extends utils.Interface {
 
   encodeFunctionData(
     functionFragment: "addAlloBasic",
+    values: [PromiseOrValue<BytesLike>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "addAlloBonus",
     values: [PromiseOrValue<BytesLike>]
   ): string;
   encodeFunctionData(
@@ -141,6 +147,10 @@ export interface _ItemRegistrySystemInterface extends utils.Interface {
 
   decodeFunctionResult(
     functionFragment: "addAlloBasic",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "addAlloBonus",
     data: BytesLike
   ): Result;
   decodeFunctionResult(functionFragment: "addAlloDT", data: BytesLike): Result;
@@ -279,6 +289,11 @@ export interface _ItemRegistrySystem extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
+    addAlloBonus(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
     addAlloDT(
       arguments: PromiseOrValue<BytesLike>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
@@ -363,6 +378,11 @@ export interface _ItemRegistrySystem extends BaseContract {
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
+  addAlloBonus(
+    arguments: PromiseOrValue<BytesLike>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
   addAlloDT(
     arguments: PromiseOrValue<BytesLike>,
     overrides?: Overrides & { from?: PromiseOrValue<string> }
@@ -443,6 +463,11 @@ export interface _ItemRegistrySystem extends BaseContract {
 
   callStatic: {
     addAlloBasic(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
+    addAlloBonus(
       arguments: PromiseOrValue<BytesLike>,
       overrides?: CallOverrides
     ): Promise<BigNumber>;
@@ -552,6 +577,11 @@ export interface _ItemRegistrySystem extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
+    addAlloBonus(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
     addAlloDT(
       arguments: PromiseOrValue<BytesLike>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
@@ -633,6 +663,11 @@ export interface _ItemRegistrySystem extends BaseContract {
 
   populateTransaction: {
     addAlloBasic(
+      arguments: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    addAlloBonus(
       arguments: PromiseOrValue<BytesLike>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;

--- a/packages/contracts/deploy.json
+++ b/packages/contracts/deploy.json
@@ -105,6 +105,7 @@
         "Harmony",
         "IDParent",
         "IsComplete",
+        "IsRegistry",
         "Index",
         "IndexRoom",
         "Level",

--- a/packages/contracts/src/deployment/world/admin.ts
+++ b/packages/contracts/src/deployment/world/admin.ts
@@ -623,6 +623,15 @@ export function createAdminAPI(compiledCalls: string[]) {
     ]);
   }
 
+  async function addItemBonus(index: number, usecase: string, type: string, value: number) {
+    genCall('system.item.registry', [index, usecase, type, value], 'addAlloBonus', [
+      'uint32',
+      'string',
+      'string',
+      'int256',
+    ]);
+  }
+
   async function addItemDT(
     index: number,
     usecase: string,
@@ -832,6 +841,7 @@ export function createAdminAPI(compiledCalls: string[]) {
           requirement: addItemRequirement,
           allo: {
             basic: addItemBasic,
+            bonus: addItemBonus,
             droptable: addItemDT,
             stat: addItemStat,
           },

--- a/packages/contracts/src/libraries/LibBonus.sol
+++ b/packages/contracts/src/libraries/LibBonus.sol
@@ -92,13 +92,23 @@ library LibBonus {
     IDParentComponent(getAddrByID(components, IDParentCompID)).set(id, parentID);
   }
 
+  function regRemoveByAnchor(IUintComp components, uint256[] memory anchorIDs) internal {
+    uint256[] memory ids = queryByParent(components, anchorIDs);
+    return regRemove(components, ids);
+  }
+
+  function regRemoveByAnchor(IUintComp components, uint256 anchorID) internal {
+    uint256[] memory ids = queryByParent(components, anchorID);
+    regRemove(components, ids);
+  }
+
   /// @notice removes a registry entry
-  function registryRemove(IUintComp components, uint256 id) internal {
-    LibEntityType.remove(components, id);
-    IsRegistryComponent(getAddrByID(components, IsRegCompID)).remove(id);
-    IDParentComponent(getAddrByID(components, IDParentCompID)).remove(id);
-    TypeComponent(getAddrByID(components, TypeCompID)).remove(id);
-    ValueComponent(getAddrByID(components, ValueCompID)).remove(id);
+  function regRemove(IUintComp components, uint256[] memory ids) internal {
+    LibEntityType.remove(components, ids);
+    IsRegistryComponent(getAddrByID(components, IsRegCompID)).remove(ids);
+    IDParentComponent(getAddrByID(components, IDParentCompID)).remove(ids);
+    TypeComponent(getAddrByID(components, TypeCompID)).remove(ids);
+    ValueComponent(getAddrByID(components, ValueCompID)).remove(ids);
   }
 
   /// @notice removes a bonus instance
@@ -238,6 +248,13 @@ library LibBonus {
     uint256 parentID
   ) internal view returns (uint256[] memory) {
     return IUintComp(getAddrByID(components, IDParentCompID)).getEntitiesWithValue(parentID);
+  }
+
+  function queryByParent(
+    IUintComp components,
+    uint256[] memory parentIDs
+  ) internal view returns (uint256[] memory) {
+    return IUintComp(getAddrByID(components, IDParentCompID)).getEntitiesWithValue(parentIDs);
   }
 
   function queryByType(

--- a/packages/contracts/src/libraries/LibConditional.sol
+++ b/packages/contracts/src/libraries/LibConditional.sol
@@ -16,7 +16,7 @@ import { LogicTypeComponent, ID as LogicTypeCompID } from "components/LogicTypeC
 import { TypeComponent, ID as TypeCompID } from "components/TypeComponent.sol";
 import { SubtypeComponent, ID as SubtypeCompID } from "components/SubtypeComponent.sol";
 
-import { LibArray } from "libraries/utils/LibArray.sol";
+import { LibComp } from "libraries/utils/LibComp.sol";
 import { LibGetter } from "libraries/utils/LibGetter.sol";
 
 enum LOGIC {
@@ -54,6 +54,7 @@ struct Condition {
  * heavily inspired by Quest condition checks. Does not yet support increase/decrease checks, but can in future
  */
 library LibConditional {
+  using LibComp for IUintComp;
   using LibString for string;
 
   ///////////////////////
@@ -230,20 +231,14 @@ library LibConditional {
   // QUERIES
 
   function queryFor(IUintComp components, uint256 id) internal view returns (uint256[] memory) {
-    return IDParentComponent(getAddrByID(components, IDParentCompID)).getEntitiesWithValue(id);
+    return IUintComp(getAddrByID(components, IDParentCompID)).getEntitiesWithValue(id);
   }
 
   function queryFor(
     IUintComp components,
     uint256[] memory ids
   ) internal view returns (uint256[] memory) {
-    IDParentComponent parentComp = IDParentComponent(getAddrByID(components, IDParentCompID));
-
-    uint256[][] memory all = new uint256[][](ids.length);
-    for (uint256 i; i < ids.length; i++) {
-      all[i] = parentComp.getEntitiesWithValue(ids[i]);
-    }
-    return LibArray.flatten(all);
+    return IUintComp(getAddrByID(components, IDParentCompID)).getEntitiesWithValue(ids);
   }
 
   /// @notice queries for conditions with subtype

--- a/packages/contracts/src/libraries/LibItem.sol
+++ b/packages/contracts/src/libraries/LibItem.sol
@@ -113,7 +113,7 @@ library LibItem {
   }
 
   /// @notice delete a Registry entry for an item.
-  function deleteItem(IUintComp components, uint32 index) internal {
+  function deleteItem(IUintComp components, uint32 index) public {
     uint256 id = genID(index);
     LibEntityType.remove(components, id);
     IndexItemComponent(getAddrByID(components, IndexItemCompID)).remove(id);
@@ -263,7 +263,7 @@ library LibItem {
     string memory useCase
   ) internal view returns (uint256[] memory) {
     uint256 refID = LibReference.genID(useCase, genRefAnchor(index));
-    return LibAllo.queryFor(components, genAlloParentID(refID));
+    return LibAllo.queryFor(components, genAlloAnchor(refID));
   }
 
   function getReqsFor(
@@ -287,7 +287,7 @@ library LibItem {
     uint32 index
   ) internal view returns (uint256[] memory) {
     uint256[] memory refs = getAllReferences(components, index);
-    for (uint256 i; i < refs.length; i++) refs[i] = genAlloParentID(refs[i]);
+    for (uint256 i; i < refs.length; i++) refs[i] = genAlloAnchor(refs[i]);
     return LibAllo.queryFor(components, refs);
   }
 
@@ -346,7 +346,7 @@ library LibItem {
     return uint256(keccak256(abi.encodePacked("item.usecase", index)));
   }
 
-  function genAlloParentID(uint256 refID) internal pure returns (uint256) {
+  function genAlloAnchor(uint256 refID) internal pure returns (uint256) {
     return uint256(keccak256(abi.encodePacked("item.allo", refID)));
   }
 

--- a/packages/contracts/src/libraries/LibSkillRegistry.sol
+++ b/packages/contracts/src/libraries/LibSkillRegistry.sol
@@ -125,7 +125,7 @@ library LibSkillRegistry {
     for (uint256 i; i < reqs.length; i++) LibConditional.remove(components, reqs[i]);
 
     uint256[] memory bonuses = queryBonuses(components, index);
-    for (uint256 i; i < bonuses.length; i++) LibBonus.registryRemove(components, bonuses[i]);
+    LibBonus.regRemove(components, bonuses);
   }
 
   /////////////////

--- a/packages/contracts/src/libraries/utils/LibComp.sol
+++ b/packages/contracts/src/libraries/utils/LibComp.sol
@@ -8,9 +8,12 @@ import { StatComponent } from "solecs/components/StatComponent.sol";
 
 import { Stat, StatLib } from "solecs/components/types/Stat.sol";
 
+import { LibArray } from "libraries/utils/LibArray.sol";
+
 /// @notice a library for useful component operations
 library LibComp {
   using LibString for string;
+  using LibArray for uint256[][];
 
   /////////////////
   // CHECKS
@@ -71,5 +74,30 @@ library LibComp {
     bytes[] memory values = new bytes[](entities.length);
     for (uint256 i; i < entities.length; i++) values[i] = abi.encode(value);
     component.set(entities, values);
+  }
+
+  ////////////////////
+  // QUERIES
+
+  function getEntitiesWithValue(
+    IComp comp,
+    bytes[] memory values
+  ) internal view returns (uint256[] memory) {
+    uint256[][] memory all = new uint256[][](values.length);
+    for (uint256 i; i < values.length; i++) {
+      all[i] = comp.getEntitiesWithValue(values[i]);
+    }
+    return all.flatten();
+  }
+
+  function getEntitiesWithValue(
+    IUintComp comp,
+    uint256[] memory values
+  ) internal view returns (uint256[] memory) {
+    uint256[][] memory all = new uint256[][](values.length);
+    for (uint256 i; i < values.length; i++) {
+      all[i] = comp.getEntitiesWithValue(values[i]);
+    }
+    return all.flatten();
   }
 }

--- a/packages/contracts/src/systems/_ItemRegistrySystem.sol
+++ b/packages/contracts/src/systems/_ItemRegistrySystem.sol
@@ -92,8 +92,20 @@ contract _ItemRegistrySystem is System {
     require(LibItem.getByIndex(components, index) != 0, "ItemReg: item does not exist");
 
     uint256 refID = LibItem.createUseCase(components, index, useCase);
-    uint256 parentID = LibItem.genAlloParentID(refID);
+    uint256 parentID = LibItem.genAlloAnchor(refID);
     return LibAllo.createBasic(components, parentID, alloType, alloIndex, alloValue);
+  }
+
+  function addAlloBonus(bytes memory arguments) public onlyOwner returns (uint256) {
+    (uint32 index, string memory useCase, string memory bonusType, int256 bonusValue) = abi.decode(
+      arguments,
+      (uint32, string, string, int256)
+    );
+    require(LibItem.getByIndex(components, index) != 0, "ItemReg: item does not exist");
+
+    uint256 refID = LibItem.createUseCase(components, index, useCase);
+    uint256 parentID = LibItem.genAlloAnchor(refID);
+    return LibAllo.createBonus(components, parentID, bonusType, bonusValue);
   }
 
   function addAlloDT(bytes memory arguments) public onlyOwner returns (uint256) {
@@ -107,7 +119,7 @@ contract _ItemRegistrySystem is System {
     require(LibItem.getByIndex(components, index) != 0, "ItemReg: item does not exist");
 
     uint256 refID = LibItem.createUseCase(components, index, useCase);
-    uint256 parentID = LibItem.genAlloParentID(refID);
+    uint256 parentID = LibItem.genAlloAnchor(refID);
     return LibAllo.createDT(components, parentID, keys, weights, value);
   }
 
@@ -124,7 +136,7 @@ contract _ItemRegistrySystem is System {
     require(LibItem.getByIndex(components, index) != 0, "ItemReg: item does not exist");
 
     uint256 refID = LibItem.createUseCase(components, index, useCase);
-    uint256 parentID = LibItem.genAlloParentID(refID);
+    uint256 parentID = LibItem.genAlloAnchor(refID);
     return LibAllo.createStat(components, parentID, statType, base, shift, boost, sync);
   }
 

--- a/packages/contracts/src/test/systems/Skill.t.sol
+++ b/packages/contracts/src/test/systems/Skill.t.sol
@@ -256,10 +256,11 @@ contract SkillTest is SetupTemplate {
   // UTILS
 
   function _resetSkills(PlayerAccount memory acc, uint256 targetID) internal {
-    _giveItem(acc, resetItemIndex, 1);
-
-    vm.startPrank(acc.operator);
-    _KamiUseSkillResetSystem.executeTyped(targetID, resetItemIndex);
+    vm.startPrank(deployer);
+    LibFlag.set(components, targetID, "CAN_RESET_SKILLS", true);
     vm.stopPrank();
+
+    vm.prank(acc.operator);
+    _SkillResetSystem.executeTyped(targetID);
   }
 }


### PR DESCRIPTION
not particularly satisfied with the `alloBonus` shape. Design choices with this structure:
- Pros:
    - fits into `LibBonus` shapes easily
    - clean distribution (`giveBonus`)
- Cons:
    - special allo type
    - 1 allo <> many bonuses mapping, rather than 1 to 1
Chose this over `1 allo <> 1 bonus` structure because it was cleaner overall. Maybe would want to facelift `LibAllo` shapes a little, or even split this library up