### PR TITLE
Split Publish Pipeline

### DIFF
--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -1,4 +1,4 @@
-name: Publish to public repo
+name: Publish to Public Client Repo
 
 on:
   push:
@@ -25,7 +25,7 @@ jobs:
           ## SETUP SSH KEY
           eval $(ssh-agent -s)
           mkdir -p ~/.ssh
-          echo "${{secrets.KAMI_CONTRACTS_DEPLOY_KEY}}" > ~/.ssh/id_rsa
+          echo "${{secrets.KAMI_CLIENT_DEPLOY_KEY}}" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
           ls -la ~/.ssh/id_rsa
           ssh-keyscan github.com >> ~/.ssh/known_hosts

--- a/.github/workflows/publish-contracts.yml
+++ b/.github/workflows/publish-contracts.yml
@@ -1,11 +1,11 @@
-name: Publish to public repo
+name: Publish to Public Contracts Repo
 
 on:
   push:
     branches:
       - main
     paths:
-      - 'packages/client/**'
+      - 'packages/contracts/**'
 
 env:
   TARGET_REPO_OWNER: 'Asphodel-OS'


### PR DESCRIPTION
Requires two new secrets KAMI_CLIENT_DEPLOY_KEY and KAMI_CONTRACTS_DEPLOY_KEY that will hold the ssh private for the os repos