### PR TITLE
horizontal stackable bonuses

### DIFF
--- a/packages/contracts/deployment/world/data/items/items.csv
+++ b/packages/contracts/deployment/world/data/items/items.csv
@@ -34,19 +34,19 @@ Slightly sacred. "
 ,In Game,Black Poppy,1010,Material,,,,,,"You can’t tell whether it’s a very dark purple or actually black. A rare flower. "
 ,In Game,Daffodil,1011,Material,,,,,,"A reflection of fallen Narcissus… Has its own uses and applications. "
 ,In Game,Mint,1012,Material,,,,,,A herb with many applications. Not often found here….
-,To Deploy,Sanguine Shroom,1013,Material,,,,,,A mushroom that bruises and bleeds like flesh. Some individuals hold a colorful belief that they feed on decaying spirits.
-,To Deploy,Chalkberry,1014,Material,,,,,,A dry and extremely bitter berry coated with chalky white fungus. The berry itself is inedible; useless except as a medium for a unique wild yeast.
-,To Deploy,Empty Cup,1102,Material,,,,,,A small reusable cup crafted from stone. Useful for drinking potions or other beverages.
+,In Game,Sanguine Shroom,1013,Material,,,,,,A mushroom that bruises and bleeds like flesh. Some individuals hold a colorful belief that they feed on decaying spirits.
+,In Game,Chalkberry,1014,Material,,,,,,A dry and extremely bitter berry coated with chalky white fungus. The berry itself is inedible; useless except as a medium for a unique wild yeast.
+,In Game,Empty Cup,1102,Material,,,,,,A small reusable cup crafted from stone. Useful for drinking potions or other beverages.
 ,In Game,Microplastics,1103,Material,,,,,,"Fine translucent powder. A promising new substance in hexerei. "
 ,In Game,Pine Pollen,1104,Material,,,,,,"Some people think this is very good for you. "
-,To Deploy,Powdered Red Amber,1107,Material,,,,,,Fine powder made from crushing a red amber crystal. Can be used to sand and polish metals.
+,In Game,Powdered Red Amber,1107,Material,,,,,,Fine powder made from crushing a red amber crystal. Can be used to sand and polish metals.
 ,In Game,Black Poppy Extract,1110,Material,,,,,,Useful alkaloids in a sticky black goo. One of the most ancient ingredients.
 ,In Game,Essence of Daffodil,1111,Material,,,,,,"Poisonous to living things, but useful when making medicines and potions."
 ,In Game,Shredded Mint,1112,Material,,,,,,Makes a cooling and relaxing tea. Also used in various magical applications.
-,To Deploy,Sanguineous Powder,1113,Material,,,,,,"A dark, reddish powder that resembles dried blood, or maybe just coffee. Edible, but can also be used as an ink or dye."
-,To Deploy,Berry Chalk,1114,Material,,,,,,A chalky fungus scraped from a rare berry. Can ferment certain materials to produce a rejuvenating beverage.
-,To Deploy,Holy Syrup,1201,Material,,,,,,Holy Dust diluted into a quantity of water. Forms a thin syrup that can be measured out for crafting.
-,To Deploy,Resin Tincture,1202,Material,,,,,,"A sweet, spicy syrup made from the natural resin found in the trees of Kamigotchi World. Useful for a number of recipes."
+,In Game,Sanguineous Powder,1113,Material,,,,,,"A dark, reddish powder that resembles dried blood, or maybe just coffee. Edible, but can also be used as an ink or dye."
+,In Game,Berry Chalk,1114,Material,,,,,,A chalky fungus scraped from a rare berry. Can ferment certain materials to produce a rejuvenating beverage.
+,In Game,Holy Syrup,1201,Material,,,,,,Holy Dust diluted into a quantity of water. Forms a thin syrup that can be measured out for crafting.
+,In Game,Resin Tincture,1202,Material,,,,,,"A sweet, spicy syrup made from the natural resin found in the trees of Kamigotchi World. Useful for a number of recipes."
 ,In Game,Red Gakki Ribbon,11001,Revive,Kami,,,"STATE-RESTING,HP+10",,"Capable of raising a Kamigotchi from the dead. 
 
 These ribbons are greatly prized…. "
