### PR TITLE
ERC20 balance watcher

### DIFF
--- a/packages/client/src/app/cache/config/config.ts
+++ b/packages/client/src/app/cache/config/config.ts
@@ -1,9 +1,14 @@
 import { World } from '@mud-classic/recs';
 
 import { Components } from 'network/components';
-import { getConfigFieldValue, getConfigFieldValueArray } from 'network/shapes/Config';
+import {
+  getConfigFieldValue,
+  getConfigFieldValueAddress,
+  getConfigFieldValueArray,
+} from 'network/shapes/Config';
 
 export const ValueCache = new Map<string, number>();
+export const AddressCache = new Map<string, string>();
 export const ArrayCache = new Map<string, number[]>();
 export const UpdateTs = new Map<string, number>(); // last update ts of config field
 
@@ -16,6 +21,17 @@ export const processValue = (world: World, components: Components, field: string
   const value = getConfigFieldValue(world, components, field);
   ValueCache.set(field, value);
   return value;
+};
+
+export const getAddress = (world: World, components: Components, field: string): string => {
+  if (!AddressCache.has(field)) processAddress(world, components, field);
+  return AddressCache.get(field)!;
+};
+
+export const processAddress = (world: World, components: Components, field: string): string => {
+  const address = getConfigFieldValueAddress(world, components, field);
+  if (address != '0x000000000000000000000000000000000000dEaD') AddressCache.set(field, address);
+  return address;
 };
 
 // get an array type of config field

--- a/packages/client/src/app/cache/config/index.ts
+++ b/packages/client/src/app/cache/config/index.ts
@@ -1,6 +1,8 @@
 export {
+  getAddress as getConfigAddress,
   getArray as getConfigArray,
   getValue as getConfigValue,
+  processAddress as processConfigAddress,
   processArray as processConfigArray,
   processValue as processConfigValue,
 } from './config';

--- a/packages/client/src/app/components/fixtures/TokenBalances.tsx
+++ b/packages/client/src/app/components/fixtures/TokenBalances.tsx
@@ -1,0 +1,63 @@
+import styled from 'styled-components';
+
+import { map, merge } from 'rxjs';
+import { Address } from 'viem';
+import { useWatchBlockNumber } from 'wagmi';
+
+import { getConfigAddress } from 'app/cache/config';
+import { registerUIComponent } from 'app/root';
+import { useAccount, useTokens } from 'app/stores';
+import { useERC20Balance } from 'network/chain';
+
+export function registerTokenBalances() {
+  registerUIComponent(
+    'TokenBalances',
+    {
+      colStart: 0,
+      colEnd: 0,
+      rowStart: 0,
+      rowEnd: 0,
+    },
+    (layers) => {
+      const { network } = layers;
+      const { actions, components } = network;
+      const { LoadingState } = components;
+
+      return merge(actions.Action.update$, LoadingState.update$).pipe(
+        map(() => {
+          const { world, components } = network;
+
+          return {
+            tokens: {
+              onyx: getConfigAddress(world, components, 'ONYX_ADDRESS') as Address,
+            },
+          };
+        })
+      );
+    },
+    ({ tokens }) => {
+      const { account } = useAccount();
+      const { setOnyx, setInit } = useTokens();
+
+      // doesn't seem to work reliably - updates upon Action for additional trigger
+      useWatchBlockNumber({
+        onBlockNumber: () => {
+          refetchOnyx();
+          setOnyx(onyxBal);
+        },
+      });
+
+      const { balances: onyxBal, refetch: refetchOnyx } = useERC20Balance(
+        account.ownerAddress as Address,
+        tokens.onyx,
+        '0x0000000000000000000000000000000000000000' // todo: get address of TokenAllowanceComponent
+      );
+
+      return <Wrapper style={{ display: 'block' }}></Wrapper>;
+    }
+  );
+}
+
+const Wrapper = styled.div`
+  align-items: left;
+`;

--- a/packages/client/src/app/components/index.ts
+++ b/packages/client/src/app/components/index.ts
@@ -2,6 +2,7 @@ import { registerClock } from './fixtures/clock';
 import { registerMenuLeft, registerMenuRight } from './fixtures/menu';
 import { registerNotificationFixture } from './fixtures/notifications';
 import { registerActionQueue } from './fixtures/queue';
+import { registerTokenBalances } from './fixtures/TokenBalances';
 
 import { registerAccountModal } from './modals/account';
 import { registerChatModal } from './modals/chat';
