### PR TITLE
fixed tx error handling

### DIFF
--- a/packages/client/src/engine/queue/create.ts
+++ b/packages/client/src/engine/queue/create.ts
@@ -11,14 +11,7 @@ import { Contracts } from 'engine/types';
 import { deferred } from 'utils/async';
 import { createPriorityQueue } from './priorityQueue';
 import { TxQueue } from './types';
-import {
-  getRevertReason,
-  isOverrides,
-  sendTx,
-  shouldIncNonce,
-  shouldResetNonce,
-  waitForTx,
-} from './utils';
+import { isOverrides, sendTx, shouldIncNonce, shouldResetNonce, waitForTx } from './utils';
 
 type ReturnTypeStrict<T> = T extends (...args: any) => any ? ReturnType<T> : never;
 
@@ -204,13 +197,12 @@ export function create<C extends Contracts>(
         const tx = await txResult.wait();
         console.log(`[TXQueue] TX Confirmed\n`, tx);
       } catch (e) {
-        console.warn('[TXQueue] tx failed in block', e);
-
-        // Decode and log the revert reason.
-        getRevertReason(txResult.hash, network.providers.get().json).then((reason) =>
-          console.warn('[TXQueue] Revert reason:', reason)
-        ); // calling then instead of await to avoid blocking
-        console.log(`txHash: ${txResult.hash}`);
+        console.warn('[TXQueue] tx failed in block');
+        throw e; // bubble up error
+        // // Decode and log the revert reason.
+        // getRevertReason(txResult.hash, network.providers.get().json).then((reason) =>
+        //   console.warn('[TXQueue] Revert reason:', reason)
+        // ); // calling then instead of await to avoid blocking
       }
     }
 

--- a/packages/client/src/network/api/player/harvest.ts
+++ b/packages/client/src/network/api/player/harvest.ts
@@ -3,13 +3,13 @@ import { BigNumberish } from '@ethersproject/bignumber';
 export function harvestAPI(systems: any) {
   // @dev retrieves the amount due from a passive deposit harvest and resets the starting point
   function collect(harvestIDs: BigNumberish[]) {
-    return systems['system.harvest.collect'].executeBatched(harvestIDs, { gasLimit: 2000000 });
+    return systems['system.harvest.collect'].executeBatched(harvestIDs, { gasLimit: 2500000 });
   }
 
   // @dev liquidates a harvest, if able to, using the specified pet
   function liquidate(harvestID: BigNumberish, kamiID: BigNumberish) {
     return systems['system.harvest.liquidate'].executeTyped(harvestID, kamiID, {
-      gasLimit: 2800000,
+      gasLimit: 3200000,
     });
   }
 
@@ -20,7 +20,7 @@ export function harvestAPI(systems: any) {
 
   // @dev retrieves the amount due from a passive deposit harvest and stops it.
   function stop(harvestIDs: BigNumberish[]) {
-    return systems['system.harvest.stop'].executeBatched(harvestIDs, { gasLimit: 2000000 });
+    return systems['system.harvest.stop'].executeBatched(harvestIDs, { gasLimit: 2500000 });
   }
 
   return {

--- a/packages/client/src/network/systems/ActionSystem/createActionSystem.ts
+++ b/packages/client/src/network/systems/ActionSystem/createActionSystem.ts
@@ -85,7 +85,7 @@ export function createActionSystem<M = undefined>(
       updateAction({ state: ActionState.WaitingForTxEvents }); // pending
 
       if (tx) {
-        if (request.awaitConfirmation) await tx.wait();
+        if (!request.skipConfirmation) await tx.wait();
         updateAction({ txHash: tx.hash });
       }
 
@@ -137,7 +137,7 @@ export function createActionSystem<M = undefined>(
   // message as metadata. The rest of the error is logged as a warning and can
   // be bubbled up, but does not appear to be useful for clientside reporting.
   function handleError(error: any, action: ActionRequest) {
-    console.warn('handleError()', '\naction: ', action, '\nerror: ', error);
+    // console.warn('handleError()', '\naction: ', action, '\nerror: ', error);
     if (!action.index) return;
 
     let metadata = error;

--- a/packages/client/src/network/systems/ActionSystem/types.ts
+++ b/packages/client/src/network/systems/ActionSystem/types.ts
@@ -25,5 +25,5 @@ export type ActionRequest = {
 
   // Flag to set if the queue should wait for the underlying transaction to be confirmed (in addition to being reduced)
   on?: EntityIndex; // the entity this action is related to.
-  awaitConfirmation?: boolean; // whether the queue should await tx resolution
+  skipConfirmation?: boolean; // skip confirmation for this action
 };


### PR DESCRIPTION
txQueue was not properly bubbling up errors after sending tx, resulting in transactions that with hardcoded `estimateGas` to showing false positives on txQueue

additionally updates gas limits for harvest collect/stop to account for first time inventory creations