### PR TITLE
sort deployment indices

### DIFF
--- a/packages/contracts/src/deployment/world/state/items.ts
+++ b/packages/contracts/src/deployment/world/state/items.ts
@@ -1,8 +1,16 @@
 import { AdminAPI } from '../api';
-import { getItemImage, parseKamiStateToIndex, readFile, toDelete, toRevise } from './utils';
+import {
+  bringEntityToFront,
+  getItemImage,
+  parseKamiStateToIndex,
+  readFile,
+  toDelete,
+  toRevise,
+} from './utils';
 
 export async function initItems(api: AdminAPI, overrideIndices?: number[]) {
-  const itemsCSV = await readFile('items/items.csv');
+  const unstoredItemsCSV = await readFile('items/items.csv');
+  const itemsCSV = bringEntityToFront(unstoredItemsCSV, 'ITEM');
 
   for (let i = 0; i < itemsCSV.length; i++) {
     const item = itemsCSV[i];

--- a/packages/contracts/src/deployment/world/state/quests.ts
+++ b/packages/contracts/src/deployment/world/state/quests.ts
@@ -1,5 +1,6 @@
 import { AdminAPI } from '../api';
 import {
+  bringEntityToFront,
   GACHA_TICKET_INDEX,
   parseToInitCon,
   readFile,
@@ -9,7 +10,9 @@ import {
 } from './utils';
 
 export async function initQuests(api: AdminAPI, overrideIndices?: number[]) {
-  const questCSV = await readFile('quests/quests.csv');
+  const unsortedQuestCSV = await readFile('quests/quests.csv');
+  const questCSV = bringEntityToFront(unsortedQuestCSV, 'Quest');
+
   for (let i = 0; i < questCSV.length; i++) {
     const quest = questCSV[i];
 

--- a/packages/contracts/src/deployment/world/state/utils.ts
+++ b/packages/contracts/src/deployment/world/state/utils.ts
@@ -57,6 +57,14 @@ export const generateRegID = (field: string, index: number) => {
 ///////////////
 // PROCESSORS
 
+export const bringEntityToFront = (arr: any[], entityType: string) => {
+  return arr.sort((a, b) => {
+    if (a['Class'] === entityType && b['Class'] !== entityType) return -1;
+    if (b['Class'] === entityType && a['Class'] !== entityType) return 1;
+    return 0;
+  });
+};
+
 export const textToNumberArray = (text: string): number[] => {
   text = text.replaceAll('[', '');
   text = text.replaceAll(']', '');


### PR DESCRIPTION
notion seems to have changed their `.csv` output sorting on sorted databases. resulted in `items` trying to create its effect before the registry entity

adds a small function to bring all ITEMS (or other shapes) to the front, ensure registry entity is created before adding effects