### PR TITLE
revert IconButton padding changes

### DIFF
--- a/packages/client/src/app/components/library/buttons/IconButton.tsx
+++ b/packages/client/src/app/components/library/buttons/IconButton.tsx
@@ -104,8 +104,8 @@ const Container = styled.button<ContainerProps>`
   height: ${({ scale, orientation }) => `${scale}${orientation}`};
   width: ${({ fullWidth, width }) => (fullWidth ? '100%' : width ? `${width}vw` : 'auto')};
   min-width: fit-content;
-  padding: ${({ scale, orientation }) => `${scale * 0.18}${orientation}`};
-  gap: ${({ scale, orientation }) => `${scale * 0.15}${orientation}`};
+  padding: ${({ scale, orientation }) => `${scale * 0.1}${orientation}`};
+  gap: ${({ scale, orientation }) => `${scale * 0.1}${orientation}`};
 
   display: flex;
   flex-flow: row nowrap;


### PR DESCRIPTION
woopsie made it through

we should do something about conditional padding based on whether only text (not an icon) is provided to `IconButton`