### PR TITLE
Feed bold Text less blurry 

### DIFF
--- a/packages/client/src/app/components/modals/chat/feed/Feed.tsx
+++ b/packages/client/src/app/components/modals/chat/feed/Feed.tsx
@@ -361,10 +361,8 @@ const FeedTabMessage = styled.div<{ color: string }>`
   color: black;
   width: 100%;
   font-size: 0.6vw;
-
   strong {
     font-weight: bold;
-    text-shadow: 0 0 1.5px currentColor;
     ${({ color }) => `color: ${color} `};
   }
 `;


### PR DESCRIPTION
Makes the bold text look like this:
![image](https://github.com/user-attachments/assets/8a957a2d-6210-481c-95ab-7588264167b3)
instead of this:
![image](https://github.com/user-attachments/assets/2050a7f6-6552-44f2-b605-9f7bdb506e0a)


