### PR TITLE
optimise txqueue

### DIFF
--- a/packages/client/src/constants/chains.ts
+++ b/packages/client/src/constants/chains.ts
@@ -25,3 +25,6 @@ chainConfigs.set('staging', yominet);
 chainConfigs.set('production', yominet);
 
 export const DefaultChain = chainConfigs.get(import.meta.env.MODE ?? '')!;
+
+// yominet runs with a flat fee, hardcoded fee
+export const baseGasPrice = 3e7;


### PR DESCRIPTION
reduces txqueue latency, using ethers inefficency + minievm quirks

changes:
- skips gas price estimates
  - cosmos has no fee scaling, ordered by FCFS. Hardcoded gas cost to minimum gas price
- fixed chainID
  - theres no need to call each new time

saves about 500ms per tx, 1000ms if `estimateGas()` is set to a fixed limit