### PR TITLE
Deploy All Kamis Button

### DIFF
--- a/packages/client/src/app/components/library/base/buttons/DropDownToggle.tsx
+++ b/packages/client/src/app/components/library/base/buttons/DropDownToggle.tsx
@@ -1,0 +1,165 @@
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import { useEffect, useState } from 'react';
+import styled from 'styled-components';
+
+import { playClick } from 'utils/sounds';
+import { Popover } from '../poppers/Popover';
+import { IconButton } from './IconButton';
+
+interface Props {
+  onClick: (selected: any[]) => void;
+  img: string;
+  checkList: Option[];
+  disabled?: boolean;
+  balance?: number;
+}
+
+interface Option {
+  text: string;
+  img?: string;
+  object?: any;
+  disabled?: boolean;
+}
+
+export function DropDownToggle(props: Props) {
+  const { checkList, disabled, img, balance, onClick } = props;
+  const [checked, setChecked] = useState<boolean[]>([]);
+  const [forceClose, setForceClose] = useState(false);
+
+  const resetCheckBoxes = () => setChecked(Array(checkList.length).fill(false));
+
+  const toggleCheckbox = (e: React.MouseEvent, index: number) => {
+    e.stopPropagation(); // prevent popover from closing
+    setChecked((prev) => prev.map((val, i) => (i === index ? !val : val)));
+  };
+
+  const toggleSelect = (e: React.MouseEvent) => {
+    e.stopPropagation(); // prevent popover from closing
+    const allSelected = checked.every(Boolean);
+    setChecked(checked.map(() => !allSelected));
+  };
+
+  // necessary to properly create the checked array, this way it waits for the checkList to be populated
+  useEffect(() => {
+    if (checked.length !== checkList.length) resetCheckBoxes();
+  }, [checkList, checked.length]);
+
+  // force close the popover if there are no options left and the checklist is in the process of being emptied
+  useEffect(() => {
+    if (checkList.length === 0) setForceClose(true);
+    else setForceClose(false);
+  }, [checkList]);
+
+  const Trigger = () => {
+    const handleTriggerClick = () => {
+      const selected = checkList.filter((_, i) => checked[i]).map((opt) => opt.object);
+      playClick();
+      onClick(selected);
+    };
+    return (
+      <IconButton
+        img={img}
+        disabled={disabled || !checked.includes(true)}
+        onClick={handleTriggerClick}
+        dropDown={'right'}
+      />
+    );
+  };
+
+  const MenuCheckListOption = (
+    { text, img, object }: Option,
+    i: number | null,
+    onClick: (e: React.MouseEvent) => void,
+    isSelectAll: boolean
+  ) => {
+    const imageSrc = img ?? object?.image;
+    const isChecked = isSelectAll ? checked.every(Boolean) : !!checked[i!];
+    return (
+      <MenuOption
+        key={isSelectAll ? 'SelectAll' : `toggle-${i}`}
+        onClick={onClick}
+        isSelectAll={isSelectAll}
+        disabled={disabled}
+      >
+        <Row>
+          <input type='checkbox' checked={isChecked} readOnly />
+          <span>{text}</span>
+        </Row>
+        {imageSrc && <Image src={imageSrc} />}
+      </MenuOption>
+    );
+  };
+
+  const DropDownButton = () => {
+    return (
+      <IconButton
+        img={ArrowDropDownIcon}
+        text={`${checked.filter((val) => val === true).length} Selected`}
+        width={10}
+        onClick={() => {}}
+        disabled={disabled}
+        balance={balance}
+        corner={!balance}
+        dropDown={'left'}
+      />
+    );
+  };
+
+  return (
+    <Container>
+      <Popover
+        content={[
+          MenuCheckListOption({ text: 'Select All' }, null, (e) => toggleSelect(e), true),
+          ...checkList.map((option, i) =>
+            MenuCheckListOption(option, i, (e) => toggleCheckbox(e, i), false)
+          ),
+        ]}
+        onClose={resetCheckBoxes}
+        disabled={disabled}
+        forceClose={forceClose}
+      >
+        {DropDownButton()}
+      </Popover>
+      {Trigger()}
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  display: flex;
+`;
+
+const MenuOption = styled.div<{
+  disabled?: boolean;
+  isSelectAll?: boolean;
+}>`
+  display: flex;
+  align-items: center;
+  justify-content: left;
+  gap: 0.4vw;
+  border-radius: 0.4vw;
+  font-size: 0.8vw;
+  cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
+  pointer-events: ${({ disabled }) => (disabled ? 'none' : 'auto')};
+  background-color: ${({ disabled }) => (disabled ? '#bbb' : '#fff')};
+  padding: ${({ isSelectAll }) => (isSelectAll ? '1vw 0.6vw 0.4vw 0.9vw ' : '0 0.2vw 0.1vw 2.2vw')};
+
+  &:hover {
+    background-color: #ddd;
+  }
+`;
+
+const Row = styled.span`
+  display: flex;
+  align-items: center;
+  gap: 0.6vw;
+`;
+
+const Image = styled.img`
+  height: 2vw;
+  width: 2vw;
+  object-fit: cover;
+  margin-left: auto;
+  border-radius: 0.3vw;
+  border: solid black 0.05vw;
+`;

--- a/packages/client/src/app/components/library/base/buttons/IconButton.tsx
+++ b/packages/client/src/app/components/library/base/buttons/IconButton.tsx
@@ -1,3 +1,4 @@
+import { SvgIconComponent } from '@mui/icons-material';
 import { ForwardedRef, forwardRef } from 'react';
 import styled from 'styled-components';
 
@@ -5,9 +6,10 @@ import { clickFx, hoverFx, pulseFx } from 'app/styles/effects';
 import { playClick } from 'utils/sounds';
 
 interface Props {
-  img: string;
+  img: string | SvgIconComponent;
   onClick: Function;
   text?: string;
+  width?: number;
   color?: string;
   disabled?: boolean;
   fullWidth?: boolean;
@@ -17,6 +19,7 @@ interface Props {
   radius?: number;
   scale?: number;
   scaleOrientation?: 'vw' | 'vh';
+  dropDown?: `left` | `right`;
 }
 
 // ActionButton is a text button that triggers an Action when clicked
@@ -24,7 +27,7 @@ export const IconButton = forwardRef(function IconButton(
   props: Props,
   ref: ForwardedRef<HTMLButtonElement>
 ) {
-  const { img, onClick, text, disabled, fullWidth, color, pulse } = props;
+  const { img, onClick, text, disabled, fullWidth, color, pulse, width, dropDown } = props;
   const { balance, corner } = props; // IconListButton options
   const scale = props.scale ?? 2.5;
   const scaleOrientation = props.scaleOrientation ?? 'vw';
@@ -36,8 +39,18 @@ export const IconButton = forwardRef(function IconButton(
     await onClick();
   };
 
+  const MyImage = () => {
+    if (typeof img === 'string') {
+      return <Image src={img} scale={scale} orientation={scaleOrientation} />;
+    }
+
+    const IconComponent = img;
+    return <IconComponent />;
+  };
+
   return (
     <Button
+      width={width}
       color={color ?? '#fff'}
       onClick={!disabled ? handleClick : () => {}}
       scale={scale}
@@ -47,8 +60,9 @@ export const IconButton = forwardRef(function IconButton(
       disabled={disabled}
       pulse={pulse}
       ref={ref}
+      dropDown={dropDown}
     >
-      <Image src={img} scale={scale} orientation={scaleOrientation} />
+      {<MyImage />}
       {text && (
         <Text scale={scale} orientation={scaleOrientation}>
           {text}
@@ -61,6 +75,7 @@ export const IconButton = forwardRef(function IconButton(
 });
 
 interface ButtonProps {
+  width?: number;
   color: string;
   scale: number;
   orientation: string;
@@ -68,27 +83,35 @@ interface ButtonProps {
   fullWidth?: boolean;
   disabled?: boolean;
   pulse?: boolean;
+  dropDown?: `left` | `right`;
 }
 
 const Button = styled.button<ButtonProps>`
   position: relative;
   border: solid black 0.15vw;
-  border-radius: ${({ radius }) => radius}${({ orientation }) => orientation};
-  height: ${({ scale }) => scale}${({ orientation }) => orientation};
-  width: ${({ fullWidth }) => (fullWidth ? '100%' : 'auto')};
-
-  padding: ${({ scale }) => scale * 0.1}${({ orientation }) => orientation};
-  gap: ${({ scale }) => scale * 0.1}${({ orientation }) => orientation};
-
+  border-radius: ${({ radius, orientation }) => `${radius}${orientation}`};
+  height: ${({ scale, orientation }) => `${scale}${orientation}`};
+  width: ${({ fullWidth, width }) => (fullWidth ? '100%' : width ? `${width}vw` : 'auto')};
+  min-width: fit-content;
+  padding: ${({ scale, orientation }) => `${scale * 0.1}${orientation}`};
+  gap: ${({ scale, orientation }) => `${scale * 0.1}${orientation}`};
   display: flex;
   flex-flow: row nowrap;
   justify-content: center;
   align-items: center;
-
   background-color: ${({ color, disabled }) => (disabled ? '#bbb' : color)};
   cursor: ${({ disabled }) => (disabled ? 'help' : 'pointer')};
   pointer-events: ${({ disabled }) => (disabled ? 'none' : 'auto')};
   user-select: none;
+  ${({ dropDown }) =>
+    dropDown === `left`
+      ? ` border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+  `
+      : dropDown === `right` &&
+        ` border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+  `}
   &:hover {
     animation: ${() => hoverFx()} 0.2s;
     transform: scale(1.05);
@@ -96,7 +119,6 @@ const Button = styled.button<ButtonProps>`
   &:active {
     animation: ${() => clickFx()} 0.3s;
   }
-
   animation: ${({ pulse }) => pulse && pulseFx} 3s ease-in-out infinite;
 `;
 

--- a/packages/client/src/app/components/library/base/poppers/Popover.tsx
+++ b/packages/client/src/app/components/library/base/poppers/Popover.tsx
@@ -7,10 +7,16 @@ interface Props {
   cursor?: string;
   mouseButton?: 0 | 2;
   closeOnClick?: boolean;
+  // pass the  function from the parent component to execute when the popover closes
+  onClose?: () => void;
+  // forceclose the popover from the parent component
+  forceClose?: boolean;
+  // disable the popover from the parent component
+  disabled?: boolean;
 }
 
 export const Popover = (props: Props) => {
-  const { children, content } = props;
+  const { children, content, onClose, disabled, forceClose } = props;
   const cursor = props.cursor ?? 'pointer';
   const mouseButton = props.mouseButton ?? 0;
   const closeOnClick = props.closeOnClick ?? true;
@@ -20,6 +26,12 @@ export const Popover = (props: Props) => {
   const [isVisible, setIsVisible] = useState(false);
   const [popoverPosition, setPopoverPosition] = useState({ x: 0, y: 0 });
   const [clickedScrollBar, setClickedScrollBar] = useState(true);
+
+  useEffect(() => {
+    if (props.forceClose) {
+      setIsVisible(false);
+    }
+  }, [props.forceClose]);
 
   // add interaction event listeners
   useEffect(() => {
@@ -45,7 +57,10 @@ export const Popover = (props: Props) => {
       const didSelect = closeOnClick && pRef.contains(event.target) && !clickedScrollBar;
       const didOffclick = !pRef.contains(event.target) && !tRef.contains(event.target);
       if (didSelect || didOffclick) {
-        setTimeout(() => setIsVisible(false), 100);
+        setTimeout(() => {
+          setIsVisible(false);
+          if (onClose) onClose();
+        }, 100);
       }
     };
 
@@ -68,6 +83,7 @@ export const Popover = (props: Props) => {
     else setClickedScrollBar(false);
 
     closeOnClick ? setIsVisible(false) : setIsVisible(true);
+    if (!isVisible && onClose) onClose();
   };
 
   const handlePosition = () => {
@@ -96,6 +112,7 @@ export const Popover = (props: Props) => {
         !triggerRef.current.contains(event.target)
       ) {
         setIsVisible(false);
+        if (onClose) onClose();
       }
     }
   };
@@ -106,10 +123,9 @@ export const Popover = (props: Props) => {
         cursor={cursor}
         ref={triggerRef}
         onMouseDown={(e) => {
-          if (content.length !== 0 && e.button === mouseButton) {
-            handlePosition();
-            setIsVisible(!isVisible);
-          }
+          if (disabled || content.length === 0 || e.button !== mouseButton) return;
+          handlePosition();
+          setIsVisible(!isVisible);
         }}
       >
         {children}
@@ -118,9 +134,14 @@ export const Popover = (props: Props) => {
         isVisible={isVisible}
         ref={popoverRef}
         popoverPosition={popoverPosition}
-        onClick={(e) => handleClick(e)}
+        onClick={(e) => {
+          if (disabled) return;
+          handleClick(e);
+        }}
       >
-        {content}
+        {Array.isArray(content)
+          ? content.map((item, index) => <div key={`popover-item-${index}`}>{item}</div>)
+          : content}
       </PopoverContent>
     </PopoverContainer>
   );

--- a/packages/client/src/app/components/modals/node/Node.tsx
+++ b/packages/client/src/app/components/modals/node/Node.tsx
@@ -192,13 +192,17 @@ export function registerNodeModal() {
       };
 
       // starts a harvest for the given pet and node
-      const start = (kami: Kami, node: Node) => {
+      const start = (kamis: Kami[], node: Node) => {
+        const kamiIDs = kamis.map((kami) => kami.id);
         actions.add({
           action: 'HarvestStart',
-          params: [kami.id, node.id],
-          description: `Placing ${kami.name} on ${node.name}`,
+          params: [kamiIDs, node.id],
+          description:
+            kamiIDs.length > 1
+              ? `Placing ${kamis.length} kamis on ${node.name}`
+              : `Placing ${kamis[0].name}  on ${node.name}`,
           execute: async () => {
-            return api.player.pet.harvest.start([kami.id], node.index);
+            return api.player.pet.harvest.start(kamiIDs, node.index);
           },
         });
       };
@@ -245,7 +249,7 @@ export function registerNodeModal() {
             <Header
               key='banner'
               data={{ account, node, kamiEntities: kamiEntities.account }}
-              actions={{ claim, addKami: (kami) => start(kami, node) }}
+              actions={{ claim, addKami: (kamis: Kami[]) => start(kamis, node) }}
               utils={utils}
             />,
           ]}

--- a/packages/client/src/app/components/modals/node/header/Header.tsx
+++ b/packages/client/src/app/components/modals/node/header/Header.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import { canHarvest, isResting, onCooldown } from 'app/cache/kami';
 import { IconListButton, Tooltip } from 'app/components/library';
+import { DropDownToggle } from 'app/components/library/base/buttons/DropDownToggle';
 import { useVisibility } from 'app/stores';
 import { HarvestIcon } from 'assets/images/icons/actions';
 import { rooms } from 'constants/rooms';
@@ -26,7 +27,7 @@ interface Props {
   };
   actions: {
     claim: (scavenge: ScavBar) => void;
-    addKami: (kami: Kami) => void;
+    addKami: (kamis: Kami[]) => void;
   };
   utils: {
     getAccountKamis: () => Kami[];
@@ -105,6 +106,12 @@ export const Header = (props: Props) => {
     return canHarvest(kami) && passesNodeReqs(kami);
   };
 
+  const checkList = kamis
+    .filter((kami) => canAdd(kami))
+    .map((kami) => ({
+      text: kami.name,
+      object: kami,
+    }));
   /////////////////
   // RENDERING
 
@@ -112,20 +119,36 @@ export const Header = (props: Props) => {
   const AddButton = (kamis: Kami[]) => {
     const options = kamis.filter((kami) => canAdd(kami));
     const actionOptions = options.map((kami) => {
-      return { text: `${kami.name}`, onClick: () => addKami(kami) };
+      return { text: `${kami.name}`, onClick: () => addKami(kamis) };
     });
 
     return (
-      <Tooltip text={[getDisabledReason(kamis)]} grow>
-        <IconListButton
-          key={`harvest-add`}
-          img={HarvestIcon}
-          options={actionOptions}
-          text='Add Kami to Node'
-          disabled={options.length == 0 || account.roomIndex !== node.roomIndex}
-          fullWidth
-        />
-      </Tooltip>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          width: `100%`,
+        }}
+      >
+        <Tooltip text={[getDisabledReason(kamis)]} grow>
+          <IconListButton
+            key={`harvest-add`}
+            img={HarvestIcon}
+            options={actionOptions}
+            text='Add Kami to Node'
+            disabled={options.length == 0 || account.roomIndex !== node.roomIndex}
+            fullWidth
+          />
+        </Tooltip>
+        <div style={{ marginTop: '0.6vw', width: '2vw' }}>
+          <DropDownToggle
+            img={HarvestIcon}
+            disabled={checkList.length == 0 || account.roomIndex !== node.roomIndex}
+            onClick={(selectedKamis: Kami[]) => addKami(selectedKamis)}
+            checkList={checkList}
+          />
+        </div>
+      </div>
     );
   };
 

--- a/packages/client/src/network/api/player/kamis/harvests.ts
+++ b/packages/client/src/network/api/player/kamis/harvests.ts
@@ -27,9 +27,7 @@ export const harvestsAPI = (systems: any) => {
    * @param nodeIndex nodeIndex
    */
   const start = (kamiIDs: BigNumberish[], nodeIndex: BigNumberish) => {
-    return systems['system.harvest.start'].executeBatched(kamiIDs, nodeIndex, 0, 0, {
-      gasLimit: 2200000,
-    });
+    return systems['system.harvest.start'].executeBatched(kamiIDs, nodeIndex, 0, 0);
   };
 
   /**


### PR DESCRIPTION
TODO: remove this from node
![image](https://github.com/user-attachments/assets/6ec3fad2-2422-41f1-b168-472b689b33ac)
* This new library component consists of a dropdown containing a checklist and a trigger button placed besides it.
*  Popover was modified so it can execute functions when it closes (in this case a cleaning one), be disabled and force closed from the parent. + fixed a bug that was triggering a warning in the console.
* Iconbutton  accepts more props (for visual tweaks) .
