### PR TITLE
Bonus cache

### DIFF
--- a/packages/client/src/app/cache/bonus/base.ts
+++ b/packages/client/src/app/cache/bonus/base.ts
@@ -1,0 +1,40 @@
+import { EntityIndex, World } from '@mud-classic/recs';
+
+import { Components } from 'network/';
+import { Bonus, BonusInstance, calcBonusValue, getBonusRegistry } from 'network/shapes/Bonus';
+import { getLevel, getSourceID } from 'network/shapes/utils/component';
+
+const RegistryCache = new Map<EntityIndex, Bonus>();
+const InstanceToRegistry = new Map<EntityIndex, EntityIndex>();
+
+// cache for bonus registry. doesnt ever change, assume stable once retrieved
+export const getRegistry = (world: World, components: Components, entity: EntityIndex): Bonus => {
+  if (!RegistryCache.has(entity)) process(world, components, entity);
+  return RegistryCache.get(entity)!;
+};
+
+// gets bonus instance. Level is queried live
+export const getInstance = (
+  world: World,
+  components: Components,
+  entity: EntityIndex
+): BonusInstance => {
+  if (!InstanceToRegistry.has(entity)) {
+    const source = getSourceID(components, entity);
+    InstanceToRegistry.set(entity, world.entityToIndex.get(source) || (0 as EntityIndex));
+  }
+  const reg = getRegistry(world, components, InstanceToRegistry.get(entity)!);
+  const level = getLevel(components, entity);
+  return {
+    ...reg,
+    level,
+    total: calcBonusValue(reg.value, level),
+  };
+};
+
+// save the requested item entity to the cache
+export const process = (world: World, components: Components, entity: EntityIndex): Bonus => {
+  const bonus = getBonusRegistry(world, components, entity);
+  RegistryCache.set(entity, bonus);
+  return bonus;
+};

--- a/packages/client/src/app/cache/bonus/getters.ts
+++ b/packages/client/src/app/cache/bonus/getters.ts
@@ -1,0 +1,38 @@
+import { EntityID, EntityIndex, World } from '@mud-classic/recs';
+
+import { Components } from 'network/';
+import { BonusInstance, genBonusEndAnchor, queryBonusForParent } from 'network/shapes/Bonus';
+import { getInstance } from './base';
+
+const AnchorToInstances = new Map<EntityID, EntityIndex[]>();
+
+const QueryUpdateTs = new Map<EntityID, number>();
+
+export const getForEndType = (
+  world: World,
+  components: Components,
+  endType: string,
+  holder: EntityIndex,
+  update: number
+): BonusInstance[] => {
+  const holderID = world.entities[holder];
+  const queryID = genBonusEndAnchor(endType, holderID);
+  const instances = queryByParent(components, queryID, update);
+  return instances.map((instance) => getInstance(world, components, instance));
+};
+
+const queryByParent = (
+  components: Components,
+  queryID: EntityID,
+  update: number
+): EntityIndex[] => {
+  const now = Date.now();
+  const updateTs = QueryUpdateTs.get(queryID) ?? 0;
+  const updateDelta = (now - updateTs) / 1000;
+  if (updateDelta > update) {
+    QueryUpdateTs.set(queryID, now);
+    // todo? global query retrieval similar to components.ts?
+    AnchorToInstances.set(queryID, queryBonusForParent(components, queryID));
+  }
+  return AnchorToInstances.get(queryID) ?? [];
+};

--- a/packages/client/src/app/cache/bonus/index.ts
+++ b/packages/client/src/app/cache/bonus/index.ts
@@ -1,0 +1,8 @@
+export {
+  getInstance as getBonusInstance,
+  getRegistry as getBonusRegistry,
+  process as processBonus,
+} from './base';
+export { getForEndType as getBonusesForEndType } from './getters';
+
+export type { Bonus, BonusInstance } from 'network/shapes/Bonus';

