### PR TITLE
Fix Popover showing when there is no content

### DIFF
--- a/packages/client/src/app/components/library/base/Popover.tsx
+++ b/packages/client/src/app/components/library/base/Popover.tsx
@@ -72,8 +72,10 @@ export const Popover = (props: Props) => {
       <PopoverTrigger
         ref={triggerRef}
         onClick={(e) => {
-          handlePosition();
-          setIsVisible(!isVisible);
+          if (content.length !== 0) {
+            handlePosition();
+            setIsVisible(!isVisible);
+          }
         }}
       >
         {children}


### PR DESCRIPTION
This PR fixes having an empty box/ black dot appear when there is no content passed to PopOver.

![image](https://github.com/user-attachments/assets/697387b5-a8fa-4062-86ad-f514dce59264)