@@ -69,16 +69,16 @@ These ribbons are greatly prized…. "
 ,In Game,Gakki Cookie Sticks,11304,Food,Kami,,,HP+100,,Heavy duty rations by a Kami’s standards.. Restores 100 Health to a Kamigotchi.
 ,In Game,“Paeon's Field of Flowers” Spell Card,11305,Food,Kami,,NOT_TRADABLE,HP+100,,The card depicts a mortally wounded man lying in a field of flowers. Some flowers take root on his body and knit the wounds closed while others bloom from the spilled blood. Activating this Spell Card on a Kamigotchi will restore 100 Health.
 ,In Game,Resin,11311,Food,Kami,,,HP+35,,"Sticky, with a refreshing taste. Could be used to make Amber or in other forms of crafting…"
-,In Game,XP Potion,11401,Food,Kami,,,"ITEM1003,XP+1000",,Give to a Kami to increase their XP by 1000.
-,In Game,Greater XP Potion,11402,Food,Kami,,,"ITEM1006,XP+15000",,Give to a Kami to increase their XP by 15000.
-,In Game,Respec Potion,11403,Misc,Kami,,,ITEM1003,,"Give to a Kami to reset their skill points. "
-,In Game,Grace Potion,11404,Food,Kami,,,"STRAIN-25%,ITEM1003",,"Give to a Kami to decrease loss of health during the next Harvest by 25%. "
-,In Game,Bless Potion,11405,Food,Kami,,,"BOUNTY+25%,ITEM1003",,Give to a Kami to increase the MUSU gained from the next Harvest by 25%.
-,To Deploy,Apology Letter,11406,Food,Kami,,,ARB-50%,,A letter written by a Kami with sincere remorse for its actions. Lowers Recoil when liquidating other Kami.
-,To Deploy,MUSU Magnet,11407,Food,Kami,,,DSR+50%,,This shiny purple rock attracts grains of $MUSU. It dramatically increases the proportion of $MUSU a kami retains when it’s liquidated.
-,To Deploy,Festival Chime,11408,Food,Kami,,,HIB+25,,"Magical bells that gradually increase Harvest Intensity over the next long-term harvest. Your Kami will ring this chime until it breaks. "
-,To Deploy,Energy Drink,11409,Food,Kami,,,COOLDOWN-30s,,A lightly fermented beverage that grants a burst of spiritual energy. Dramatically reduces Cooldown Shift for a kami’s next action.
-,To Deploy,Hostility Potion,11410,Food,Kami,,,"ATS+3%,ITEM1120",,"Most Kamigotchi find this bitter potion unpleasant, but some thrive on it. Expands a Kami’s Attack Threshold Shift by a small percentage."
+,To Update,XP Potion,11401,Food,Kami,,BYPASS_BONUS_RESET,"ITEM1003,XP+1000",,Give to a Kami to increase their XP by 1000.
+,To Update,Greater XP Potion,11402,Food,Kami,,BYPASS_BONUS_RESET,"ITEM1006,XP+15000",,Give to a Kami to increase their XP by 15000.
+,To Update,Respec Potion,11403,Misc,Kami,,BYPASS_BONUS_RESET,ITEM1003,,"Give to a Kami to reset their skill points. "
+,To Update,Grace Potion,11404,Food,Kami,,BYPASS_BONUS_RESET,"STRAIN-25%,ITEM1003",,"Give to a Kami to decrease loss of health during the next Harvest by 25%. "
+,To Update,Bless Potion,11405,Food,Kami,,BYPASS_BONUS_RESET,"BOUNTY+25%,ITEM1003",,Give to a Kami to increase the MUSU gained from the next Harvest by 25%.
+,To Update,Apology Letter,11406,Food,Kami,,BYPASS_BONUS_RESET,ARB-50%,,A letter written by a Kami with sincere remorse for its actions. Lowers Recoil when liquidating other Kami.
+,To Update,MUSU Magnet,11407,Food,Kami,,BYPASS_BONUS_RESET,DSR+50%,,This shiny purple rock attracts grains of $MUSU. It dramatically increases the proportion of $MUSU a kami retains when it’s liquidated.
+,To Update,Festival Chime,11408,Food,Kami,,BYPASS_BONUS_RESET,HIB+25,,"Magical bells that gradually increase Harvest Intensity over the next long-term harvest. Your Kami will ring this chime until it breaks. "
+,To Update,Energy Drink,11409,Food,Kami,,BYPASS_BONUS_RESET,COOLDOWN-30s,,A lightly fermented beverage that grants a burst of spiritual energy. Dramatically reduces Cooldown Shift for a kami’s next action.
+,To Update,Hostility Potion,11410,Food,Kami,,BYPASS_BONUS_RESET,"ATS+3%,ITEM1120",,"Most Kamigotchi find this bitter potion unpleasant, but some thrive on it. Expands a Kami’s Attack Threshold Shift by a small percentage."
 ,In Game,Giftbox,21001,Lootbox,Account,,,DT1,,"The lowest tier of giftbox. You can get XP candies, cheeseburgers, and even a few rare item drops from this! "
 ,In Game,Kamigotchi World Citizen Giftbox,21002,Lootbox,Account,,,DT2,,"A gold-trimmed and colorfully painted treasure chest. The gift inside must be particularly valuable. "
 ,In Game,Scroll of Shop Teleportation,21100,Consumable,Account,,,MOVE13,,"Instantly transports the user to Mina’s Shop. Fully insured. "

