### PR TITLE
direct txqueue

### DIFF
--- a/packages/client/src/app/components/modals/FundOperator.tsx
+++ b/packages/client/src/app/components/modals/FundOperator.tsx
@@ -34,7 +34,7 @@ export function registerFundOperatorModal() {
     ({ network }) => {
       const { actions, world } = network;
       const { account: kamiAccount } = useAccount();
-      const { selectedAddress, apis } = useNetwork();
+      const { selectedAddress, apis, signers } = useNetwork();
 
       const [isFunding, setIsFunding] = useState(true);
       const [isDripping, setIsDripping] = useState(false);
@@ -74,7 +74,7 @@ export function registerFundOperatorModal() {
           params: [amount.toString()],
           description: `Funding Operator ${amount.toString()} ONYX`,
           execute: async () => {
-            return api.account.fund(amount.toString());
+            return api.send(kamiAccount.operatorAddress, amount);
           },
         });
         const actionIndex = world.entityToIndex.get(actionID) as EntityIndex;
@@ -90,7 +90,7 @@ export function registerFundOperatorModal() {
           params: [amount.toString()],
           description: `Refunding Owner ${amount.toString()} ONYX`,
           execute: async () => {
-            return network.api.player.account.refund(amount.toString());
+            return network.api.player.send(kamiAccount.ownerAddress, amount);
           },
         });
         const actionIndex = world.entityToIndex.get(actionID) as EntityIndex;

--- a/packages/client/src/app/components/validators/GasHarasser.tsx
+++ b/packages/client/src/app/components/validators/GasHarasser.tsx
@@ -101,7 +101,7 @@ export function registerGasHarasser() {
           params: [value.toString()],
           description: `Funding Operator ${value.toLocaleString()} ONYX`,
           execute: async () => {
-            return api.account.fund(value.toString());
+            return api.send(account.operatorAddress, value);
           },
         });
         const actionIndex = world.entityToIndex.get(actionID) as EntityIndex;

--- a/packages/client/src/app/components/validators/WalletConnector.tsx
+++ b/packages/client/src/app/components/validators/WalletConnector.tsx
@@ -146,8 +146,8 @@ export function registerWalletConnecter() {
             console.log('Error getting injected provider', e);
           }
           const networkInstance = await createNetworkInstance(provider);
-          const systems = network.createSystems(networkInstance);
-          addAPI(injectedAddress, systems);
+          const txQueue = network.createTxQueue(networkInstance);
+          addAPI(injectedAddress, txQueue);
         }
         setSelectedAddress(injectedAddress);
       };

--- a/packages/client/src/app/stores/network.ts
+++ b/packages/client/src/app/stores/network.ts
@@ -2,7 +2,6 @@ import { create } from 'zustand';
 
 import { TxQueue } from 'engine/queue';
 import { PlayerAPI, createPlayerAPI } from 'network/api';
