### PR TITLE
Retry policy on State Initialization step

### DIFF
--- a/packages/client/src/workers/sync/Worker.ts
+++ b/packages/client/src/workers/sync/Worker.ts
@@ -378,7 +378,7 @@ export class SyncWorker<C extends Components> implements DoWork<Input, NetworkEv
       if (this.hasExceededMaxRetries()) {
         this.setLoadingState({
           state: SyncState.FAILED,
-          msg: `Error initializing state. Maxretries reached. Can you drop this in the discord?`,
+          msg: `Max retries reached. Can you drop this in the discord if it persists?`,
         });
         console.error('Error during stateCache output, maximum retries reached:', e);
         return;

--- a/packages/client/src/workers/sync/state/cache.ts
+++ b/packages/client/src/workers/sync/state/cache.ts
@@ -56,6 +56,7 @@ export const getEntries = <C extends Components>(
     const component = components[componentIndex];
     const entity = entities[entityIndex];
 
+    throw new Error(`Unknown component / entity: ${component}, ${entity}`);
     if (component == null || entity == null) {
       console.warn(`KEY: ${key}`);
       console.warn(`Indexes component / entity: ${componentIndex}, ${entityIndex}`);


### PR DESCRIPTION
Forces the sync worker to rerun the init() process (up to 2 times) if theres an error on the State Initialization state
<img width="2536" height="1414" alt="image" src="https://github.com/user-attachments/assets/9ea08f6b-6c40-4b60-a1fa-0d71b9c56409" />