--- a/packages/client/src/network/shapes/Bonus/getters.ts
+++ b/packages/client/src/network/shapes/Bonus/getters.ts
@@ -1,7 +1,7 @@
 import { EntityID, World } from '@mud-classic/recs';
 import { Components } from 'network/';
 import { queryForParent, queryForType } from './queries';
-import { Bonus, getBonus, getBonusValueSingle } from './types';
+import { Bonus, getBonusRegistry, getBonusValueSingle } from './types';
 
 export const getBonusValue = (
   world: World,
@@ -31,5 +31,5 @@ export const getBonusesByParent = (
   parentID: EntityID
 ): Bonus[] => {
   const entities = queryForParent(components, parentID);
-  return entities.map((entity) => getBonus(world, components, entity));
+  return entities.map((entity) => getBonusRegistry(world, components, entity));
 };

--- a/packages/client/src/network/shapes/Bonus/index.ts
+++ b/packages/client/src/network/shapes/Bonus/index.ts
@@ -1,9 +1,15 @@
 export { getBonusValue, getBonusesByParent } from './getters';
 export { parseBonusText } from './interpretation';
 export {
+  queryForEndType as queryBonusForEndType,
   queryForParent as queryBonusForParent,
   queryForType as queryBonusForType,
 } from './queries';
-export { getBonus } from './types';
+export {
+  calcBonusValue,
+  genEndAnchor as genBonusEndAnchor,
+  genTypeID as genBonusTypeID,
+  getBonusRegistry,
+} from './types';
 
-export type { Bonus } from './types';
+export type { Bonus, BonusInstance } from './types';

--- a/packages/client/src/network/shapes/Bonus/queries.ts
+++ b/packages/client/src/network/shapes/Bonus/queries.ts
@@ -1,6 +1,7 @@
 import { EntityID, EntityIndex, HasValue, QueryFragment, runQuery } from '@mud-classic/recs';
 import { Components } from 'network/';
 import { hashArgs, queryChildrenOf } from '../utils';
+import { genEndAnchor } from './types';
 
 // query the bonuses of a type for a parent entity
 export function queryForType(
@@ -14,6 +15,15 @@ export function queryForType(
   const id = hashArgs(values, types);
   const toQuery: QueryFragment[] = [HasValue(TypeID, { value: id })];
   return Array.from(runQuery(toQuery));
+}
+
+export function queryForEndType(
+  components: Components,
+  endType: string,
+  holderID: EntityID
+): EntityIndex[] {
+  const EndAnchor = genEndAnchor(endType, holderID);
+  return queryForParent(components, EndAnchor);
 }
 
 // query the bonuses associated with a parent entity

--- a/packages/client/src/network/shapes/Skill/bonuses.ts
+++ b/packages/client/src/network/shapes/Skill/bonuses.ts
@@ -1,7 +1,7 @@
 import { EntityID, EntityIndex, World } from '@mud-classic/recs';
 
 import { Components } from 'network/';
-import { Bonus, getBonus } from '../Bonus';
+import { Bonus, getBonusRegistry } from '../Bonus';
 import { hashArgs, queryChildrenOf } from '../utils';
 
 // query the Entity Indices of the bonuses of a Skill by its index
@@ -13,7 +13,7 @@ export const queryBonuses = (components: Components, skillIndex: number): Entity
 // get the Bonus objects associated with a Skill by its index
 export const getBonuses = (world: World, components: Components, skillIndex: number): Bonus[] => {
   const entities = queryBonuses(components, skillIndex);
-  const results = entities.map((entity) => getBonus(world, components, entity));
+  const results = entities.map((entity) => getBonusRegistry(world, components, entity));
   // filter out tree bonuses
   return results.filter((bonus) => !bonus.type.startsWith('SKILL_TREE_'));
 };


### PR DESCRIPTION
implements cache for bonus shapes. Not typically used - bonuses are usually nested in the parent shapes (with only value stored) - but sometimes bonuses are called at the top level (eg display all bonuses on a kami)

design decision: cache full bonus shapes flat, rather than nested in a `kami` shape. Counting on flat shapes to keep shapes cleaner in the long run