-import { SystemTypes } from 'types/SystemTypes';
 
 export interface State {
   burnerAddress: string;
@@ -13,7 +12,7 @@ export interface State {
 }
 
 interface Actions {
-  addAPI: (address: string, systems: TxQueue<SystemTypes>) => void;
+  addAPI: (address: string, txQueue: TxQueue) => void;
   setSelectedAddress: (address: string) => void;
   setBurnerAddress: (address: string) => void;
   setValidations: (validations: Validations) => void;
@@ -45,10 +44,10 @@ export const useNetwork = create<State & Actions>((set) => {
       set((state: State) => ({ ...state, selectedAddress })),
     setValidations: (validations: Validations) =>
       set((state: State) => ({ ...state, validations })),
-    addAPI: (address: string, systems: TxQueue<SystemTypes>) =>
+    addAPI: (address: string, txQueue: TxQueue) =>
       set((state: State) => ({
         ...state,
-        apis: new Map(state.apis).set(address, createPlayerAPI(systems)),
+        apis: new Map(state.apis).set(address, createPlayerAPI(txQueue)),
       })),
   };
 });

--- a/packages/client/src/engine/executors/create.ts
+++ b/packages/client/src/engine/executors/create.ts
@@ -94,7 +94,7 @@ export function createSystemExecutor<T extends { [key: string]: Contract }>(
   world.registerDisposer(dispose);
 
   return {
-    systems: txQueue,
+    txQueue,
     registerSystem,
     getSystemContract: (id: string) => {
       const name = systemIdPreimages[id] as keyof T;

--- a/packages/client/src/engine/queue/index.ts
+++ b/packages/client/src/engine/queue/index.ts
@@ -1,2 +1,2 @@
 export { create as createTxQueue } from './create';
-export type { TxQueue } from './types';
+export type { SystemQueue, TxCall, TxQueue } from './types';

--- a/packages/client/src/engine/queue/types.ts
+++ b/packages/client/src/engine/queue/types.ts
@@ -1,5 +1,16 @@
+import { TransactionReceipt, TransactionRequest } from '@ethersproject/providers';
 import { Cached } from '@mud-classic/utils';
+import { CallOverrides } from 'ethers';
 
 import { Contracts } from 'engine/types';
 
-export type TxQueue<C extends Contracts> = Cached<C>;
+export type TxQueue = { call: TxCall; systems: SystemQueue<any extends Contracts ? any : never> };
+export type SystemQueue<C extends Contracts> = Cached<C>;
+export type TxCall = (
+  txRequest: TransactionRequest,
+  callOverrides?: CallOverrides
+) => Promise<{
+  hash: string;
+  wait: () => Promise<TransactionReceipt>;
+  response: Promise<any>;
+}>;

--- a/packages/client/src/network/api/admin.ts
+++ b/packages/client/src/network/api/admin.ts
@@ -1,9 +1,12 @@
 import { defaultAbiCoder } from '@ethersproject/abi';
+import { TxQueue } from 'engine/queue';
 import { BigNumberish } from 'ethers';
 
 export type AdminAPI = Awaited<ReturnType<typeof createAdminAPI>>;
 
-export function createAdminAPI(systems: any) {
+export function createAdminAPI(txQueue: TxQueue) {
+  const { call, systems } = txQueue;
+
   // @dev admin reveal for pet if blockhash has lapsed. only called by admin
   // @param tokenId     ERC721 tokenId of the pet
   async function petForceReveal(commitIDs: BigNumberish[]) {

--- a/packages/client/src/network/api/player/index.ts
+++ b/packages/client/src/network/api/player/index.ts
@@ -1,10 +1,23 @@
 import { GasExponent } from 'constants/gas';
-import { BigNumberish, utils } from 'ethers';
+import { TxQueue } from 'engine/queue';
+import { BigNumberish, ethers, utils } from 'ethers';
 import { auctionsAPI } from './auctions';
 
 export type PlayerAPI = ReturnType<typeof createPlayerAPI>;
 
-export function createPlayerAPI(systems: any) {
+export function createPlayerAPI(txQueue: TxQueue) {
+  const { call, systems } = txQueue;
+  /////////////////
+  // NON-MUD
+
+  // parses to ether (1e18) for convienience
+  function send(address: string, amount: BigNumberish) {
+    return call({
+      to: address,
+      value: ethers.utils.parseUnits(amount.toString(), 'ether'),
+    });
+  }
+
   /////////////////
   // ECHO
 
@@ -305,6 +318,7 @@ export function createPlayerAPI(systems: any) {
   }
 
   return {
+    send,
     echo: {
       kami: echoKamis,
       room: echoRoom,
@@ -315,10 +329,8 @@ export function createPlayerAPI(systems: any) {
       use: { item: useItemPet },
     },
     account: {
-      fund: fundOperator,
       move: moveAccount,
       register: registerAccount,
-      refund: refundOwner,
       set: {
         name: setAccountName,
         operator: setAccountOperator,

--- a/packages/client/src/network/setup/setupMUDNetwork.ts
+++ b/packages/client/src/network/setup/setupMUDNetwork.ts
@@ -87,7 +87,7 @@ export async function setupMUDNetwork<
   world.registerDisposer(network.dispose);
 
   // create the system executor
-  const { systems, getSystemContract } = createSystemExecutor<SystemTypes>(
+  const { txQueue, getSystemContract } = createSystemExecutor<SystemTypes>(
     world,
     network,
     SystemsRegistry,
@@ -146,21 +146,21 @@ export async function setupMUDNetwork<
   }
 
   // allows us to create arbitrary System Executor instances by just passing in a Network
-  function createSystems(network: Network) {
-    const { systems } = createSystemExecutor<SystemTypes>(
+  function createTxQueue(network: Network) {
+    const { txQueue } = createSystemExecutor<SystemTypes>(
       world,
       network,
       SystemsRegistry,
       SystemAbis
     );
-    return systems;
+    return txQueue;
   }
 
   return {
     network,
     startSync,
-    systems,
-    createSystems,
+    txQueue,
+    createTxQueue,
     txReduced$,
   };
 }


### PR DESCRIPTION
network `systems` -> `txQueue`

`systems` was implemented as a wrapped form of `txQueue`, e.g. ``` const systemCall = () => addToQueue(systemTx)```

this opens up `txQueue` to accept transaction type, while still handling systems normally. This pull only implements a native transfer tx, ERC20 later

also cleans up `txQueue` a little bit. but tbh we can rewrite this thing entirely