@@ -42,6 +43,7 @@ export function registerFixtures() {
   registerMenuLeft();
   registerMenuRight();
   registerNotificationFixture();
+  registerTokenBalances();
 }
 
 export function registerModals() {

--- a/packages/client/src/app/stores/index.ts
+++ b/packages/client/src/app/stores/index.ts
@@ -1,7 +1,8 @@
 import { Account, Farcaster, emptyAccountDetails, useAccount } from './account';
 import { useNetwork } from './network';
 import { useSelected } from './selected';
+import { useTokens } from './tokens';
 import { Fixtures, Modals, Validators, useVisibility } from './visibility';
 
-export { emptyAccountDetails, useAccount, useNetwork, useSelected, useVisibility };
+export { emptyAccountDetails, useAccount, useNetwork, useSelected, useTokens, useVisibility };
 export type { Account, Farcaster, Fixtures, Modals, Validators };

--- a/packages/client/src/app/stores/tokens.ts
+++ b/packages/client/src/app/stores/tokens.ts
@@ -1,0 +1,30 @@
+import { create } from 'zustand';
+
+export interface State {
+  onyx: BalPair;
+  init: BalPair;
+}
+
+// expects whole number (after decimal processing)
+export interface BalPair {
+  allowance: number;
+  balance: number;
+}
+
+interface Actions {
+  setOnyx: (onyx: BalPair) => void;
+  setInit: (init: BalPair) => void;
+}
+
+export const useTokens = create<State & Actions>((set) => {
+  const initialState: State = {
+    onyx: { allowance: 0, balance: 0 },
+    init: { allowance: 0, balance: 0 },
+  };
+
+  return {
+    ...initialState,
+    setOnyx: (value: BalPair) => set((state: State) => ({ ...state, onyx: value })),
+    setInit: (value: BalPair) => set((state: State) => ({ ...state, init: value })),
+  };
+});

--- a/packages/client/src/network/chain/ERC20.ts
+++ b/packages/client/src/network/chain/ERC20.ts
@@ -1,0 +1,24 @@
+import { parseTokenBalance } from 'utils/balances';
+import { Address } from 'viem';
+import { useReadContracts } from 'wagmi';
+import { abi } from './abi/erc20';
+
+export function useBalance(address: Address, token: Address, spender?: Address) {
+  const erc20 = {
+    address: token,
+    abi: abi,
+  };
+  const results = useReadContracts({
+    contracts: [
+      { ...erc20, functionName: 'balanceOf', args: [address] },
+      { ...erc20, functionName: 'allowance', args: [address, spender] },
+    ],
+  });
+  return {
+    ...results,
+    balances: {
+      allowance: parseTokenBalance(results.data?.[1]?.result as bigint, 18),
+      balance: parseTokenBalance(results.data?.[0]?.result as bigint, 18),
+    },
+  };
+}

--- a/packages/client/src/network/chain/abi/erc20.ts
+++ b/packages/client/src/network/chain/abi/erc20.ts
@@ -1,0 +1,222 @@
+export const abi = [
+  {
+    constant: true,
+    inputs: [],
+    name: 'name',
+    outputs: [
+      {
+        name: '',
+        type: 'string',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: '_spender',
+        type: 'address',
+      },
+      {
+        name: '_value',
+        type: 'uint256',
+      },
+    ],
+    name: 'approve',
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'totalSupply',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: '_from',
+        type: 'address',
+      },
+      {
+        name: '_to',
+        type: 'address',
+      },
+      {
+        name: '_value',
+        type: 'uint256',
+      },
+    ],
+    name: 'transferFrom',
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'decimals',
+    outputs: [
+      {
+        name: '',
+        type: 'uint8',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: '_owner',
+        type: 'address',
+      },
+    ],
+    name: 'balanceOf',
+    outputs: [
+      {
+        name: 'balance',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'symbol',
+    outputs: [
+      {
+        name: '',
+        type: 'string',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: '_to',
+        type: 'address',
+      },
+      {
+        name: '_value',
+        type: 'uint256',
+      },
+    ],
+    name: 'transfer',
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: '_owner',
+        type: 'address',
+      },
+      {
+        name: '_spender',
+        type: 'address',
+      },
+    ],
+    name: 'allowance',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    payable: true,
+    stateMutability: 'payable',
+    type: 'fallback',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        name: 'spender',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+    name: 'Approval',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        name: 'from',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        name: 'to',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+    name: 'Transfer',
+    type: 'event',
+  },
+];

--- a/packages/client/src/network/chain/index.ts
+++ b/packages/client/src/network/chain/index.ts
@@ -1,0 +1,3 @@
+import { useBalance as useERC20Balance } from './ERC20';
+
+export { useERC20Balance };


### PR DESCRIPTION
Implements an empty react component to watch ERC20 token balances. Values are stored via `zustand`, can be accessed through that in other components.

Design choices
- hardcoded store for each token
  - not expecting to access many erc20s (ONYX, INIT, TIA, ETH(?))
  - map seems excessive, especially creating a new one each block
- stores balance via Number, post decimal processing
- Only watches for selected account - getting other account balances would be difficult, but unlikely we'd do this (at most, a bespoke solution for other account's ONYX?)
- updates upon user action & each block
  - `useWatchBlockNumber` seems spotty at best, not reliable. 
  - user action updates forces an extra check in case of potential balance changes

todo:
- correctly query allowance via `TokenAllowanceComp` (need a reliable way to get component addresses)
- sending `approve()` allowance txes

note: performance *seems* okay right now, but would want to closely monitor it