### PR TITLE
lazy load gacha pool kami data

### DIFF
--- a/packages/client/src/app/cache/kami/base.ts
+++ b/packages/client/src/app/cache/kami/base.ts
@@ -90,8 +90,8 @@ export const get = (
       kami.state = getState(components, entity);
       kami.time = {
         start: kami.time?.start ?? 0,
-        last: getLastTime(components, entity),
-        cooldown: getLastActionTime(components, entity),
+        last: getLastTime(components, entity, debug),
+        cooldown: getLastActionTime(components, entity, debug),
       };
 
       // populate health if it's defined

--- a/packages/client/src/app/components/modals/gacha/Gacha.tsx
+++ b/packages/client/src/app/components/modals/gacha/Gacha.tsx
@@ -46,7 +46,7 @@ export function registerGachaModal() {
           const accountID = world.entities[accountEntity];
           const accountOptions = { inventories: 2, live: 2 };
           const auctionOptions = { items: 3600, balance: 1 };
-          const kamiOptions = { live: 0, bonuses: 3600, progress: 3600, stats: 3600, traits: 3600 };
+          const kamiOptions = { live: 0, progress: 3600, stats: 3600, traits: 3600 };
 
           // TODO: boot the poolKamis query to MainDisplay once we consolidate tab views under it
           return {
@@ -67,8 +67,8 @@ export function registerGachaModal() {
               getItem: (index: number) => getItemByIndex(world, components, index),
               getItemBalance: (inventories: Inventory[], index: number) =>
                 getInventoryBalance(inventories, index),
-              getKami: (entity: EntityIndex) => getKami(world, components, entity),
-              queryGachaKamis: () => queryKamis(components, { account: GACHA_ID }),
+              getKami: (entity: EntityIndex) =>
+                getKami(world, components, entity, kamiOptions, false),
             },
           };
         })
