### PR TITLE
use room name for node modal title

### DIFF
--- a/packages/client/src/app/components/modals/node/header/Header.tsx
+++ b/packages/client/src/app/components/modals/node/header/Header.tsx
@@ -130,11 +130,11 @@ export const Header = (props: Props) => {
   };
 
   return (
-    <Container key={node.name}>
+    <Container>
       <Content>
         <Image src={getNodeImage()} />
         <Details>
-          <Name>{node.name}</Name>
+          <Name>{room.name}</Name>
           <Row>
             <Label>Type: </Label>
             <TextTooltip text={[node.affinity ?? '']}>


### PR DESCRIPTION
we're not keeping the node name/descriptions up to date
don't rely on those. rely on room data instead