### PR TITLE
Shape specific conditionals

### DIFF
--- a/packages/client/abi/_RecipeRegistrySystem.json
+++ b/packages/client/abi/_RecipeRegistrySystem.json
@@ -68,6 +68,11 @@
           "name": "value",
           "type": "uint32",
           "internalType": "uint32"
+        },
+        {
+          "name": "condFor",
+          "type": "string",
+          "internalType": "string"
         }
       ],
       "outputs": [
@@ -290,7 +295,7 @@
   ],
   "methodIdentifiers": {
     "addAssigner(uint32,uint256)": "32a3075b",
-    "addRequirement(uint32,string,string,uint32,uint32)": "bc244f02",
+    "addRequirement(uint32,string,string,uint32,uint32,string)": "51e12765",
     "cancelOwnershipHandover()": "54d1f13d",
     "completeOwnershipHandover(address)": "f04e283e",
     "create(bytes)": "cf5ba53f",

--- a/packages/client/types/ethers-contracts/_RecipeRegistrySystem.ts
+++ b/packages/client/types/ethers-contracts/_RecipeRegistrySystem.ts
@@ -31,7 +31,7 @@ import type {
 export interface _RecipeRegistrySystemInterface extends utils.Interface {
   functions: {
     "addAssigner(uint32,uint256)": FunctionFragment;
-    "addRequirement(uint32,string,string,uint32,uint32)": FunctionFragment;
+    "addRequirement(uint32,string,string,uint32,uint32,string)": FunctionFragment;
     "cancelOwnershipHandover()": FunctionFragment;
     "completeOwnershipHandover(address)": FunctionFragment;
     "create(bytes)": FunctionFragment;
@@ -73,7 +73,8 @@ export interface _RecipeRegistrySystemInterface extends utils.Interface {
       PromiseOrValue<string>,
       PromiseOrValue<string>,
       PromiseOrValue<BigNumberish>,
-      PromiseOrValue<BigNumberish>
+      PromiseOrValue<BigNumberish>,
+      PromiseOrValue<string>
     ]
   ): string;
   encodeFunctionData(
@@ -245,6 +246,7 @@ export interface _RecipeRegistrySystem extends BaseContract {
       type_: PromiseOrValue<string>,
       index: PromiseOrValue<BigNumberish>,
       value: PromiseOrValue<BigNumberish>,
+      condFor: PromiseOrValue<string>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
@@ -309,6 +311,7 @@ export interface _RecipeRegistrySystem extends BaseContract {
     type_: PromiseOrValue<string>,
     index: PromiseOrValue<BigNumberish>,
     value: PromiseOrValue<BigNumberish>,
+    condFor: PromiseOrValue<string>,
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
@@ -373,6 +376,7 @@ export interface _RecipeRegistrySystem extends BaseContract {
       type_: PromiseOrValue<string>,
       index: PromiseOrValue<BigNumberish>,
       value: PromiseOrValue<BigNumberish>,
+      condFor: PromiseOrValue<string>,
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
@@ -458,6 +462,7 @@ export interface _RecipeRegistrySystem extends BaseContract {
       type_: PromiseOrValue<string>,
       index: PromiseOrValue<BigNumberish>,
       value: PromiseOrValue<BigNumberish>,
+      condFor: PromiseOrValue<string>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
@@ -523,6 +528,7 @@ export interface _RecipeRegistrySystem extends BaseContract {
       type_: PromiseOrValue<string>,
       index: PromiseOrValue<BigNumberish>,
       value: PromiseOrValue<BigNumberish>,
+      condFor: PromiseOrValue<string>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 

--- a/packages/contracts/deploy.json
+++ b/packages/contracts/deploy.json
@@ -136,6 +136,7 @@
       "writeAccess": [
         "EntityType",
         "Experience",
+        "ForString",
         "IDFrom",
         "IDParent",
         "IDTo",
@@ -145,7 +146,6 @@
         "LogicType",
         "Keys",
         "Stamina",
-        "Subtype",
         "Values",
         "Value",
         "Type"
@@ -159,6 +159,7 @@
       "name": "_RoomRegistrySystem",
       "writeAccess": [
         "EntityType",
+        "ForString",
         "IDParent",
         "IDRoom",
         "IndexRoom",
@@ -169,7 +170,6 @@
         "LogicType",
         "Name",
         "Type",
-        "Subtype",
         "Value"
       ]
     },

--- a/packages/contracts/src/deployment/world/admin.ts
+++ b/packages/contracts/src/deployment/world/admin.ts
@@ -109,13 +109,14 @@ export function createAdminAPI(compiledCalls: string[]) {
     type: string,
     logic: string,
     conIndex: number,
-    conValue: number
+    conValue: number,
+    conFor: string
   ) {
     genCall(
       'system.goal.registry',
-      [goalIndex, type, logic, conIndex, conValue],
+      [goalIndex, type, logic, conIndex, conValue, conFor],
       'addRequirement',
-      ['uint32', 'string', 'string', 'uint32', 'uint256']
+      ['uint32', 'string', 'string', 'uint32', 'uint256', 'string']
     );
   }
 
@@ -243,13 +244,14 @@ export function createAdminAPI(compiledCalls: string[]) {
     conditionType: string,
     logicType: string,
     index: number,
-    value: BigNumberish
+    value: BigNumberish,
+    for_: string
   ) {
     genCall(
       'system.listing.registry',
-      [merchantIndex, itemIndex, conditionType, logicType, index, value],
+      [merchantIndex, itemIndex, conditionType, logicType, index, value, for_],
       'addRequirement',
-      ['uint32', 'uint32', 'string', 'string', 'uint32', 'uint256']
+      ['uint32', 'uint32', 'string', 'string', 'uint32', 'uint256', 'string']
     );
   }
 
@@ -285,19 +287,19 @@ export function createAdminAPI(compiledCalls: string[]) {
 
   async function createNodeRequirement(
     index: number,
-    for_: string,
     type: string,
     logic: string,
     index_: number,
-    value: number
+    value: number,
+    for_: string
   ) {
-    genCall('system.node.registry', [index, for_, type, logic, index_, value], 'addRequirement', [
+    genCall('system.node.registry', [index, type, logic, index_, value, for_], 'addRequirement', [
       'uint32',
-      'string',
       'string',
       'string',
       'uint32',
       'uint256',
+      'string',
     ]);
   }
 
@@ -372,13 +374,14 @@ export function createAdminAPI(compiledCalls: string[]) {
     logicType: string,
     type: string,
     index: number,
-    value: BigNumberish
+    value: BigNumberish,
+    for_: string
   ) {
     genCall(
       'system.quest.registry',
-      [questIndex, name, logicType, type, index, value],
+      [questIndex, name, logicType, type, index, value, for_],
       'addObjective',
-      ['uint32', 'string', 'string', 'string', 'uint32', 'uint256']
+      ['uint32', 'string', 'string', 'string', 'uint32', 'uint256', 'string']
     );
   }
 
@@ -388,13 +391,14 @@ export function createAdminAPI(compiledCalls: string[]) {
     logicType: string,
     type: string,
     index: number,
-    value: BigNumberish
+    value: BigNumberish,
+    for_: string
   ) {
     genCall(
       'system.quest.registry',
-      [questIndex, logicType, type, index, value],
+      [questIndex, logicType, type, index, value, for_],
       'addRequirement',
-      ['uint32', 'string', 'string', 'uint32', 'uint256']
+      ['uint32', 'string', 'string', 'uint32', 'uint256', 'string']
     );
   }
 
@@ -472,9 +476,10 @@ export function createAdminAPI(compiledCalls: string[]) {
     type: string,
     logic: string,
     index_: number,
-    value: number
+    value: number,
+    for_: string
   ) {
-    genCall('system.recipe.registry', [index, type, logic, index_, value], 'addRequirement');
+    genCall('system.recipe.registry', [index, type, logic, index_, value, for_], 'addRequirement');
   }
 
   async function deleteRecipe(index: number) {
@@ -508,13 +513,14 @@ export function createAdminAPI(compiledCalls: string[]) {
     conditionIndex: number,
     conditionValue: BigNumberish,
     type: string,
-    logicType: string
+    logicType: string,
+    for_: string
   ) {
     genCall(
       'system.room.registry',
-      [roomIndex, sourceIndex, conditionIndex, conditionValue, type, logicType],
+      [roomIndex, sourceIndex, conditionIndex, conditionValue, type, logicType, for_],
       'addGate',
-      ['uint32', 'uint32', 'uint32', 'uint256', 'string', 'string']
+      ['uint32', 'uint32', 'uint32', 'uint256', 'string', 'string', 'string']
     );
   }
 
@@ -561,13 +567,14 @@ export function createAdminAPI(compiledCalls: string[]) {
     type: string,
     logicType: string,
     index: number,
-    value: number
+    value: number,
+    for_: string
   ) {
     genCall(
       'system.skill.registry',
-      [skillIndex, type, logicType, index, value],
+      [skillIndex, type, logicType, index, value, for_],
       'addRequirement',
-      ['uint32', 'string', 'string', 'uint32', 'uint256']
+      ['uint32', 'string', 'string', 'uint32', 'uint256', 'string']
     );
   }
 
@@ -678,13 +685,14 @@ export function createAdminAPI(compiledCalls: string[]) {
     type_: string,
     logicType: string,
     index_: number,
-    value: number
+    value: number,
+    for_: string
   ) {
     genCall(
       'system.item.registry',
-      [index, usecase, type_, logicType, index_, value],
+      [index, usecase, type_, logicType, index_, value, for_],
       'addRequirement',
-      ['uint32', 'string', 'string', 'string', 'uint32', 'uint256']
+      ['uint32', 'string', 'string', 'string', 'uint32', 'uint256', 'string']
     );
   }
 

--- a/packages/contracts/src/deployment/world/state/items.ts
+++ b/packages/contracts/src/deployment/world/state/items.ts
@@ -122,7 +122,8 @@ async function addRequirement(api: AdminAPI, item: any) {
     type,
     logicType,
     index,
-    value
+    value,
+    ''
   );
 }
 

--- a/packages/contracts/src/deployment/world/state/listings.ts
+++ b/packages/contracts/src/deployment/world/state/listings.ts
@@ -49,5 +49,13 @@ const initRequirement = async (
   index: number,
   value: BigNumberish
 ) => {
-  await api.listing.add.requirement(npcIndex, itemIndex, conditionType, logicType, index, value);
+  await api.listing.add.requirement(
+    npcIndex,
+    itemIndex,
+    conditionType,
+    logicType,
+    index,
+    value,
+    ''
+  );
 };

--- a/packages/contracts/src/deployment/world/state/nodes.ts
+++ b/packages/contracts/src/deployment/world/state/nodes.ts
@@ -81,11 +81,11 @@ async function initNode(api: AdminAPI, entry: any) {
 async function initRequirement(api: AdminAPI, entry: any) {
   await api.node.add.requirement(
     Number(entry['Index']),
-    'KAMI',
     'LEVEL',
     'CURR_MAX',
     0,
-    Number(entry['Level Limit'])
+    Number(entry['Level Limit']),
+    'KAMI'
   );
 }
 

--- a/packages/contracts/src/deployment/world/state/quests.ts
+++ b/packages/contracts/src/deployment/world/state/quests.ts
@@ -104,7 +104,8 @@ async function initQuestRequirement(api: AdminAPI, entry: any) {
     cond.logicType,
     cond.type,
     cond.index,
-    cond.value
+    cond.value,
+    ''
   );
 }
 
@@ -121,7 +122,8 @@ async function initQuestObjective(api: AdminAPI, entry: any) {
     entry['DeltaType'] + '_' + entry['Operator'],
     cond.type,
     cond.index,
-    cond.value
+    cond.value,
+    ''
   );
 }
 

--- a/packages/contracts/src/deployment/world/state/recipes.ts
+++ b/packages/contracts/src/deployment/world/state/recipes.ts
@@ -92,7 +92,8 @@ async function addRequirement(api: AdminAPI, entry: any) {
       'ITEM',
       'CURR_MIN',
       toolIndex,
-      1
+      1,
+      ''
     );
   }
 }

--- a/packages/contracts/src/deployment/world/state/rooms.ts
+++ b/packages/contracts/src/deployment/world/state/rooms.ts
@@ -3,12 +3,17 @@ import { getGoalID, readFile, toDelete, toRevise } from './utils';
 
 // hardcoded gates - placeholder until notion is up
 const gates = {
-  1: (api: AdminAPI) => api.room.createGate(1, 1, 0, 0, 'CURR_MIN', 'KAMI'), // load bearing test to initialse IndexSourceComponent - queries wont work without
-  12: (api: AdminAPI) => api.room.createGate(12, 0, 0, getGoalID(2), 'COMPLETE_COMP', 'BOOL_IS'),
-  31: (api: AdminAPI) => api.room.createGate(31, 0, 0, getGoalID(1), 'COMPLETE_COMP', 'BOOL_IS'),
-  50: (api: AdminAPI) => api.room.createGate(50, 0, 0, getGoalID(3), 'COMPLETE_COMP', 'BOOL_IS'),
-  53: (api: AdminAPI) => api.room.createGate(53, 0, 0, getGoalID(4), 'COMPLETE_COMP', 'BOOL_IS'),
-  55: (api: AdminAPI) => api.room.createGate(55, 0, 0, getGoalID(6), 'COMPLETE_COMP', 'BOOL_IS'),
+  1: (api: AdminAPI) => api.room.createGate(1, 1, 0, 0, 'CURR_MIN', 'KAMI', ''), // load bearing test to initialse IndexSourceComponent - queries wont work without
+  12: (api: AdminAPI) =>
+    api.room.createGate(12, 0, 0, getGoalID(2), 'COMPLETE_COMP', 'BOOL_IS', ''),
+  31: (api: AdminAPI) =>
+    api.room.createGate(31, 0, 0, getGoalID(1), 'COMPLETE_COMP', 'BOOL_IS', ''),
+  50: (api: AdminAPI) =>
+    api.room.createGate(50, 0, 0, getGoalID(3), 'COMPLETE_COMP', 'BOOL_IS', ''),
+  53: (api: AdminAPI) =>
+    api.room.createGate(53, 0, 0, getGoalID(4), 'COMPLETE_COMP', 'BOOL_IS', ''),
+  55: (api: AdminAPI) =>
+    api.room.createGate(55, 0, 0, getGoalID(6), 'COMPLETE_COMP', 'BOOL_IS', ''),
 };
 
 export async function initRooms(api: AdminAPI, overrideIndices?: number[]) {

--- a/packages/contracts/src/deployment/world/state/skills.ts
+++ b/packages/contracts/src/deployment/world/state/skills.ts
@@ -101,6 +101,6 @@ async function initMutualExclusionRequirement(api: AdminAPI, skill: any) {
 
   const values = keys.split(',');
   values.forEach(async (v: string) => {
-    await api.registry.skill.add.requirement(index, 'SKILL', 'CURR_MAX', Number(v), 0);
+    await api.registry.skill.add.requirement(index, 'SKILL', 'CURR_MAX', Number(v), 0, '');
   });
 }

--- a/packages/contracts/src/libraries/LibGoals.sol
+++ b/packages/contracts/src/libraries/LibGoals.sol
@@ -12,6 +12,7 @@ import { IsCompleteComponent, ID as IsCompleteCompID } from "components/IsComple
 import { IndexComponent, ID as IndexCompID } from "components/IndexComponent.sol";
 import { IndexRoomComponent, ID as IndexRoomCompID } from "components/IndexRoomComponent.sol";
 import { NameComponent, ID as NameCompID } from "components/NameComponent.sol";
+import { TypeComponent, ID as TypeCompID } from "components/TypeComponent.sol";
 import { ValueComponent, ID as ValueCompID } from "components/ValueComponent.sol";
 
 import { LibArray } from "libraries/utils/LibArray.sol";
@@ -147,9 +148,9 @@ library LibGoals {
     uint256 amt
   ) internal returns (uint256) {
     uint256 objID = genObjID(goalID);
-    IUintComp balComp = IUintComp(getAddrByID(components, ValueCompID));
-    uint256 currBal = balComp.safeGet(goalID);
-    uint256 targetBal = balComp.safeGet(objID);
+    IUintComp valComp = IUintComp(getAddrByID(components, ValueCompID));
+    uint256 currBal = valComp.safeGet(goalID);
+    uint256 targetBal = valComp.safeGet(objID);
 
     // cap contribution to target balance
     if (currBal + amt >= targetBal) {
@@ -159,12 +160,12 @@ library LibGoals {
     }
 
     // dec account's balance
-    string memory type_ = LibConditional.getType(components, objID);
-    uint32 index = LibConditional.getIndex(components, objID);
+    string memory type_ = TypeComponent(getAddrByID(components, TypeCompID)).get(objID);
+    uint32 index = IndexComponent(getAddrByID(components, IndexCompID)).safeGet(objID);
     LibSetter.dec(components, type_, index, amt, accID);
 
     // inc goal's balance & inc account contribution
-    balComp.set(goalID, currBal + amt);
+    valComp.set(goalID, currBal + amt);
     incContribution(components, accID, goalID, amt);
 
     return amt;

--- a/packages/contracts/src/libraries/LibNode.sol
+++ b/packages/contracts/src/libraries/LibNode.sol
@@ -52,11 +52,9 @@ library LibNode {
     IWorld world,
     IUintComp components,
     uint32 nodeIndex,
-    string memory for_,
     Condition memory req
   ) internal returns (uint256 id) {
     id = LibConditional.createFor(world, components, req, genReqAnchor(nodeIndex));
-    LibFor.set(components, id, for_);
   }
 
   function addScavBar(

--- a/packages/contracts/src/libraries/LibQuests.sol
+++ b/packages/contracts/src/libraries/LibQuests.sol
@@ -190,16 +190,17 @@ library LibQuests {
     Condition[] memory objs = LibConditional.get(components, objIDs);
 
     for (uint256 i; i < objs.length; i++) {
+      uint256 targetID = LibConditional.parseTargetShape(components, accID, objs[i].for_);
       (HANDLER handler, LOGIC operator) = LibConditional.parseLogic(objs[i]);
 
       if (handler == HANDLER.CURRENT) {
-        result = LibConditional._checkCurr(components, accID, objs[i], operator);
+        result = LibConditional._checkCurr(components, targetID, objs[i], operator);
       } else if (handler == HANDLER.INCREASE) {
-        result = checkIncrease(components, accID, questID, objIDs[i], objs[i], operator);
+        result = checkIncrease(components, targetID, questID, objIDs[i], objs[i], operator);
       } else if (handler == HANDLER.DECREASE) {
-        result = checkDecrease(components, accID, questID, objIDs[i], objs[i], operator);
+        result = checkDecrease(components, targetID, questID, objIDs[i], objs[i], operator);
       } else if (handler == HANDLER.BOOLEAN) {
-        result = LibConditional._checkBool(components, accID, objs[i], operator);
+        result = LibConditional._checkBool(components, targetID, objs[i], operator);
       } else {
         revert("Unknown objective handler");
       }

--- a/packages/contracts/src/libraries/LibRoom.sol
+++ b/packages/contracts/src/libraries/LibRoom.sol
@@ -50,13 +50,10 @@ library LibRoom {
     IUintComp components,
     uint32 roomIndex,
     uint32 sourceIndex, // optional: if condition specific from Room A->B
-    uint32 condIndex,
-    uint256 condValue,
-    string memory type_,
-    string memory logicType
+    Condition memory data
   ) internal returns (uint256 id) {
     id = world.getUniqueEntityId();
-    LibConditional.create(components, id, Condition(type_, logicType, condIndex, condValue));
+    LibConditional.create(components, id, data);
 
     IDRoomComponent(getAddrByID(components, IDRoomCompID)).set(id, genGateAtPtr(roomIndex));
     IDParentComponent sourceComp = IDParentComponent(getAddrByID(components, IDParentCompID));
@@ -139,6 +136,14 @@ library LibRoom {
   /////////////////
   // GETTERS
 
+  function get(IUintComp components, uint256 id) internal view returns (uint32) {
+    return IndexRoomComponent(getAddrByID(components, IndexRoomCompID)).safeGet(id);
+  }
+
+  function getLocation(IUintComp components, uint256 id) internal view returns (Coord memory) {
+    return LocationComponent(getAddrByID(components, LocationCompID)).get(id);
+  }
+
   /// @notice Get all the possible exits of a given room.
   /// @dev rooms can exit to adjacent rooms by default; this is for special exits (ie portals from A->B)
   function getSpecialExits(
@@ -147,14 +152,6 @@ library LibRoom {
   ) internal view returns (uint32[] memory) {
     ExitsComponent comp = ExitsComponent(getAddrByID(components, ExitsCompID));
     return comp.has(id) ? comp.get(id) : new uint32[](0);
-  }
-
-  function getIndex(IUintComp components, uint256 id) internal view returns (uint32) {
-    return IndexRoomComponent(getAddrByID(components, IndexRoomCompID)).get(id);
-  }
-
-  function getLocation(IUintComp components, uint256 id) internal view returns (Coord memory) {
-    return LocationComponent(getAddrByID(components, LocationCompID)).get(id);
   }
 
   /////////////////

--- a/packages/contracts/src/libraries/utils/LibFor.sol
+++ b/packages/contracts/src/libraries/utils/LibFor.sol
@@ -39,11 +39,11 @@ library LibFor {
   // GETTERS
 
   function get(IUintComp components, uint256 id) internal view returns (string memory) {
-    return ForStringComponent(getAddrByID(components, ForStringCompID)).get(id);
+    return ForStringComponent(getAddrByID(components, ForStringCompID)).safeGet(id);
   }
 
   function get(IUintComp components, uint256[] memory ids) internal view returns (string[] memory) {
-    return ForStringComponent(getAddrByID(components, ForStringCompID)).get(ids);
+    return ForStringComponent(getAddrByID(components, ForStringCompID)).safeGet(ids);
   }
 
   /////////////////

--- a/packages/contracts/src/libraries/utils/LibGetter.sol
+++ b/packages/contracts/src/libraries/utils/LibGetter.sol
@@ -85,7 +85,7 @@ library LibGetter {
     } else if (_type.eq("QUEST")) {
       return LibQuests.checkAccQuestComplete(components, index, targetID);
     } else if (_type.eq("ROOM")) {
-      return LibRoom.getIndex(components, targetID) == index;
+      return getRoom(components, targetID) == index;
     } else if (_type.eq("PHASE")) {
       return LibPhase.get(block.timestamp) == index;
     } else if (_type.eq("COOLDOWN")) {
@@ -100,6 +100,26 @@ library LibGetter {
     } else {
       revert("Unknown bool condition type");
     }
+  }
+
+  ///////////////
+  // SHAPE SPECIFIC GETTERS
+
+  /// @dev checks for any many types of entity shapes. if shape is known beforehand, query account directly
+  function getAccount(IUintComp components, uint256 id) internal view returns (uint256) {
+    string memory shape = LibEntityType.get(components, id);
+
+    if (shape.eq("ACCOUNT")) return id;
+    else if (shape.eq("KAMI")) return LibKami.getAccount(components, id);
+    else revert("LibGetter: invalid entity shape (no acc)");
+  }
+
+  /// @dev checks for any many types of entity shapes. if shape is known beforehand, query room directly
+  function getRoom(IUintComp components, uint256 id) internal view returns (uint32) {
+    string memory shape = LibEntityType.get(components, id);
+
+    if (shape.eq("KAMI")) return LibKami.getRoom(components, id);
+    else return LibRoom.get(components, id);
   }
 
   ///////////////

--- a/packages/contracts/src/systems/_GoalRegistrySystem.sol
+++ b/packages/contracts/src/systems/_GoalRegistrySystem.sol
@@ -25,7 +25,7 @@ contract _GoalRegistrySystem is System {
       uint32 objIndex,
       uint256 objValue
     ) = abi.decode(arguments, (uint32, string, string, uint32, string, string, uint32, uint256));
-    Condition memory objective = Condition(objType, objLogic, objIndex, objValue);
+    Condition memory objective = Condition(objType, objLogic, objIndex, objValue, ""); // no for
 
     // check that the goal exists
     require(LibGoals.getByIndex(components, goalIndex) == 0, "Goal alr exist");
@@ -36,15 +36,17 @@ contract _GoalRegistrySystem is System {
     return LibGoals.create(components, goalIndex, name, description, roomIndex, objective);
   }
 
+  /// pulltodo
   function addRequirement(bytes memory arguments) public onlyOwner returns (uint256) {
     (
       uint32 goalIndex,
       string memory reqType,
       string memory reqLogic,
       uint32 reqIndex,
-      uint256 reqValue
-    ) = abi.decode(arguments, (uint32, string, string, uint32, uint256));
-    Condition memory requirement = Condition(reqType, reqLogic, reqIndex, reqValue);
+      uint256 reqValue,
+      string memory reqFor
+    ) = abi.decode(arguments, (uint32, string, string, uint32, uint256, string));
+    Condition memory requirement = Condition(reqType, reqLogic, reqIndex, reqValue, reqFor);
     // check that the goal exists
     require(LibGoals.getByIndex(components, goalIndex) != 0, "Goal does not exist");
     require(!LibString.eq(requirement.type_, ""), "Req type cannot be empty");

--- a/packages/contracts/src/systems/_ItemRegistrySystem.sol
+++ b/packages/contracts/src/systems/_ItemRegistrySystem.sol
@@ -60,6 +60,7 @@ contract _ItemRegistrySystem is System {
     return id;
   }
 
+  /// pulltodo
   function addRequirement(bytes memory arguments) public onlyOwner returns (uint256) {
     (
       uint32 index,
@@ -67,8 +68,9 @@ contract _ItemRegistrySystem is System {
       string memory condType,
       string memory condLogic,
       uint32 condIndex,
-      uint256 condValue
-    ) = abi.decode(arguments, (uint32, string, string, string, uint32, uint256));
+      uint256 condValue,
+      string memory condFor
+    ) = abi.decode(arguments, (uint32, string, string, string, uint32, uint256, string));
     require(LibItem.getByIndex(components, index) != 0, "ItemReg: item does not exist");
 
     return
@@ -77,7 +79,7 @@ contract _ItemRegistrySystem is System {
         components,
         index,
         useCase,
-        Condition(condType, condLogic, condIndex, condValue)
+        Condition(condType, condLogic, condIndex, condValue, condFor)
       );
   }
 

--- a/packages/contracts/src/systems/_ListingRegistrySystem.sol
+++ b/packages/contracts/src/systems/_ListingRegistrySystem.sol
@@ -31,6 +31,7 @@ contract _ListingRegistrySystem is System {
     return abi.encode(id);
   }
 
+  /// pulltodo
   function addRequirement(bytes memory arguments) public onlyOwner {
     (
       uint32 npcIndex,
@@ -38,8 +39,9 @@ contract _ListingRegistrySystem is System {
       string memory reqType,
       string memory logicType,
       uint32 index,
-      uint256 value
-    ) = abi.decode(arguments, (uint32, uint32, string, string, uint32, uint256));
+      uint256 value,
+      string memory condFor
+    ) = abi.decode(arguments, (uint32, uint32, string, string, uint32, uint256, string));
 
     require(LibNPC.get(components, npcIndex) != 0, "NPC: does not exist");
     require(LibItem.getByIndex(components, itemIndex) != 0, "Item: does not exist");
@@ -51,7 +53,7 @@ contract _ListingRegistrySystem is System {
       world,
       components,
       id,
-      Condition(reqType, logicType, index, value)
+      Condition(reqType, logicType, index, value, condFor)
     );
   }
 

--- a/packages/contracts/src/systems/_NodeRegistrySystem.sol
+++ b/packages/contracts/src/systems/_NodeRegistrySystem.sol
@@ -37,15 +37,16 @@ contract _NodeRegistrySystem is System {
     return id;
   }
 
+  /// pulltodo
   function addRequirement(bytes memory arguments) public onlyOwner returns (uint256) {
     (
       uint32 nodeIndex,
-      string memory for_,
       string memory type_,
       string memory logicType,
       uint32 index,
-      uint256 value
-    ) = abi.decode(arguments, (uint32, string, string, string, uint32, uint256));
+      uint256 value,
+      string memory for_
+    ) = abi.decode(arguments, (uint32, string, string, uint32, uint256, string));
 
     uint256 nodeID = LibNode.getByIndex(components, nodeIndex);
     require(nodeID != 0, "Node does not exist");
@@ -56,8 +57,7 @@ contract _NodeRegistrySystem is System {
         world,
         components,
         nodeIndex,
-        for_,
-        Condition(type_, logicType, index, value)
+        Condition(type_, logicType, index, value, for_)
       );
   }
 

--- a/packages/contracts/src/systems/_QuestRegistrySystem.sol
+++ b/packages/contracts/src/systems/_QuestRegistrySystem.sol
@@ -32,6 +32,7 @@ contract _QuestRegistrySystem is System {
     return regID;
   }
 
+  /// pulltodo
   function addObjective(bytes memory arguments) public onlyOwner returns (uint256) {
     (
       uint32 questIndex,
@@ -39,8 +40,9 @@ contract _QuestRegistrySystem is System {
       string memory logicType,
       string memory type_,
       uint32 index, // generic index
-      uint256 value
-    ) = abi.decode(arguments, (uint32, string, string, string, uint32, uint256));
+      uint256 value,
+      string memory condFor
+    ) = abi.decode(arguments, (uint32, string, string, string, uint32, uint256, string));
 
     uint256 questID = LibQuestRegistry.getByIndex(components, questIndex);
     require(questID != 0, "Quest does not exist");
@@ -52,18 +54,20 @@ contract _QuestRegistrySystem is System {
         components,
         questIndex,
         name,
-        Condition(type_, logicType, index, value)
+        Condition(type_, logicType, index, value, condFor)
       );
   }
 
+  /// pulltodo
   function addRequirement(bytes memory arguments) public onlyOwner returns (uint256) {
     (
       uint32 questIndex,
       string memory logicType,
       string memory type_,
       uint32 index,
-      uint256 value
-    ) = abi.decode(arguments, (uint32, string, string, uint32, uint256));
+      uint256 value,
+      string memory condFor
+    ) = abi.decode(arguments, (uint32, string, string, uint32, uint256, string));
 
     uint256 questID = LibQuestRegistry.getByIndex(components, questIndex);
     require(questID != 0, "Quest does not exist");
@@ -74,7 +78,7 @@ contract _QuestRegistrySystem is System {
         world,
         components,
         questIndex,
-        Condition(type_, logicType, index, value)
+        Condition(type_, logicType, index, value, condFor)
       );
   }
 

--- a/packages/contracts/src/systems/_RecipeRegistrySystem.sol
+++ b/packages/contracts/src/systems/_RecipeRegistrySystem.sol
@@ -36,19 +36,21 @@ contract _RecipeRegistrySystem is System {
     return LibRecipe.addAssigner(components, regID, index, assignerID);
   }
 
+  /// pulltodo
   function addRequirement(
     uint32 recipeIndex,
     string memory logicType,
     string memory type_,
     uint32 index, // can be empty
-    uint32 value // can be empty
+    uint32 value, // can be empty
+    string memory condFor
   ) public onlyOwner returns (uint256) {
     return
       LibRecipe.createRequirement(
         world,
         components,
         recipeIndex,
-        Condition(logicType, type_, index, value)
+        Condition(logicType, type_, index, value, condFor)
       );
   }
 

--- a/packages/contracts/src/systems/_RoomRegistrySystem.sol
+++ b/packages/contracts/src/systems/_RoomRegistrySystem.sol
@@ -6,6 +6,7 @@ import { IWorld } from "solecs/interfaces/IWorld.sol";
 import { getAddrByID } from "solecs/utils.sol";
 
 import { Coord, LibRoom } from "libraries/LibRoom.sol";
+import { Condition } from "libraries/LibConditional.sol";
 
 uint256 constant ID = uint256(keccak256("system.room.registry"));
 
@@ -35,6 +36,7 @@ contract _RoomRegistrySystem is System {
     return id;
   }
 
+  /// pulltodo
   function addGate(bytes memory arguments) public onlyOwner returns (uint256) {
     (
       uint32 roomIndex,
@@ -42,8 +44,9 @@ contract _RoomRegistrySystem is System {
       uint32 conditionIndex,
       uint256 conditionValue,
       string memory type_,
-      string memory logicType
-    ) = abi.decode(arguments, (uint32, uint32, uint32, uint256, string, string));
+      string memory logicType,
+      string memory condFor
+    ) = abi.decode(arguments, (uint32, uint32, uint32, uint256, string, string, string));
 
     require(LibRoom.getByIndex(components, roomIndex) != 0, "Room: does not exist");
     require(
@@ -57,10 +60,7 @@ contract _RoomRegistrySystem is System {
         components,
         roomIndex,
         sourceIndex,
-        conditionIndex,
-        conditionValue,
-        type_,
-        logicType
+        Condition(type_, logicType, conditionIndex, conditionValue, condFor)
       );
   }
 

--- a/packages/contracts/src/systems/_SkillRegistrySystem.sol
+++ b/packages/contracts/src/systems/_SkillRegistrySystem.sol
@@ -63,20 +63,26 @@ contract _SkillRegistrySystem is System {
     return id;
   }
 
+  /// pulltodo
   function addRequirement(bytes memory arguments) public onlyOwner returns (uint256) {
     (
       uint32 skillIndex,
       string memory type_,
       string memory logicType,
       uint32 index,
-      uint256 value
-    ) = abi.decode(arguments, (uint32, string, string, uint32, uint256));
+      uint256 value,
+      string memory condFor
+    ) = abi.decode(arguments, (uint32, string, string, uint32, uint256, string));
 
     require(LibSkillRegistry.getByIndex(components, skillIndex) != 0, "Skill does not exist");
 
-    Condition memory data = Condition(type_, logicType, index, value);
-    uint256 id = LibSkillRegistry.addRequirement(world, components, skillIndex, data);
-    return id;
+    return
+      LibSkillRegistry.addRequirement(
+        world,
+        components,
+        skillIndex,
+        Condition(type_, logicType, index, value, condFor)
+      );
   }
 
   function remove(uint32 index) public onlyOwner {

--- a/packages/contracts/src/test/libs/Conditional.t.sol
+++ b/packages/contracts/src/test/libs/Conditional.t.sol
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+import "tests/utils/SetupTemplate.t.sol";
+
+contract ConditionalTest is SetupTemplate {
+  Wrapper wrapper;
+  uint256[] conditions;
+  uint256 parentID;
+
+  function setUp() public override {
+    super.setUp();
+    wrapper = new Wrapper();
+  }
+
+  function testConditionalShape() public {
+    /// creating
+
+    uint256 conID = _create("ITEM", "CURR_MIN", 0, 1, "", parentID);
+    assertTrue(_TypeComponent.has(conID));
+    assertTrue(_LogicTypeComponent.has(conID));
+    assertFalse(_IndexComponent.has(conID)); // index was 0, skipped
+    assertTrue(_ValueComponent.has(conID));
+    assertFalse(_ForStringComponent.has(conID)); // for was empty, skipped
+
+    uint256 conID2 = _create("ITEM", "CURR_MIN", 1, 0, "for", parentID);
+    assertTrue(_TypeComponent.has(conID2));
+    assertTrue(_LogicTypeComponent.has(conID2));
+    assertTrue(_IndexComponent.has(conID2));
+    assertFalse(_ValueComponent.has(conID2)); // value was 0, skipped
+    assertTrue(_ForStringComponent.has(conID2));
+
+    /// querying
+
+    uint256[] memory queryIDs = LibConditional.queryFor(components, parentID);
+    assertEq(queryIDs.length, 2);
+    assertEq(queryIDs[0], conID);
+    assertEq(queryIDs[1], conID2);
+
+    /// deleting
+
+    vm.startPrank(deployer);
+    LibConditional.remove(components, conID);
+    assertFalse(_TypeComponent.has(conID));
+    assertFalse(_LogicTypeComponent.has(conID));
+    assertFalse(_IndexComponent.has(conID));
+    assertFalse(_ValueComponent.has(conID));
+    assertFalse(_ForStringComponent.has(conID));
+
+    LibConditional.remove(components, conID2);
+    assertFalse(_TypeComponent.has(conID2));
+    assertFalse(_LogicTypeComponent.has(conID2));
+    assertFalse(_IndexComponent.has(conID2));
+    assertFalse(_ValueComponent.has(conID2));
+    assertFalse(_ForStringComponent.has(conID2));
+  }
+
+  function testConditionalForShapeParse() public {
+    uint256 kamiID = _mintKami(alice);
+    Condition memory data = Condition("type", "logic", 3, 5, "for");
+
+    data.for_ = "ACCOUNT";
+    uint256 id = LibConditional.parseTargetShape(components, alice.id, data.for_);
+    assertEq(id, alice.id);
+    id = LibConditional.parseTargetShape(components, kamiID, data.for_);
+    assertEq(id, alice.id);
+
+    data.for_ = "ROOM";
+    id = LibConditional.parseTargetShape(components, alice.id, data.for_);
+    assertEq(id, LibRoom.getByIndex(components, 1));
+    id = LibConditional.parseTargetShape(components, kamiID, data.for_);
+    assertEq(id, LibRoom.getByIndex(components, 1));
+
+    data.for_ = "KAMI";
+    vm.expectRevert("LibCon: invalid for (exp kami, not kami)");
+    wrapper.parseTargetShape(components, alice.id, data.for_);
+    id = LibConditional.parseTargetShape(components, kamiID, data.for_);
+    assertEq(id, kamiID);
+
+    data.for_ = "FOO";
+    vm.expectRevert("LibCon: invalid for shape");
+    wrapper.parseTargetShape(components, alice.id, data.for_);
+  }
+
+  function testConditionalForShapeSingle() public {
+    uint256 kamiID = _mintKami(alice);
+    uint256 accCond = _create("ITEM", "CURR_MIN", 1, 1, "ACCOUNT", parentID);
+    conditions.push(accCond);
+    uint256 kamiCond = _create("STATE", "BOOL_IS", 1, 1, "KAMI", parentID);
+    conditions.push(kamiCond);
+    _giveItem(alice, 1, 1);
+
+    // check accCond
+    uint256[] memory singleCond = new uint256[](1);
+    singleCond[0] = accCond;
+    assertTrue(LibConditional.check(components, singleCond, alice.id));
+    assertTrue(LibConditional.check(components, singleCond, kamiID));
+
+    // check petCond (kami resting)
+    singleCond[0] = kamiCond;
+    assertTrue(LibConditional.check(components, singleCond, kamiID));
+
+    // check both via kami
+    assertTrue(LibConditional.check(components, conditions, kamiID));
+  }
+
+  /////////////////
+  // UTILS
+
+  function _create(
+    string memory type_,
+    string memory logic,
+    uint32 index,
+    uint256 value,
+    string memory for_,
+    uint256 _parentID
+  ) internal returns (uint256 id) {
+    vm.startPrank(deployer);
+    id = LibConditional.createFor(
+      world,
+      components,
+      Condition(type_, logic, index, value, for_),
+      _parentID
+    );
+    vm.stopPrank();
+  }
+}
+
+contract Wrapper {
+  function parseTargetShape(
+    IUint256Component components,
+    uint256 targetID,
+    string memory forShape
+  ) public returns (uint256) {
+    return LibConditional.parseTargetShape(components, targetID, forShape);
+  }
+}

--- a/packages/contracts/src/test/systems/Crafting.t.sol
+++ b/packages/contracts/src/test/systems/Crafting.t.sol
@@ -33,7 +33,7 @@ contract CraftingTest is SetupTemplate {
 
     // requirement
     vm.prank(deployer);
-    __RecipeRegistrySystem.addRequirement(1, "CURR_MIN", "ITEM", 1, 1);
+    __RecipeRegistrySystem.addRequirement(1, "CURR_MIN", "ITEM", 1, 1, "");
 
     // removal
     vm.prank(deployer);

--- a/packages/contracts/src/test/systems/Goals.t.sol
+++ b/packages/contracts/src/test/systems/Goals.t.sol
@@ -22,9 +22,9 @@ contract GoalsTest is SetupTemplate {
 
   function testGoalShape() public {
     uint32 goalIndex = 1;
-    uint256 goalID = _createGoal(1, 0, Condition("type", "logic", 0, 0));
-    uint256 requirementID1 = _createGoalRequirement(1, Condition("type", "logic", 1, 0));
-    uint256 requirementID2 = _createGoalRequirement(1, Condition("type", "logic", 2, 0));
+    uint256 goalID = _createGoal(1, 0, Condition("type", "logic", 0, 0, ""));
+    uint256 requirementID1 = _createGoalRequirement(1, Condition("type", "logic", 1, 0, ""));
+    uint256 requirementID2 = _createGoalRequirement(1, Condition("type", "logic", 2, 0, ""));
     uint256 rewardID1 = _createGoalRewardBasic(1, 100, "type", 1, 0);
     uint256 rewardID2 = _createGoalRewardBasic(1, 200, "type", 2, 0);
     uint256 rewardID3 = _createGoalRewardDisplay(1, "name");
@@ -51,7 +51,7 @@ contract GoalsTest is SetupTemplate {
     uint256 goalID = _createGoal(
       goalIndex,
       0,
-      Condition("ITEM", "CURR_MIN", MUSU_INDEX, targetAmt)
+      Condition("ITEM", "CURR_MIN", MUSU_INDEX, targetAmt, "")
     );
     uint256 rwdBronze = _createGoalRewardBasic(goalIndex, 100, "ITEM", 100, 1);
     uint256 rwdSilver = _createGoalRewardBasic(goalIndex, 200, "ITEM", 200, 1);

--- a/packages/contracts/src/test/systems/Items/ItemShapes.t.sol
+++ b/packages/contracts/src/test/systems/Items/ItemShapes.t.sol
@@ -27,9 +27,9 @@ contract ItemShapeTest is ItemTemplate {
     uint32 index = 1;
     vm.startPrank(deployer);
     __ItemRegistrySystem.create(abi.encode(index, "FOOD", "name", "description", "media"));
-    __ItemRegistrySystem.addRequirement(abi.encode(index, "USE", "type", "BOOL_IS", 1, 0));
-    __ItemRegistrySystem.addRequirement(abi.encode(index, "BURN", "type", "BOOL_IS", 1, 0));
-    __ItemRegistrySystem.addRequirement(abi.encode(index, "BURN", "type", "BOOL_IS", 2, 0));
+    __ItemRegistrySystem.addRequirement(abi.encode(index, "USE", "type", "BOOL_IS", 1, 0, ""));
+    __ItemRegistrySystem.addRequirement(abi.encode(index, "BURN", "type", "BOOL_IS", 1, 0, ""));
+    __ItemRegistrySystem.addRequirement(abi.encode(index, "BURN", "type", "BOOL_IS", 2, 0, ""));
     vm.stopPrank();
 
     // check reference existence

--- a/packages/contracts/src/test/systems/Node.t.sol
+++ b/packages/contracts/src/test/systems/Node.t.sol
@@ -28,7 +28,7 @@ contract NodeTest is SetupTemplate {
       abi.encode(1, "HARVEST", 1, "Test Node", "this is a node", "NORMAL")
     );
     // add requirement
-    __NodeRegistrySystem.addRequirement(abi.encode(1, "ACCOUNT", "ROOM", "BOOL_IS", 1, 0));
+    __NodeRegistrySystem.addRequirement(abi.encode(1, "ROOM", "BOOL_IS", 1, 0, "ACCOUNT"));
     vm.stopPrank();
 
     // try starting basic harvest
@@ -43,7 +43,7 @@ contract NodeTest is SetupTemplate {
     // setup
     uint32 nodeIndex = 1;
     uint256 nodeID = _createHarvestingNode(nodeIndex, 1, "Test Node", "this is a node", "NORMAL");
-    _createNodeRequirement(nodeIndex, "KAMI", "LEVEL", "CURR_MIN", 0, 2);
+    _createNodeRequirement(nodeIndex, "LEVEL", "CURR_MIN", 0, 2, "KAMI");
 
     // cannot add level 1 pet to node
     assertFalse(LibNode.checkReqs(components, nodeIndex, alice.id, aKamiID));
@@ -63,8 +63,8 @@ contract NodeTest is SetupTemplate {
     // setup
     uint32 nodeIndex = 1;
     uint256 nodeID = _createHarvestingNode(nodeIndex, 1, "Test Node", "this is a node", "NORMAL");
-    _createNodeRequirement(nodeIndex, "ACCOUNT", "LEVEL", "CURR_MIN", 0, 2);
-    _createNodeRequirement(nodeIndex, "ACCOUNT", "ROOM", "BOOL_IS", 1, 0);
+    _createNodeRequirement(nodeIndex, "LEVEL", "CURR_MIN", 0, 2, "ACCOUNT");
+    _createNodeRequirement(nodeIndex, "ROOM", "BOOL_IS", 1, 0, "ACCOUNT");
 
     // cannot add level 1 account to node
     assertFalse(LibNode.checkReqs(components, nodeIndex, alice.id, aKamiID));
@@ -84,9 +84,9 @@ contract NodeTest is SetupTemplate {
     // setup
     uint32 nodeIndex = 1;
     uint256 nodeID = _createHarvestingNode(nodeIndex, 1, "Test Node", "this is a node", "NORMAL");
-    _createNodeRequirement(nodeIndex, "ACCOUNT", "LEVEL", "CURR_MIN", 0, 2);
-    _createNodeRequirement(nodeIndex, "ACCOUNT", "ROOM", "BOOL_IS", 1, 0);
-    _createNodeRequirement(nodeIndex, "KAMI", "LEVEL", "CURR_MIN", 0, 2);
+    _createNodeRequirement(nodeIndex, "LEVEL", "CURR_MIN", 0, 2, "ACCOUNT");
+    _createNodeRequirement(nodeIndex, "ROOM", "BOOL_IS", 1, 0, "ACCOUNT");
+    _createNodeRequirement(nodeIndex, "LEVEL", "CURR_MIN", 0, 2, "KAMI");
 
     // cannot add, level 1 acc and pet
     assertFalse(LibNode.checkReqs(components, nodeIndex, alice.id, aKamiID));

--- a/packages/contracts/src/test/systems/Room.t.sol
+++ b/packages/contracts/src/test/systems/Room.t.sol
@@ -86,7 +86,7 @@ contract RoomTest is SetupTemplate {
     // move
     vm.startPrank(alice.operator);
     for (uint i = 0; i < numMove; i++) {
-      uint32 nextRoom = LibRoom.getIndex(components, alice.id) == 1 ? 2 : 1;
+      uint32 nextRoom = LibRoom.get(components, alice.id) == 1 ? 2 : 1;
       if (i >= baseStamina) vm.expectRevert("Account: insufficient stamina");
       _AccountMoveSystem.executeTyped(nextRoom);
     }
@@ -243,7 +243,7 @@ contract RoomTest is SetupTemplate {
     _createRoom("2", Coord(0, 1, 0), 2);
 
     vm.startPrank(deployer);
-    __RoomRegistrySystem.addGate(abi.encode(2, 0, 0, 0, "ITEM", "CURR_MIN"));
+    __RoomRegistrySystem.addGate(abi.encode(2, 0, 0, 0, "ITEM", "CURR_MIN", ""));
     vm.stopPrank();
 
     _AssertAccRoom(accountIndex, 1);
@@ -261,10 +261,10 @@ contract RoomTest is SetupTemplate {
     _createRoom("4", Coord(11, 10, 10), 4);
     _createRoom("5", Coord(1, 2, 0), 5);
     vm.startPrank(deployer);
-    __RoomRegistrySystem.addGate(abi.encode(2, 0, 10, 1, "ITEM", "CURR_MIN"));
-    __RoomRegistrySystem.addGate(abi.encode(3, 0, 10, 1, "ITEM", "CURR_MIN"));
-    __RoomRegistrySystem.addGate(abi.encode(4, 1, 10, 1, "ITEM", "CURR_MIN"));
-    __RoomRegistrySystem.addGate(abi.encode(5, 1, 10, 1, "ITEM", "CURR_MIN"));
+    __RoomRegistrySystem.addGate(abi.encode(2, 0, 10, 1, "ITEM", "CURR_MIN", ""));
+    __RoomRegistrySystem.addGate(abi.encode(3, 0, 10, 1, "ITEM", "CURR_MIN", ""));
+    __RoomRegistrySystem.addGate(abi.encode(4, 1, 10, 1, "ITEM", "CURR_MIN", ""));
+    __RoomRegistrySystem.addGate(abi.encode(5, 1, 10, 1, "ITEM", "CURR_MIN", ""));
     vm.stopPrank();
 
     uint32 accountIndex = 0;
@@ -312,7 +312,11 @@ contract RoomTest is SetupTemplate {
   function testGoalGate() public {
     uint32 goalIndex = 1;
     uint256 goalAmt = 1111;
-    uint256 goalID = _createGoal(goalIndex, 1, Condition("ITEM", "CURR_MIN", MUSU_INDEX, goalAmt));
+    uint256 goalID = _createGoal(
+      goalIndex,
+      1,
+      Condition("ITEM", "CURR_MIN", MUSU_INDEX, goalAmt, "")
+    );
     _createRoom("1", Coord(1, 1, 0), 1); // original room, goal located here
     _createRoom("2", Coord(0, 1, 0), 2); // room to be gated
     _createRoomGate(2, 0, 0, LibGoals.genGoalID(goalIndex), "COMPLETE_COMP", "BOOL_IS");

--- a/packages/contracts/src/test/utils/SetupTemplate.t.sol
+++ b/packages/contracts/src/test/utils/SetupTemplate.t.sol
@@ -259,7 +259,7 @@ abstract contract SetupTemplate is TestSetupImports {
 
   function _moveAccount(uint playerIndex, Coord memory location) internal {
     uint256 roomID = LibRoom.queryByLocation(components, location);
-    return _moveAccount(playerIndex, LibRoom.getIndex(components, roomID));
+    return _moveAccount(playerIndex, LibRoom.get(components, roomID));
   }
 
   function _buyFromListing(uint playerIndex, uint listingID, uint256 amt) internal {
@@ -497,7 +497,14 @@ abstract contract SetupTemplate is TestSetupImports {
     vm.prank(deployer);
     return
       __GoalRegistrySystem.addRequirement(
-        abi.encode(goalIndex, condition.type_, condition.logic, condition.index, condition.value)
+        abi.encode(
+          goalIndex,
+          condition.type_,
+          condition.logic,
+          condition.index,
+          condition.value,
+          condition.for_
+        )
       );
   }
 
@@ -566,10 +573,23 @@ abstract contract SetupTemplate is TestSetupImports {
     string memory logicType,
     string memory type_
   ) internal returns (uint256) {
+    return
+      _createRoomGate(roomIndex, sourceIndex, conditionIndex, conditionValue, logicType, type_, "");
+  }
+
+  function _createRoomGate(
+    uint32 roomIndex,
+    uint32 sourceIndex,
+    uint32 conditionIndex,
+    uint256 conditionValue,
+    string memory logicType,
+    string memory type_,
+    string memory for_
+  ) internal returns (uint256) {
     vm.prank(deployer);
     return
       __RoomRegistrySystem.addGate(
-        abi.encode(roomIndex, sourceIndex, conditionIndex, conditionValue, logicType, type_)
+        abi.encode(roomIndex, sourceIndex, conditionIndex, conditionValue, logicType, type_, for_)
       );
   }
 
@@ -589,16 +609,16 @@ abstract contract SetupTemplate is TestSetupImports {
 
   function _createNodeRequirement(
     uint32 nodeIndex,
-    string memory for_,
     string memory type_,
     string memory logicType,
     uint32 index,
-    uint256 value
+    uint256 value,
+    string memory for_
   ) internal returns (uint) {
     vm.prank(deployer);
     return
       __NodeRegistrySystem.addRequirement(
-        abi.encode(nodeIndex, for_, type_, logicType, index, value)
+        abi.encode(nodeIndex, type_, logicType, index, value, for_)
       );
   }
 
@@ -656,7 +676,9 @@ abstract contract SetupTemplate is TestSetupImports {
     id = __ItemRegistrySystem.createConsumable(
       abi.encode(index, "KAMI", name, description, "FOOD", mediaURI)
     );
-    __ItemRegistrySystem.addRequirement(abi.encode(index, "USE", "KAMI_CAN_EAT", "BOOL_IS", 0, 0));
+    __ItemRegistrySystem.addRequirement(
+      abi.encode(index, "USE", "KAMI_CAN_EAT", "BOOL_IS", 0, 0, "")
+    );
     __ItemRegistrySystem.addAlloBasic(abi.encode(index, "USE", "XP", 0, experience));
     __ItemRegistrySystem.addAlloStat(abi.encode(index, "USE", "HEALTH", 0, 0, 0, health));
     vm.stopPrank();
@@ -674,7 +696,7 @@ abstract contract SetupTemplate is TestSetupImports {
       abi.encode(index, "KAMI", name, description, "REVIVE", mediaURI)
     );
     __ItemRegistrySystem.addRequirement(
-      abi.encode(index, "USE", "STATE", "BOOL_IS", LibKami.stateToIndex("DEAD"), 0)
+      abi.encode(index, "USE", "STATE", "BOOL_IS", LibKami.stateToIndex("DEAD"), 0, "", "")
     );
     __ItemRegistrySystem.addAlloBasic(
       abi.encode(index, "USE", "STATE", LibKami.stateToIndex("RESTING"), 0)
@@ -711,10 +733,22 @@ abstract contract SetupTemplate is TestSetupImports {
     uint32 index, // can be empty
     uint256 value // can be empty
   ) public returns (uint256) {
+    return _createQuestObjective(questIndex, name, logicType, _type, index, value, "");
+  }
+
+  function _createQuestObjective(
+    uint32 questIndex,
+    string memory name,
+    string memory logicType,
+    string memory _type,
+    uint32 index,
+    uint256 value,
+    string memory for_
+  ) public returns (uint256) {
     vm.prank(deployer);
     return
       __QuestRegistrySystem.addObjective(
-        abi.encode(questIndex, name, logicType, _type, index, value)
+        abi.encode(questIndex, name, logicType, _type, index, value, for_)
       );
   }
 
@@ -725,9 +759,22 @@ abstract contract SetupTemplate is TestSetupImports {
     uint32 index, // can be empty
     uint value // can be empty
   ) public returns (uint256) {
+    return _createQuestRequirement(questIndex, logicType, _type, index, value, "");
+  }
+
+  function _createQuestRequirement(
+    uint32 questIndex,
+    string memory logicType,
+    string memory _type,
+    uint32 index,
+    uint value,
+    string memory for_
+  ) public returns (uint256) {
     vm.prank(deployer);
     return
-      __QuestRegistrySystem.addRequirement(abi.encode(questIndex, logicType, _type, index, value));
+      __QuestRegistrySystem.addRequirement(
+        abi.encode(questIndex, logicType, _type, index, value, for_)
+      );
   }
 
   // basic reward only
@@ -816,9 +863,22 @@ abstract contract SetupTemplate is TestSetupImports {
     uint32 index, // can be empty
     uint value // can be empty
   ) internal returns (uint256) {
+    return _createSkillRequirement(skillIndex, type_, logicType, index, value, "");
+  }
+
+  function _createSkillRequirement(
+    uint32 skillIndex,
+    string memory type_,
+    string memory logicType,
+    uint32 index,
+    uint value,
+    string memory for_
+  ) internal returns (uint256) {
     vm.prank(deployer);
     return
-      __SkillRegistrySystem.addRequirement(abi.encode(skillIndex, type_, logicType, index, value));
+      __SkillRegistrySystem.addRequirement(
+        abi.encode(skillIndex, type_, logicType, index, value, for_)
+      );
   }
 
   /* TRAITS */


### PR DESCRIPTION
conditionals upgrade: now allows for target entity shapes! example:
> *for ROOM*: get room details instead of account/kami
> *for ACCOUNT*: get account details if entry type is kami
> *for ""*: use original targetID

replaces previous custom `node requirements` implementation. requires a redeploy on all systems that use conditions + needed in prev stack