### PR TITLE
clean up account pfp pull on account modal

### DIFF
--- a/packages/client/src/app/cache/account/base.ts
+++ b/packages/client/src/app/cache/account/base.ts
@@ -5,8 +5,13 @@ import { Account, getAccount, getAccountConfigs, NullAccount } from 'network/sha
 import { NameCache, OperatorCache, OwnerCache } from 'network/shapes/Account/queries';
 import { getMusuBalance } from 'network/shapes/Item';
 import { getStamina } from 'network/shapes/Stats';
-import { getLastActionTime, getLastTime, getRoomIndex } from 'network/shapes/utils/component';
-import { getFriends, getInventories, getPfp, getStats } from './getters';
+import {
+  getLastActionTime,
+  getLastTime,
+  getMediaURI,
+  getRoomIndex,
+} from 'network/shapes/utils/component';
+import { getFriends, getInventories, getStats } from './getters';
 
 // Account caches and Account cache checkers
 export const AccountCache = new Map<EntityIndex, Account>(); // account entity -> account
@@ -100,13 +105,10 @@ export const get = (
   }
 
   if (options.pfp !== undefined) {
-    console.log(`account cache start`);
     const updateTs = PfpURITs.get(entity) ?? 0;
     const updateDelta = (now - updateTs) / 1000; // convert to seconds
     if (updateDelta > options.pfp) {
-      console.log(`account cache if`);
-      acc.pfpURI = getPfp(world, components, entity);
-      console.log(`account cache get ${acc.pfpURI}`);
+      acc.pfpURI = getMediaURI(components, entity);
       PfpURITs.set(entity, now);
     }
   }

--- a/packages/client/src/app/cache/account/getters.ts
+++ b/packages/client/src/app/cache/account/getters.ts
@@ -8,7 +8,6 @@ import {
   queryAccountInventories,
   queryAccountKamis,
 } from 'network/shapes/Account';
-import { getPfpURI } from 'network/shapes/Account/pfp';
 import { getInventory } from '../inventory';
 import { getKami, KamiRefreshOptions } from '../kami';
 
@@ -46,10 +45,4 @@ export const getStats = (
 ): AccountStats => {
   if (!entity) return { coin: 0, kills: 0 };
   return getAccountStats(world, components, entity);
-};
-
-// get the pfpURI for an Account entity
-export const getPfp = (world: World, components: Components, entity: EntityIndex) => {
-  if (!entity) return '';
-  return getPfpURI(world, components, entity);
 };

--- a/packages/client/src/app/components/modals/account/Account.tsx
+++ b/packages/client/src/app/components/modals/account/Account.tsx
@@ -40,7 +40,7 @@ export function registerAccountModal() {
 
       const accountOptions = {
         friends: 60,
-        pfp: 1,
+        pfp: 5,
       };
 
       return interval(3333).pipe(

--- a/packages/client/src/network/shapes/Account/pfp.ts
+++ b/packages/client/src/network/shapes/Account/pfp.ts
@@ -1,8 +1,0 @@
-import { EntityIndex, World } from '@mud-classic/recs';
-import { Components } from 'network/components';
-import { getMediaURI } from '../utils/component';
-
-export const getPfpURI = (world: World, components: Components, entity: EntityIndex): string => {
-  const id = world.entities[entity];
-  return getMediaURI(components, entity);
-};


### PR DESCRIPTION
just a bit of cleanup. two things to note @Xenofluxx:
- when we need to retrieve a single component, we can just route directly through the component function found in `shapes/utils/component.ts` rather than creating wrapping functions to that end 
- we should avoid keeping console logs on regular, passive function calls. these ideally shouldnt hit prod unless we're intentionally debugging. error/warn logging on unexpected state (e.g. missing component entries) is fine

changes in this PR:
- removes console logs
- removes extraneous functions/files
- increases cadence of pfp refreshes 1s->5s (dont really need this to be so frequent)