### PR TITLE
Emitter systemID -> identifier

### DIFF
--- a/packages/contracts/src/libraries/LibAccount.sol
+++ b/packages/contracts/src/libraries/LibAccount.sol
@@ -267,11 +267,4 @@ library LibAccount {
   ) internal {
     LibData.inc(components, accID, 0, "KAMI_STAKE", count);
   }
-
-  function logMove(IWorld world, uint256 systemId, bytes memory values) internal {
-    uint8[] memory _schema = new uint8[](1);
-    _schema[0] = uint8(LibTypes.SchemaValue.UINT32);
-
-    LibEmitter.emitSystemCall(world, systemId, _schema, values);
-  }
 }

--- a/packages/contracts/src/libraries/LibRoom.sol
+++ b/packages/contracts/src/libraries/LibRoom.sol
@@ -6,6 +6,7 @@ import { IWorld } from "solecs/interfaces/IWorld.sol";
 import { LibQuery, QueryFragment, QueryType } from "solecs/LibQuery.sol";
 import { getAddrByID, getCompByID } from "solecs/utils.sol";
 import { Coord, CoordLib } from "solecs/components/types/Coord.sol";
+import { LibTypes } from "solecs/LibTypes.sol";
 
 import { IDRoomComponent, ID as IDRoomCompID } from "components/IDRoomComponent.sol";
 // world2: (formally IDPointer) change to IDTarget or IDTo/From
@@ -19,6 +20,7 @@ import { NameComponent, ID as NameCompID } from "components/NameComponent.sol";
 import { LibArray } from "libraries/utils/LibArray.sol";
 import { LibComp } from "libraries/utils/LibComp.sol";
 import { LibEntityType } from "libraries/utils/LibEntityType.sol";
+import { LibEmitter } from "libraries/utils/LibEmitter.sol";
 
 import { Condition, LibConditional } from "libraries/LibConditional.sol";
 import { LibConfig } from "libraries/LibConfig.sol";
@@ -247,8 +249,14 @@ library LibRoom {
   //////////////////////
   // LOGGING
 
-  function logMove(IUintComp components, uint256 holderID) public {
+  function logMove(IWorld world, IUintComp components, uint32 roomIndex, uint256 holderID) public {
     LibData.inc(components, holderID, 0, "MOVE", 1);
+
+    // emit event
+    uint8[] memory _schema = new uint8[](1);
+    _schema[0] = uint8(LibTypes.SchemaValue.UINT32);
+
+    LibEmitter.emitSystemCall(world, "MOVE", _schema, abi.encode(holderID, roomIndex));
   }
 
   //////////////////////

--- a/packages/contracts/src/libraries/LibTrade.sol
+++ b/packages/contracts/src/libraries/LibTrade.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.28;
 import { IUint256Component as IUintComp } from "solecs/interfaces/IUint256Component.sol";
 import { IWorld } from "solecs/interfaces/IWorld.sol";
 import { getAddrByID, getCompByID } from "solecs/utils.sol";
+import { LibTypes } from "solecs/LibTypes.sol";
 
 import { IDOwnsTradeComponent, ID as IDOwnsTradeCompID } from "components/IDOwnsTradeComponent.sol";
 import { IdTargetComponent, ID as IdTargetCompID } from "components/IdTargetComponent.sol";
@@ -11,6 +12,7 @@ import { KeysComponent, ID as KeysCompID } from "components/KeysComponent.sol";
 import { ValuesComponent, ID as ValuesCompID } from "components/ValuesComponent.sol";
 
 import { LibEntityType } from "libraries/utils/LibEntityType.sol";
+import { LibEmitter } from "libraries/utils/LibEmitter.sol";
 
 import { LibAccount } from "libraries/LibAccount.sol";
 import { LibConfig } from "libraries/LibConfig.sol";
@@ -207,5 +209,7 @@ library LibTrade {
     uint256 seller = IDOwnsTradeComponent(getAddrByID(components, IDOwnsTradeCompID)).get(tradeID);
     LibData.inc(components, buyer, 0, "TRADE_COMPLETE", 1);
     LibData.inc(components, seller, 0, "TRADE_COMPLETE", 1);
+
+    // todo: emit event
   }
 }

--- a/packages/contracts/src/libraries/utils/LibEmitter.sol
+++ b/packages/contracts/src/libraries/utils/LibEmitter.sol
@@ -8,12 +8,12 @@ import { IEmitter } from "../../solecs/interfaces/IEmitter.sol";
 library LibEmitter {
   function emitSystemCall(
     IWorld world,
-    uint256 systemId,
+    string memory identifier,
     uint8[] memory schema,
     bytes memory values
   ) internal {
     address emitter = world._emitter();
-    if (emitter != address(0)) IEmitter(emitter).emitSystemCalled(systemId, schema, values);
+    if (emitter != address(0)) IEmitter(emitter).emitSystemCalled(identifier, schema, values);
   }
 
   function emitMessage(

--- a/packages/contracts/src/solecs/Emitter.sol
+++ b/packages/contracts/src/solecs/Emitter.sol
@@ -2,15 +2,15 @@
 pragma solidity >=0.8.28;
 
 contract Emitter {
-  event SystemCalled(uint256 indexed systemId, uint8[] schema, bytes value);
+  event SystemCalled(string indexed identifier, uint8[] schema, bytes value);
   event Message(uint32 indexed roomIndex, uint256 indexed accountId, string message);
 
   function emitSystemCalled(
-    uint256 systemId,
+    string memory identifier,
     uint8[] calldata schema,
     bytes calldata value
   ) external {
-    emit SystemCalled(systemId, schema, value);
+    emit SystemCalled(identifier, schema, value);
   }
 
   function emitMessage(uint32 roomIndex, uint256 accountId, string memory message) external {

--- a/packages/contracts/src/solecs/interfaces/IEmitter.sol
+++ b/packages/contracts/src/solecs/interfaces/IEmitter.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.28;
 
 interface IEmitter {
   function emitSystemCalled(
-    uint256 systemId,
+    string calldata identifier,
     uint8[] calldata schema,
     bytes calldata value
   ) external;

--- a/packages/contracts/src/systems/AccountMoveSystem.sol
+++ b/packages/contracts/src/systems/AccountMoveSystem.sol
@@ -44,10 +44,8 @@ contract AccountMoveSystem is System {
     LibAccount.move(components, accID, toIndex); // implicit stamina check
 
     // standard logging and tracking
-    LibRoom.logMove(components, accID);
+    LibRoom.logMove(world, components, toIndex, accID);
     LibAccount.updateLastTs(components, accID);
-
-    LibAccount.logMove(world, ID, arguments);
 
     return "";
   }


### PR DESCRIPTION
@CarrotIfson edited emitter to support multiple events from the same system. instead of using `systemID`, now uses a string identifier

also some cleanups on the move logging

will need to redeploy emitter and AccountMoveSystem