### PR TITLE
deprecate world

### DIFF
--- a/packages/contracts/deployment/commands/deprecateSystem.ts
+++ b/packages/contracts/deployment/commands/deprecateSystem.ts
@@ -2,14 +2,14 @@ const yargs = require('yargs/yargs');
 const { hideBin } = require('yargs/helpers');
 import dotenv from 'dotenv';
 import { constants } from 'ethers';
-import { ignoreSolcErrors } from '../utils';
+import { getAllSystemIDs, ignoreSolcErrors } from '../utils';
 import execa = require('execa');
 
 import { getDeployerKey, getRpc, getWorld, setAutoMine } from '../utils';
 
 const argv = yargs(hideBin(process.argv))
   .usage('Usage: $0 -mode <mode> -systems <address[]>')
-  .demandOption(['mode', 'systems'])
+  .demandOption(['mode'])
   .parse();
 dotenv.config();
 
@@ -17,7 +17,7 @@ const run = async () => {
   // setup
   const mode = argv.mode || 'DEV';
   const world = argv.world ? argv.world : getWorld(mode);
-  const systems: string[] = argv.systems;
+  const systems: string[] = argv.systems ? argv.systems : getAllSystemIDs();
   const idType = argv.byAddress ? 'ADDRESS' : 'ID';
 
   console.log(systems);

--- a/packages/contracts/deployment/scripts/codegen/deploy.ts
+++ b/packages/contracts/deployment/scripts/codegen/deploy.ts
@@ -2,8 +2,8 @@ import ejs from 'ejs';
 import { writeFile } from 'fs/promises';
 import path from 'path';
 import { DeployConfig, getDeployComponents, getDeploySystems } from '../../utils';
+import { deploymentDir } from '../../utils/paths';
 import { generateImports } from './imports';
-import { deploymentDir } from './paths';
 
 /**
  * Generate LibDeploy.sol from deploy.json

--- a/packages/contracts/deployment/scripts/codegen/ids.ts
+++ b/packages/contracts/deployment/scripts/codegen/ids.ts
@@ -1,7 +1,7 @@
 import { readFile, writeFile } from 'fs/promises';
 import path from 'path';
 import { extractIdFromFile, keccak256 } from '../../utils/ids';
-import { contractsDir, deployConfigPath } from './paths';
+import { contractsDir, deployConfigPath } from '../../utils/paths';
 
 export async function generateIDs() {
   const config = JSON.parse(await readFile(deployConfigPath, { encoding: 'utf8' }));

--- a/packages/contracts/deployment/scripts/codegen/imports.ts
+++ b/packages/contracts/deployment/scripts/codegen/imports.ts
@@ -1,7 +1,7 @@
 import ejs from 'ejs';
 import { readFile, writeFile } from 'fs/promises';
 import path from 'path';
-import { deployConfigPath, deploymentDir } from './paths';
+import { deployConfigPath, deploymentDir } from '../../utils/paths';
 
 export async function generateImports(out: string) {
   const config = JSON.parse(await readFile(deployConfigPath, { encoding: 'utf8' }));

--- a/packages/contracts/deployment/scripts/codegen/initWorld.ts
+++ b/packages/contracts/deployment/scripts/codegen/initWorld.ts
@@ -1,7 +1,7 @@
 import ejs from 'ejs';
 import { readFile, writeFile } from 'fs/promises';
 import path from 'path';
-import { deploymentDir } from './paths';
+import { deploymentDir } from '../../utils/paths';
 
 export async function generateInitWorld() {
   const callsPath = path.join(deploymentDir, 'contracts/initStream.json');

--- a/packages/contracts/deployment/scripts/codegen/mappings.ts
+++ b/packages/contracts/deployment/scripts/codegen/mappings.ts
@@ -3,7 +3,7 @@ import { glob } from 'glob';
 import path from 'path';
 import { deferred } from '../../utils/deferred';
 import { extractIdFromFile } from '../../utils/ids';
-import { clientDir, componentsDir, deploymentDir, systemsDir } from './paths';
+import { clientDir, componentsDir, deploymentDir, systemsDir } from '../../utils/paths';
 
 export async function genClientSystemData(clear?: boolean) {
   const outputDir = clientDir + 'types/';

--- a/packages/contracts/deployment/scripts/codegen/schemas.ts
+++ b/packages/contracts/deployment/scripts/codegen/schemas.ts
@@ -6,7 +6,7 @@ import {
   componentSchemaPath,
   contractsDir,
   deployConfigPath,
-} from './paths';
+} from '../../utils/paths';
 
 /**
  * Generate Component register.ts and component schemas in client

--- a/packages/contracts/deployment/scripts/deployer.ts
+++ b/packages/contracts/deployment/scripts/deployer.ts
@@ -1,8 +1,8 @@
 import { constants } from 'ethers';
 import { ignoreSolcErrors } from '../utils';
 import { findLog } from '../utils/findLog';
+import { deploymentDir } from '../utils/paths';
 import { generateLibDeploy } from './codegen';
-import { deploymentDir } from './codegen/paths';
 import execa = require('execa');
 
 /**

--- a/packages/contracts/deployment/utils/ids.ts
+++ b/packages/contracts/deployment/utils/ids.ts
@@ -1,5 +1,7 @@
 import { keccak256 as keccak256Bytes, toUtf8Bytes } from 'ethers/lib/utils';
 import { readFileSync } from 'fs';
+import path from 'path';
+import { contractsDir, deployConfigPath } from './paths';
 
 export const IDregex = new RegExp(/(?<=uint256 constant ID = uint256\(keccak256\(")(.*)(?="\))/);
 
@@ -11,4 +13,32 @@ export function extractIdFromFile(path: string): string | null {
 
 export function keccak256(data: string) {
   return keccak256Bytes(toUtf8Bytes(data));
+}
+
+export function getAllCompIDs(): string[] {
+  const config = JSON.parse(readFileSync(deployConfigPath, { encoding: 'utf8' }));
+
+  const components: any[] = config.components;
+  const ids: string[] = [];
+  components.map((comp) => {
+    const id = extractIdFromFile(
+      path.join(contractsDir, 'src/components', comp.comp + 'Component.sol')
+    );
+    if (id) ids.push(id);
+  });
+
+  return ids;
+}
+
+export function getAllSystemIDs(): string[] {
+  const config = JSON.parse(readFileSync(deployConfigPath, { encoding: 'utf8' }));
+
+  const systems: any[] = config.systems;
+  const ids: string[] = [];
+  systems.map((sys) => {
+    const id = extractIdFromFile(path.join(contractsDir, 'src/systems', sys.name + '.sol'));
+    if (id) ids.push(id);
+  });
+
+  return ids;
 }

--- a/packages/contracts/deployment/utils/index.ts
+++ b/packages/contracts/deployment/utils/index.ts
@@ -11,4 +11,4 @@ export {
 } from './deploy';
 export { findLog } from './findLog';
 export { ignoreSolcErrors } from './forge';
-export { extractIdFromFile, keccak256 } from './ids';
+export { extractIdFromFile, getAllCompIDs, getAllSystemIDs, keccak256 } from './ids';

--- a/packages/contracts/deployment/utils/paths.ts
+++ b/packages/contracts/deployment/utils/paths.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-export const deploymentDir = path.join(__dirname, '../../');
+export const deploymentDir = path.join(__dirname, '../');
 export const clientDir = path.join(deploymentDir, '../../client/');
 export const contractsDir = path.join(deploymentDir, '../');
 export const systemsDir = path.join(contractsDir, 'src/systems/');


### PR DESCRIPTION
enables easy world deprecation. upgrades previous `deprecateSystem.ts` to default to all systems

to murder a world: `pnpm deprecate:testnet`