@@ -103,12 +103,14 @@ export function registerGachaModal() {
 
       // ticking
       useEffect(() => {
+        setAccount(getAccount());
+
         const tick = () => setTick(Date.now());
         const timerID = setInterval(tick, 1000);
         return () => clearInterval(timerID);
       }, []);
 
-      // update the data when the modal is opened
+      // update the data when the modal is open
       useEffect(() => {
         if (!modals.gacha) return;
         if (mode === 'ALT') {
@@ -319,6 +321,7 @@ export function registerGachaModal() {
               controls={{ mode, setMode: handleSetMode, tab, filters, sorts }}
               data={{
                 ...data,
+                account,
                 auctions: { gacha: gachaAuction, reroll: rerollAuction },
               }}
               state={{ setQuantity, selectedKamis, setSelectedKamis, tick }}

--- a/packages/client/src/app/components/modals/gacha/display/Display.tsx
+++ b/packages/client/src/app/components/modals/gacha/display/Display.tsx
@@ -2,6 +2,7 @@ import { EntityIndex } from '@mud-classic/recs';
 import styled from 'styled-components';
 
 import { ActionButton, Overlay } from 'app/components/library';
+import { Account } from 'network/shapes/Account';
 import { Auction } from 'network/shapes/Auction';
 import { Kami } from 'network/shapes/Kami';
 import { Filter, Sort, TabType, ViewMode } from '../types';
@@ -21,6 +22,7 @@ interface Props {
     sorts: Sort[];
   };
   data: {
+    account: Account;
     accountEntity: EntityIndex;
     poolKamis: EntityIndex[];
     auctions: {
@@ -37,14 +39,13 @@ interface Props {
   utils: {
     getKami: (entity: EntityIndex) => Kami;
     getAccountKamis: () => Kami[];
-    queryGachaKamis: () => EntityIndex[];
   };
 }
 
 export const Display = (props: Props) => {
   const { state, controls, data, caches, utils } = props;
   const { mode, setMode, tab } = controls;
-  const { auctions, poolKamis } = data;
+  const { account, auctions, poolKamis } = data;
 
   const toggleMode = () => {
     if (mode === 'DEFAULT') setMode('ALT');
@@ -67,7 +68,7 @@ export const Display = (props: Props) => {
       <Pool
         caches={caches}
         controls={controls}
-        data={{ auction: auctions.gacha, entities: poolKamis }}
+        data={{ account, auction: auctions.gacha, entities: poolKamis }}
         utils={utils}
         isVisible={tab === 'GACHA'}
       />

--- a/packages/client/src/app/components/modals/gacha/display/pool/Pool.tsx
+++ b/packages/client/src/app/components/modals/gacha/display/pool/Pool.tsx
@@ -1,11 +1,12 @@
 import { EntityIndex } from '@mud-classic/recs';
 import styled from 'styled-components';
 
+import { Account } from 'network/shapes/Account';
 import { Auction } from 'network/shapes/Auction';
 import { Kami } from 'network/shapes/Kami/types';
 import { Filter, Sort, TabType, ViewMode } from '../../types';
 import { AuctionView } from '../auctions/AuctionView';
-import { PoolView } from './KamiView';
+import { KamiView } from './KamiView';
 
 interface Props {
   controls: {
@@ -19,6 +20,7 @@ interface Props {
     kamiBlocks: Map<EntityIndex, JSX.Element>;
   };
   data: {
+    account: Account;
     auction: Auction;
     entities: EntityIndex[];
   };
@@ -35,7 +37,7 @@ export const Pool = (props: Props) => {
 
   return (
     <Container isVisible={isVisible}>
-      <PoolView
+      <KamiView
         controls={controls}
         caches={caches}
         data={data}

--- a/packages/client/src/app/components/modals/gacha/display/pool/constants.ts
+++ b/packages/client/src/app/components/modals/gacha/display/pool/constants.ts
@@ -1,2 +1,2 @@
 export const EMPTY_TEXT = ['kachapon is empty', 'nothing to see here..'];
-export const LOADING_TEXT = ['your gacha pool is loading', 'please be patient'];
+export const LOADING_TEXT = ['kachapon is loading', 'please be patient..'];

--- a/packages/client/src/network/shapes/Kami/progress.ts
+++ b/packages/client/src/network/shapes/Kami/progress.ts
@@ -10,7 +10,7 @@ export interface Progress {
 
 export const getProgress = (components: Components, entity: EntityIndex): Progress => {
   return {
-    level: getLevel(components, entity),
+    level: getLevel(components, entity, 1),
     experience: getExperience(components, entity),
   };
 };

--- a/packages/client/src/network/shapes/utils/component.ts
+++ b/packages/client/src/network/shapes/utils/component.ts
@@ -320,18 +320,27 @@ export const getSkillIndex = (components: Components, entity: EntityIndex): numb
 // TIME
 
 // get the last action time of an entity (cooldown reset)
-export const getLastActionTime = (components: Components, entity: EntityIndex): number => {
+export const getLastActionTime = (
+  components: Components,
+  entity: EntityIndex,
+  debug?: boolean
+): number => {
   const { LastActionTime } = components;
   const result = getComponentValue(LastActionTime, entity)?.value;
-  if (result === undefined) console.warn('getLastActionTime(): undefined for entity', entity);
+  if (debug && result === undefined)
+    console.warn('getLastActionTime(): undefined for entity', entity);
   return (result ?? 0) * 1;
 };
 
 // get the last time of an entity
-export const getLastTime = (components: Components, entity: EntityIndex): number => {
+export const getLastTime = (
+  components: Components,
+  entity: EntityIndex,
+  debug?: boolean
+): number => {
   const { LastTime } = components;
   const result = getComponentValue(LastTime, entity)?.value;
-  if (result === undefined) console.warn('getLastTime(): undefined for entity', entity);
+  if (debug && result === undefined) console.warn('getLastTime(): undefined for entity', entity);
   return (result ?? 0) * 1;
 };
 


### PR DESCRIPTION
processing overhead is a bit intense with additional data points like stats and traits added. lazily loads pool kami data at the start of the game without disrupting the ui rendering

if this causes performance degradation for some users we could also consider only starting the load once the player enters the vending machine room 