### PR TITLE
togglable cache logging

### DIFF
--- a/packages/client/src/app/cache/account/getters.ts
+++ b/packages/client/src/app/cache/account/getters.ts
@@ -21,10 +21,11 @@ export const getKamis = (
   world: World,
   components: Components,
   entity: EntityIndex,
-  kamiOptions?: KamiRefreshOptions
+  kamiOptions?: KamiRefreshOptions,
+  debug?: boolean
 ) => {
   const kamiEntities = queryAccountKamis(world, components, entity);
-  return kamiEntities.map((kEntity) => getKami(world, components, kEntity, kamiOptions));
+  return kamiEntities.map((kEntity) => getKami(world, components, kEntity, kamiOptions, debug));
 };
 
 // get all Inventory objects for an Account entity

--- a/packages/client/src/app/cache/kami/base.ts
+++ b/packages/client/src/app/cache/kami/base.ts
@@ -56,10 +56,12 @@ export const get = (
   world: World,
   components: Components,
   entity: EntityIndex,
-  options?: RefreshOptions
+  options?: RefreshOptions,
+  debug?: boolean
 ) => {
   if (!KamiCache.has(entity)) process(world, components, entity);
   const kami = KamiCache.get(entity)!;
+  if (debug) console.log(`===retrieving kami ${kami.index} ${kami.name}===`);
   if (!options) return kami;
 
   const now = Date.now();
@@ -69,7 +71,7 @@ export const get = (
     const updateTs = LiveUpdateTs.get(entity) ?? 0;
     const updateDelta = (now - updateTs) / 1000; // convert to seconds
     if (updateDelta > options.live) {
-      console.log(`updating live state for kami ${kami.index} ${kami.name}`);
+      if (debug) console.log(`  updating live kami state`);
       kami.state = getState(components, entity);
       kami.time = {
         start: kami.time?.start ?? 0,
@@ -88,7 +90,7 @@ export const get = (
     const updateTs = BonusesUpdateTs.get(entity) ?? 0;
     const updateDelta = (now - updateTs) / 1000; // convert to seconds
     if (updateDelta > options.bonuses) {
-      console.log(`updating bonuses for kami ${kami.index} ${kami.name}`);
+      if (debug) console.log(`  updating kami bonuses`);
       kami.bonuses = getKamiBonuses(world, components, entity);
       BonusesUpdateTs.set(entity, now);
     }
@@ -99,7 +101,7 @@ export const get = (
     const updateTs = ConfigsUpdateTs.get(entity) ?? 0;
     const updateDelta = (now - updateTs) / 1000; // convert to seconds
     if (updateDelta > options.config) {
-      console.log(`updating config for kami ${kami.index} ${kami.name}`);
+      if (debug) console.log(`  updating kami config`);
       kami.config = getKamiConfigs(world, components);
       ConfigsUpdateTs.set(entity, now);
     }
@@ -110,7 +112,7 @@ export const get = (
     const updateTs = FlagsUpdateTs.get(entity) ?? 0;
     const updateDelta = (now - updateTs) / 1000; // convert to seconds
     if (updateDelta > options.flags) {
-      console.log(`updating flags for kami ${kami.index} ${kami.name}`);
+      if (debug) console.log(`  updating kami flags`);
       kami.flags = getKamiFlags(world, components, entity);
       FlagsUpdateTs.set(entity, now);
     }
@@ -122,7 +124,7 @@ export const get = (
     const updateTs = HarvestUpdateTs.get(entity) ?? 0;
     const updateDelta = (now - updateTs) / 1000; // convert to seconds
     if (updateDelta > options.harvest) {
-      console.log(`updating harvest for kami ${kami.index} ${kami.name}`);
+      if (debug) console.log(`  updating kami harvest`);
       kami.harvest = getKamiHarvest(world, components, entity);
       // NOTE: this pattern is a remnant for how calcs are currently run
       // ideally we want to flatten the shapes and avoid automatically populating
@@ -140,7 +142,7 @@ export const get = (
     const updateTs = ProgressUpdateTs.get(entity) ?? 0;
     const updateDelta = (now - updateTs) / 1000; // convert to seconds
     if (updateDelta > options.progress) {
-      console.log(`updating progress for kami ${kami.index} ${kami.name}`);
+      if (debug) console.log(`  updating kami progress`);
       kami.progress = getKamiProgress(world, components, entity);
       ProgressUpdateTs.set(entity, now);
     }
@@ -151,7 +153,7 @@ export const get = (
     const updateTs = RerollsUpdateTs.get(entity) ?? 0;
     const updateDelta = (now - updateTs) / 1000; // convert to seconds
     if (updateDelta > options.rerolls) {
-      console.log(`updating rerolls for kami ${kami.index} ${kami.name}`);
+      if (debug) console.log(`  updating kami rerolls`);
       kami.rerolls = getRerolls(components, entity);
       RerollsUpdateTs.set(entity, now);
     }
@@ -163,7 +165,7 @@ export const get = (
     const updateTs = SkillsUpdateTs.get(entity) ?? 0;
     const updateDelta = (now - updateTs) / 1000; // convert to seconds
     if (updateDelta > options.skills) {
-      console.log(`updating skills for kami ${kami.index} ${kami.name}`);
+      if (debug) console.log(`  updating kami skills`);
       kami.skills = getKamiSkills(world, components, entity);
       SkillsUpdateTs.set(entity, now);
     }
@@ -174,7 +176,7 @@ export const get = (
     const updateTs = StatsUpdateTs.get(entity) ?? 0;
     const updateDelta = (now - updateTs) / 1000; // convert to seconds
     if (updateDelta > options.stats) {
-      console.log(`updating stats for kami ${kami.index} ${kami.name}`);
+      if (debug) console.log(`  updating kami stats`);
       kami.stats = getKamiStats(world, components, entity, true);
       StatsUpdateTs.set(entity, now);
     }
@@ -185,7 +187,7 @@ export const get = (
     const updateTs = TimeUpdateTs.get(entity) ?? 0;
     const updateDelta = (now - updateTs) / 1000; // convert to seconds
     if (updateDelta > options.time) {
-      console.log(`updating times for kami ${kami.index} ${kami.name}`);
+      if (debug) console.log(`  updating kami times`);
       kami.time = getKamiTimes(components, entity);
       TimeUpdateTs.set(entity, now);
     }
@@ -196,13 +198,15 @@ export const get = (
     const updateTs = TraitsUpdateTs.get(entity) ?? 0;
     const updateDelta = (now - updateTs) / 1000; // convert to seconds
     if (updateDelta > options.traits) {
-      console.log(`updating traits for kami ${kami.index} ${kami.name}`);
+      if (debug) console.log(`  updating kami traits`);
       kami.traits = getKamiTraits(world, components, entity);
       TraitsUpdateTs.set(entity, now);
     }
   }
 
+  if (debug) console.log(`  updating health rate`);
   updateHealthRate(kami);
+  if (debug) console.log(`finished retrieving kami ${kami.index} ${kami.name}`);
   return kami;
 };
 

--- a/packages/client/src/app/components/modals/inventory/Inventory.tsx
+++ b/packages/client/src/app/components/modals/inventory/Inventory.tsx
@@ -3,6 +3,7 @@ import { interval, map } from 'rxjs';
 import { getAccount, getAccountInventories, getAccountKamis } from 'app/cache/account';
 import { ModalHeader, ModalWrapper } from 'app/components/library';
 import { registerUIComponent } from 'app/root';
+import { useAccount } from 'app/stores';
 import { inventoryIcon } from 'assets/images/icons/menu';
 import { Account, queryAccountFromEmbedded } from 'network/shapes/Account';
 import { passesConditions } from 'network/shapes/Conditional';
@@ -27,6 +28,7 @@ export function registerInventoryModal() {
         map(() => {
           const { network } = layers;
           const { world, components } = network;
+          const { debug } = useAccount.getState();
           const accountEntity = queryAccountFromEmbedded(network);
           const kamiRefreshOptions = {
             live: 0,
@@ -47,7 +49,8 @@ export function registerInventoryModal() {
             utils: {
               getAccount: () => getAccount(world, components, accountEntity),
               getInventories: () => getAccountInventories(world, components, accountEntity),
-              getKamis: () => getAccountKamis(world, components, accountEntity, kamiRefreshOptions),
+              getKamis: () =>
+                getAccountKamis(world, components, accountEntity, kamiRefreshOptions, debug.cache),
               meetsRequirements: (holder: Kami | Account, item: Item) =>
                 passesConditions(world, components, item.requirements.use, holder),
               getMusuBalance: () => getMusuBalance(world, components, accountEntity),

--- a/packages/client/src/app/components/modals/party/Party.tsx
+++ b/packages/client/src/app/components/modals/party/Party.tsx
@@ -4,6 +4,7 @@ import { getAccount, getAccountKamis } from 'app/cache/account';
 import { ModalHeader, ModalWrapper } from 'app/components/library';
 import { UseItemButton } from 'app/components/library/actions';
 import { registerUIComponent } from 'app/root';
+import { useAccount } from 'app/stores';
 import { kamiIcon } from 'assets/images/icons/menu';
 import { Account, queryAccountFromEmbedded } from 'network/shapes/Account';
 import { Kami } from 'network/shapes/Kami';
@@ -25,6 +26,7 @@ export function registerPartyModal() {
         map(() => {
           const { network } = layers;
           const { world, components } = network;
+          const { debug } = useAccount.getState();
 
           const accountEntity = queryAccountFromEmbedded(network);
           const accRefreshOptions = {
@@ -53,7 +55,8 @@ export function registerPartyModal() {
             },
             utils: {
               getAccount: () => getAccount(world, components, accountEntity, accRefreshOptions),
-              getKamis: () => getAccountKamis(world, components, accountEntity, kamiRefreshOptions),
+              getKamis: () =>
+                getAccountKamis(world, components, accountEntity, kamiRefreshOptions, debug.cache),
             },
           };
         })

--- a/packages/client/src/app/components/modals/settings/Debugging.tsx
+++ b/packages/client/src/app/components/modals/settings/Debugging.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 import { ActionButton } from 'app/components/library';
-import { useVisibility } from 'app/stores';
+import { useAccount, useVisibility } from 'app/stores';
 
 interface Props {
   actions: {
@@ -12,7 +12,12 @@ interface Props {
 
 export const Debugging = (props: Props) => {
   const { actions } = props;
+  const { debug, setDebug } = useAccount();
   const { modals, setModals } = useVisibility();
+
+  const toggleDebug = () => {
+    setDebug({ cache: !debug.cache });
+  };
 
   const FieldRow = (label: string, buttonText: string, onClick: () => void) => {
     return (
@@ -34,6 +39,7 @@ export const Debugging = (props: Props) => {
         {FieldRow('Commits Modal', 'Open', () => setModals({ reveal: true }))}
         {FieldRow('Sync kamis', 'sync', actions.echoKamis)}
         {FieldRow('Sync location', 'sync', actions.echoRoom)}
+        {FieldRow('Cache Debugging', debug.cache ? 'turn off' : 'turn on', toggleDebug)}
       </Section>
     </Container>
   );

--- a/packages/client/src/app/stores/account.ts
+++ b/packages/client/src/app/stores/account.ts
@@ -9,10 +9,12 @@ interface State {
   account: Account;
   farcaster: Farcaster; // kinda gross to have this in here
   validations: Validations;
+  debug: Debug;
 }
 
 interface Actions {
   setAccount: (data: Account) => void;
+  setDebug: (data: Debug) => void;
   setFarcaster: (data: Farcaster) => void;
   setValidations: (data: Validations) => void;
 }
@@ -39,6 +41,10 @@ export const emptyAccountDetails = (): Account => ({
   operatorAddress: '',
 });
 
+interface Debug {
+  cache: boolean;
+}
+
 ////////////////
 // FARCASTER
 
@@ -63,6 +69,7 @@ interface Validations {
 export const useAccount = create<State & Actions>((set) => {
   const initialState: State = {
     account: emptyAccountDetails(),
+    debug: { cache: false },
     farcaster: { id: 0, signer: '' },
     validations: {
       accountExists: false,
@@ -73,6 +80,7 @@ export const useAccount = create<State & Actions>((set) => {
   return {
     ...initialState,
     setAccount: (data: Account) => set((state: State) => ({ ...state, account: data })),
+    setDebug: (data: Debug) => set((state: State) => ({ ...state, debug: data })),
     setFarcaster: (data: Farcaster) => set((state: State) => ({ ...state, farcaster: data })),
     setValidations: (data: Validations) => set((state: State) => ({ ...state, validations: data })),
   };


### PR DESCRIPTION
adds a toggle for kami cache logging, which is enabled on the inventory and party modals