--- a/packages/contracts/src/libraries/LibAllo.sol
+++ b/packages/contracts/src/libraries/LibAllo.sol
@@ -23,6 +23,8 @@ import { Stat, LibStat } from "libraries/LibStat.sol";
 /**
  * @notice
  * Allos are shapes that indicate some sort of a one time distribution of other shapes
+ * note: Allos are strictly no takebacksies - ensure reverse mapping is not required post distribution
+ *    (entities created must be able to be deleted by other systems (e.g. temp bonuses) or is a balance (e.g. inventory))
  * - similar to Conditionals in that it matches a DescribedEntity (type + index)
  * - Can give
  *   - bonuses (unimplemented)
@@ -218,7 +220,7 @@ library LibAllo {
     uint256 mult,
     uint256 targetID
   ) internal {
-    LibBonus.incByTemporary(components, alloID, targetID, mult);
+    LibBonus.assignTemporary(components, alloID, targetID);
   }
 
   /// @notice distributes droptable rewards by creating a commit

--- a/packages/contracts/src/systems/KamiUseItemSystem.sol
+++ b/packages/contracts/src/systems/KamiUseItemSystem.sol
@@ -30,10 +30,9 @@ contract KamiUseItemSystem is System {
     LibItem.verifyRequirements(components, itemIndex, "USE", kamiID);
 
     // reset action bonuses
-    // if (!LibItem.bypassBonusReset(components, itemIndex)) // enables bonus stacking
-    LibBonus.resetUponHarvestAction(components, kamiID);
-    LibBonus.resetUponDeath(components, kamiID);
-    LibBonus.resetUponLiquidation(components, kamiID);
+    if (!LibItem.bypassBonusReset(components, itemIndex)) {
+      LibBonus.resetUponHarvestAction(components, kamiID);
+    }
 
     // use item
     LibKami.sync(components, kamiID);

--- a/packages/contracts/test/systems/Items/ItemKami.t.sol
+++ b/packages/contracts/test/systems/Items/ItemKami.t.sol
@@ -10,4 +10,72 @@ contract ItemKamiTest is ItemTemplate {
   // 3. test room constraints
   // 4. test cooldown
   // 5. test effects - basic, more detailed testing in allo
+
+  function testItemKamiBonus() public {
+    uint32 itemA = 111;
+    uint32 itemB = 112;
+    uint32 itemC = 113;
+    _createConsumable(itemA, "KAMI");
+    _createConsumable(itemB, "KAMI");
+    _createConsumable(itemC, "KAMI");
+    vm.startPrank(deployer);
+    __ItemRegistrySystem.addAlloBonus(
+      abi.encode(itemA, "USE", "BONUS_1", "UPON_HARVEST_ACTION", 0, 3)
+    );
+    __ItemRegistrySystem.addAlloBonus(
+      abi.encode(itemB, "USE", "BONUS_1", "UPON_HARVEST_ACTION", 0, 5)
+    );
+    __ItemRegistrySystem.addAlloBonus(
+      abi.encode(itemC, "USE", "BONUS_2", "UPON_HARVEST_ACTION", 0, 7)
+    );
+    __ItemRegistrySystem.addFlag(itemA, "BYPASS_BONUS_RESET");
+    __ItemRegistrySystem.addFlag(itemB, "BYPASS_BONUS_RESET");
+    __ItemRegistrySystem.addFlag(itemC, "BYPASS_BONUS_RESET");
+    vm.stopPrank();
+
+    // alice setup
+    uint256 kamiID = _mintKami(alice);
+    _giveItem(alice, itemA, 10);
+    _giveItem(alice, itemB, 10);
+    _giveItem(alice, itemC, 10);
+
+    // use itemA
+    vm.prank(alice.operator);
+    _KamiUseItemSystem.executeTyped(kamiID, itemA);
+    assertEq(LibBonus.getFor(components, "BONUS_1", kamiID), 3);
+    assertEq(LibBonus.getFor(components, "BONUS_2", kamiID), 0);
+
+    // use itemA again, should not stack
+    vm.prank(alice.operator);
+    _KamiUseItemSystem.executeTyped(kamiID, itemA);
+    assertEq(LibBonus.getFor(components, "BONUS_1", kamiID), 3);
+    assertEq(LibBonus.getFor(components, "BONUS_2", kamiID), 0);
+
+    // use itemB, should stack
+    vm.prank(alice.operator);
+    _KamiUseItemSystem.executeTyped(kamiID, itemB);
+    assertEq(LibBonus.getFor(components, "BONUS_1", kamiID), 8);
+    assertEq(LibBonus.getFor(components, "BONUS_2", kamiID), 0);
+
+    // use itemC, should increase BONUS_2
+    vm.prank(alice.operator);
+    _KamiUseItemSystem.executeTyped(kamiID, itemC);
+    assertEq(LibBonus.getFor(components, "BONUS_1", kamiID), 8);
+    assertEq(LibBonus.getFor(components, "BONUS_2", kamiID), 7);
+
+    // use itemA again, should not stack
+    vm.prank(alice.operator);
+    _KamiUseItemSystem.executeTyped(kamiID, itemA);
+    assertEq(LibBonus.getFor(components, "BONUS_1", kamiID), 8);
+    assertEq(LibBonus.getFor(components, "BONUS_2", kamiID), 7);
+
+    // feeding food, will reset bonuses
+    uint32 foodIndex = 114;
+    _createFood(foodIndex, "name", "description", 0, 0, "media");
+    _giveItem(alice, foodIndex, 10);
+    vm.prank(alice.operator);
+    _KamiUseItemSystem.executeTyped(kamiID, foodIndex);
+    assertEq(LibBonus.getFor(components, "BONUS_1", alice.id), 0);
+    assertEq(LibBonus.getFor(components, "BONUS_2", alice.id), 0);
+  }
 }


### PR DESCRIPTION
Stackable bonuses! This one needed a surgery to adjust the shapes.

## Design choices
- Removing multipliers for *all* temporary bonuses
  - permanent bonuses (skills) multiply off a base value
  - Anti-vertical stacking means temporary bonuses will always be stuck at level 1
  - Potential future timed bonus will individual instances for each end time, each at level 1
- Some stricter type enforcement to prevent temp bonuses ever being assigned as a perm
- This makes TempBonuses relatively restrictive. Likely we will only use this with `LibAllo` for assignment; stuff like skills or (future) equipment have more flexibility with PermBonuses

## To Deploy
- `KamiUseItemSystem`
- update items to include `BYPASS_BONUS_RESET` flag
- all systems that use `LibAllo` - only `items` use bonus allos for now, but good to keep the other systems up to date

