### PR TITLE
Allo sourceIDs

### DIFF
--- a/packages/contracts/deployment/world/data/items/items.csv
+++ b/packages/contracts/deployment/world/data/items/items.csv
@@ -47,28 +47,28 @@ Slightly sacred. "
 ,In Game,Berry Chalk,1114,Material,,,,,,A chalky fungus scraped from a rare berry. Can ferment certain materials to produce a rejuvenating beverage.
 ,In Game,Holy Syrup,1201,Material,,,,,,Holy Dust diluted into a quantity of water. Forms a thin syrup that can be measured out for crafting.
 ,In Game,Resin Tincture,1202,Material,,,,,,"A sweet, spicy syrup made from the natural resin found in the trees of Kamigotchi World. Useful for a number of recipes."
-,In Game,Red Gakki Ribbon,11001,Revive,Kami,,,"STATE-RESTING,HP+10",,"Capable of raising a Kamigotchi from the dead. 
+,To Update,Red Gakki Ribbon,11001,Revive,Kami,,,"STATE-RESTING,HP+10",,"Capable of raising a Kamigotchi from the dead. 
 
 These ribbons are greatly prized…. "
-,In Game,“Melkarth’s Heroic Awakening” Spell Card,11002,Revive,Kami,,NOT_TRADABLE,"STATE-RESTING,HP+50",,The card depicts the figure of an ancient god silhouetted by a wreath of energy that obscures the details of his face and attire. Melkarth grants a blessing of rebirth to fallen warriors. Activating this Spell Card will revive a Kamigotchi that has been incapacitated.
-,In Game,Holy Dust,11011,Misc,Kami,,,,,This sacred dust can be used to rename Kamigotchi… At the proper place.
-,In Game,Gaokerena Mochi,11110,Food,Kami,,,HEALTH+10,,"A glossy purple mochi. It's filled with a green and fibrous root paste confection made with milk. Permanently adds +10 to a Kamigotchi’s Health. "
-,In Game,Sunset Apple Mochi,11120,Food,Kami,,,POWER+1,,"A deep red and orange mochi. It's filled with a golden apple jam that has a warm, heavenly flavor. Permanently adds +1 to a Kamigotchi’s Power."
-,In Game,Kami Mochi,11130,Food,Kami,,,VIOLENCE+1,,"A deep blue mochi with a butterfly stamp. It's filled with soft, white curds that resemble a fresh cheese. Permanently adds +1 to a Kamigotchi’s Violence. "
-,In Game,Mana Mochi,11140,Food,Kami,,,HARMONY+1,,A sky blue mochi. It's filled with small white grains that burst with a honey-sweet flavor. Permanently adds +1 to a Kamigotchi’s Harmony.
-,In Game,XP Candy (Small),11201,Food,Kami,,NOT_TRADABLE,"HP+5,XP+25",,"Feed this to a Kamigotchi to give them a little bit of experience. "
-,In Game,XP Candy (Medium),11202,Food,Kami,,NOT_TRADABLE,"XP+100,HP+10",,"Provides a decent amount of XP when fed to a Kami. "
-,In Game,XP Candy (Large),11203,Food,Kami,,NOT_TRADABLE,"HP+20,XP+200",,"This gives a lot of XP when fed to a Kamigotchi. "
-,In Game,XP Candy (Huge),11204,Food,Kami,,NOT_TRADABLE,"HP+50,XP+1000",,This is far larger than any XP Candy you’ve seen before. Gives a huge amount of XP when fed to a Kamigotchi.
-,In Game,“Cultivation I” Spell Card,11211,Food,Kami,,NOT_TRADABLE,"XP+100,HP+20",,"The card depicts a pale sprout emerging from rich, black soil. Activating this Spell Card on a Kamigotchi will restore 20 HP and grant 100 XP."
-,In Game,“Cultivation II” Spell Card,11212,Food,Kami,,NOT_TRADABLE,"XP+200,HP+50",,The card depicts a teardrop-shaped flowerbud growing out of light brown soil. Activating this Spell Card on a Kamigotchi will restore 50 HP and grant 200 XP.
-,In Game,“Cultivation III” Spell Card,11213,Food,Kami,,NOT_TRADABLE,"XP+1000,HP+100",,The card depicts a flower heartily blooming in pale and sandy earth. Activating this Spell Card on a Kamigotchi will restore 100 HP and grant 1000 XP.
-,In Game,Maple-Flavor Ghost Gum,11301,Food,Kami,,,HP+25,,"The most basic form of food available in this world - restores 25 Health to a Kamigotchi. "
-,In Game,Cheeseburger,11302,Food,Kami,,,HP+50,,"These burgers, still in their original wrapping, are occasionally found in the scrapyard. Apparently Kamigotchi love them. "
-,In Game,Pom-Pom Fruit Candy,11303,Food,Kami,,,HP+50,,These fruit candies contain a huge amount of energy. Restores 50 Health to a Kamigotchi.
-,In Game,Gakki Cookie Sticks,11304,Food,Kami,,,HP+100,,Heavy duty rations by a Kami’s standards.. Restores 100 Health to a Kamigotchi.
-,In Game,“Paeon's Field of Flowers” Spell Card,11305,Food,Kami,,NOT_TRADABLE,HP+100,,The card depicts a mortally wounded man lying in a field of flowers. Some flowers take root on his body and knit the wounds closed while others bloom from the spilled blood. Activating this Spell Card on a Kamigotchi will restore 100 Health.
-,In Game,Resin,11311,Food,Kami,,,HP+35,,"Sticky, with a refreshing taste. Could be used to make Amber or in other forms of crafting…"
+,To Update,“Melkarth’s Heroic Awakening” Spell Card,11002,Revive,Kami,,NOT_TRADABLE,"STATE-RESTING,HP+50",,The card depicts the figure of an ancient god silhouetted by a wreath of energy that obscures the details of his face and attire. Melkarth grants a blessing of rebirth to fallen warriors. Activating this Spell Card will revive a Kamigotchi that has been incapacitated.
+,To Update,Holy Dust,11011,Misc,Kami,,,,,This sacred dust can be used to rename Kamigotchi… At the proper place.
+,To Update,Gaokerena Mochi,11110,Food,Kami,,,HEALTH+10,,"A glossy purple mochi. It's filled with a green and fibrous root paste confection made with milk. Permanently adds +10 to a Kamigotchi’s Health. "
+,To Update,Sunset Apple Mochi,11120,Food,Kami,,,POWER+1,,"A deep red and orange mochi. It's filled with a golden apple jam that has a warm, heavenly flavor. Permanently adds +1 to a Kamigotchi’s Power."
+,To Update,Kami Mochi,11130,Food,Kami,,,VIOLENCE+1,,"A deep blue mochi with a butterfly stamp. It's filled with soft, white curds that resemble a fresh cheese. Permanently adds +1 to a Kamigotchi’s Violence. "
+,To Update,Mana Mochi,11140,Food,Kami,,,HARMONY+1,,A sky blue mochi. It's filled with small white grains that burst with a honey-sweet flavor. Permanently adds +1 to a Kamigotchi’s Harmony.
+,To Update,XP Candy (Small),11201,Food,Kami,,NOT_TRADABLE,"HP+5,XP+25",,"Feed this to a Kamigotchi to give them a little bit of experience. "
+,To Update,XP Candy (Medium),11202,Food,Kami,,NOT_TRADABLE,"XP+100,HP+10",,"Provides a decent amount of XP when fed to a Kami. "
+,To Update,XP Candy (Large),11203,Food,Kami,,NOT_TRADABLE,"HP+20,XP+200",,"This gives a lot of XP when fed to a Kamigotchi. "
+,To Update,XP Candy (Huge),11204,Food,Kami,,NOT_TRADABLE,"HP+50,XP+1000",,This is far larger than any XP Candy you’ve seen before. Gives a huge amount of XP when fed to a Kamigotchi.
+,To Update,“Cultivation I” Spell Card,11211,Food,Kami,,NOT_TRADABLE,"XP+100,HP+20",,"The card depicts a pale sprout emerging from rich, black soil. Activating this Spell Card on a Kamigotchi will restore 20 HP and grant 100 XP."
+,To Update,“Cultivation II” Spell Card,11212,Food,Kami,,NOT_TRADABLE,"XP+200,HP+50",,The card depicts a teardrop-shaped flowerbud growing out of light brown soil. Activating this Spell Card on a Kamigotchi will restore 50 HP and grant 200 XP.
+,To Update,“Cultivation III” Spell Card,11213,Food,Kami,,NOT_TRADABLE,"XP+1000,HP+100",,The card depicts a flower heartily blooming in pale and sandy earth. Activating this Spell Card on a Kamigotchi will restore 100 HP and grant 1000 XP.
+,To Update,Maple-Flavor Ghost Gum,11301,Food,Kami,,,HP+25,,"The most basic form of food available in this world - restores 25 Health to a Kamigotchi. "
+,To Update,Cheeseburger,11302,Food,Kami,,,HP+50,,"These burgers, still in their original wrapping, are occasionally found in the scrapyard. Apparently Kamigotchi love them. "
+,To Update,Pom-Pom Fruit Candy,11303,Food,Kami,,,HP+50,,These fruit candies contain a huge amount of energy. Restores 50 Health to a Kamigotchi.
+,To Update,Gakki Cookie Sticks,11304,Food,Kami,,,HP+100,,Heavy duty rations by a Kami’s standards.. Restores 100 Health to a Kamigotchi.
+,To Update,“Paeon's Field of Flowers” Spell Card,11305,Food,Kami,,NOT_TRADABLE,HP+100,,The card depicts a mortally wounded man lying in a field of flowers. Some flowers take root on his body and knit the wounds closed while others bloom from the spilled blood. Activating this Spell Card on a Kamigotchi will restore 100 Health.
+,To Update,Resin,11311,Food,Kami,,,HP+35,,"Sticky, with a refreshing taste. Could be used to make Amber or in other forms of crafting…"
 ,To Update,XP Potion,11401,Food,Kami,,BYPASS_BONUS_RESET,"ITEM1003,XP+1000",,Give to a Kami to increase their XP by 1000.
 ,To Update,Greater XP Potion,11402,Food,Kami,,BYPASS_BONUS_RESET,"ITEM1006,XP+15000",,Give to a Kami to increase their XP by 15000.
 ,To Update,Respec Potion,11403,Misc,Kami,,BYPASS_BONUS_RESET,ITEM1003,,"Give to a Kami to reset their skill points. "
@@ -79,13 +79,13 @@ These ribbons are greatly prized…. "
 ,To Update,Festival Chime,11408,Food,Kami,,BYPASS_BONUS_RESET,HIB+25,,"Magical bells that gradually increase Harvest Intensity over the next long-term harvest. Your Kami will ring this chime until it breaks. "
 ,To Update,Energy Drink,11409,Food,Kami,,BYPASS_BONUS_RESET,COOLDOWN-30s,,A lightly fermented beverage that grants a burst of spiritual energy. Dramatically reduces Cooldown Shift for a kami’s next action.
 ,To Update,Hostility Potion,11410,Food,Kami,,BYPASS_BONUS_RESET,"ATS+3%,ITEM1120",,"Most Kamigotchi find this bitter potion unpleasant, but some thrive on it. Expands a Kami’s Attack Threshold Shift by a small percentage."
-,In Game,Giftbox,21001,Lootbox,Account,,,DT1,,"The lowest tier of giftbox. You can get XP candies, cheeseburgers, and even a few rare item drops from this! "
-,In Game,Kamigotchi World Citizen Giftbox,21002,Lootbox,Account,,,DT2,,"A gold-trimmed and colorfully painted treasure chest. The gift inside must be particularly valuable. "
-,In Game,Scroll of Shop Teleportation,21100,Consumable,Account,,,MOVE13,,"Instantly transports the user to Mina’s Shop. Fully insured. "
-,In Game,Ice Cream,21201,Food,Account,,,SP+20,,"Restorative ice-cream. Food for you, personally. Restores a little bit of your stamina."
-,In Game,Better Ice Cream,21202,Food,Account,,,SP+40,,"A slightly larger and higher-quality ice-cream. What is this made of? Restores a medium amount of stamina. "
-,In Game,Best Ice Cream,21203,Food,Account,,,SP+80,,"A huge, lavishly decorated ice-cream. It doesn’t seem to be melting at all… Restores a lot of stamina. "
-,In Game,“Neith’s River of Life” Spell Card,21204,Food,Account,,NOT_TRADABLE,SP+80,,"The card depicts a flooding river beneath the night sky. The magical waters grant a bounty of stamina, and the reeds grow nearly as tall as the pyramids. Activating this Spell Card on an Operator will restore 80 Stamina."
+,To Update,Giftbox,21001,Lootbox,Account,,,DT1,,"The lowest tier of giftbox. You can get XP candies, cheeseburgers, and even a few rare item drops from this! "
+,To Update,Kamigotchi World Citizen Giftbox,21002,Lootbox,Account,,,DT2,,"A gold-trimmed and colorfully painted treasure chest. The gift inside must be particularly valuable. "
+,To Update,Scroll of Shop Teleportation,21100,Consumable,Account,,,MOVE13,,"Instantly transports the user to Mina’s Shop. Fully insured. "
+,To Update,Ice Cream,21201,Food,Account,,,SP+20,,"Restorative ice-cream. Food for you, personally. Restores a little bit of your stamina."
+,To Update,Better Ice Cream,21202,Food,Account,,,SP+40,,"A slightly larger and higher-quality ice-cream. What is this made of? Restores a medium amount of stamina. "
+,To Update,Best Ice Cream,21203,Food,Account,,,SP+80,,"A huge, lavishly decorated ice-cream. It doesn’t seem to be melting at all… Restores a lot of stamina. "
+,To Update,“Neith’s River of Life” Spell Card,21204,Food,Account,,NOT_TRADABLE,SP+80,,"The card depicts a flooding river beneath the night sky. The magical waters grant a bounty of stamina, and the reeds grow nearly as tall as the pyramids. Activating this Spell Card on an Operator will restore 80 Stamina."
 ,In Game,Spice Grinder,23100,Tool,,,,,,Can be used to break down ingredients.
 ,In Game,Portable Burner,23101,Tool,,,,,,"Can be used to make Potions at a riverside. "
 ,In Game,Screwdriver,23102,Tool,,,,,,For driving screws. May be of practical use….

--- a/packages/contracts/deployment/world/data/quests/quests.csv
+++ b/packages/contracts/deployment/world/data/quests/quests.csv
@@ -1,143 +1,143 @@
 ﻿Key,Index,Status,Title,Daily,Description,Requirements,Objectives,Rewards
-MSQ001,1,In Game,Welcome to Kamigotchi World,No,"Hi there, Player! Welcome to Kamigotchi World! You can call me Menu. I’ll always be here to give you tips, track your items, quests, and companions, and I even have a map of the area! You can navigate by clicking on the map to pilot your Operator.
+MSQ001,1,To Update,Welcome to Kamigotchi World,No,"Hi there, Player! Welcome to Kamigotchi World! You can call me Menu. I’ll always be here to give you tips, track your items, quests, and companions, and I even have a map of the area! You can navigate by clicking on the map to pilot your Operator.
 
 Start by exploring my options and clicking around the screen. When you’ve seen the basics, we can move on - just complete this quest. ",,,2x Agency Reputation
-MSQ002,2,In Game,Beginning Your Journey,No,"Feel like you’re getting the hang of my interface? Great! Now that you’re oriented, you can start exploring your surroundings. You move around by using the Map Menu at the top left of your screen. Navigate over to the scrapyard and check it out.
+MSQ002,2,To Update,Beginning Your Journey,No,"Feel like you’re getting the hang of my interface? Great! Now that you’re oriented, you can start exploring your surroundings. You move around by using the Map Menu at the top left of your screen. Navigate over to the scrapyard and check it out.
 
 Explore the world a little, then check back in with me. I’ll give you a Spell Card. These work even if you don’t believe in magic. Using this card will restore your Stamina so you can move around more! ",Complete MSQ001,Move 3 Times,"1x ""Neith’s River of Life"" Spell Card"
-MSQ003,3,In Game,Your First Kami,No,"Now you’re oriented and on your feet. Ready to find out why this place is the Kamigotchi World? I bet! Now all you need to do is make friends with a Kami yourself!
+MSQ003,3,To Update,Your First Kami,No,"Now you’re oriented and on your feet. Ready to find out why this place is the Kamigotchi World? I bet! Now all you need to do is make friends with a Kami yourself!
 
 Have you seen the Vending Machine out in the junkyard? Believe it or not, we’ve got it powered on, fully stocked, and plugged in… but not to an electrical outlet! I’ll explain more later, but for now, just get yourself a Kami.",Complete MSQ002,Own 1 Kamigotchi,6x Agency Reputation
-MSQ004,4,In Game,What Kami Do: Harvesting,No,"Kamigotchi remain at rest when being held, but when you let them out to run around, they really get busy!
+MSQ004,4,To Update,What Kami Do: Harvesting,No,"Kamigotchi remain at rest when being held, but when you let them out to run around, they really get busy!
 
 We call it “Harvesting”, but they harvest passively, not through labor. When a Kami is placed down in the world, they draw a kind of energy out of the environment and into themselves. We call this energy $MUSU. I’ll explain it in more detail later.
 
 You can wander to other Rooms while your Kami are Harvesting, but don’t forget where you left them! Tired Kami are vulnerable to predators. 
 
 When you’re done, I’ll give you an XP Candy - you can use this to help level up your Kamigotchi! ",Complete MSQ003,Harvest for >5 minutes,1x XP Candy (Small)
-MSQ005,5,In Game,What Kami Do: Scavenging,No,"$MUSU isn’t the only thing the Kamigotchi collect. Over time, the Harvesting action generates a force that draws objects and items to the Kami, like a kind of gravity that only seems to affect specific things.
+MSQ005,5,To Update,What Kami Do: Scavenging,No,"$MUSU isn’t the only thing the Kamigotchi collect. Over time, the Harvesting action generates a force that draws objects and items to the Kami, like a kind of gravity that only seems to affect specific things.
 
 Which things? It’s not clear. The selection changes based on your Kami’s location. Some are simply fallen sticks and old stones, but other items are more interesting. We call this action “Scavenging”.
 
 Try this out for yourself. See what kind of present the Kami brings you!",Complete MSQ004,Scavenge 1 Item,4x Agency Reputation
-MSQ006,6,In Game,What Kami Do: Liquidating,No,"If your Kami isn’t really enjoying Harvesting, it may not be built for such a relaxed existence. A Kami with a high Violence may find it lucrative to conflict with its peers. 
+MSQ006,6,To Update,What Kami Do: Liquidating,No,"If your Kami isn’t really enjoying Harvesting, it may not be built for such a relaxed existence. A Kami with a high Violence may find it lucrative to conflict with its peers. 
 
 Predatory Kami may use their violent nature to Liquidate other Kami and gain large amounts of $MUSU in the process. This may be antisocial, but there’s no harm done. Just like a Kami isn’t really hurt when it’s low on Health, a Kami isn’t really dead when it’s Liquidated. It may not be able to hold its body in shape, but it can always come back!",Complete MSQ005,Liquidate another Kamigotchi,4x Agency Reputation
-MSQ007,7,In Game,Making $MUSU,No,"$MUSU is a form of energy that exists everywhere in the universe. This Kamigotchi World has a particularly high concentration. $MUSU is what keeps everything here tied together like the knots in a big rope net. 
+MSQ007,7,To Update,Making $MUSU,No,"$MUSU is a form of energy that exists everywhere in the universe. This Kamigotchi World has a particularly high concentration. $MUSU is what keeps everything here tied together like the knots in a big rope net. 
 
 Collect a moderate amount of $MUSU, then I’ll explain more.",Complete MSQ004,Collect 500 $MUSU,"4x Agency Reputation,1x “Cultivation I” Spell Card"
-MSQ008,8,In Game,Supporting Local Businesses,No,"In this world and the places that surround it, $MUSU is also a kind of currency. If you need a specific item, someone might sell just what you need, for the right price. You might even get the itch to start trading goods yourself!
+MSQ008,8,To Update,Supporting Local Businesses,No,"In this world and the places that surround it, $MUSU is also a kind of currency. If you need a specific item, someone might sell just what you need, for the right price. You might even get the itch to start trading goods yourself!
 
 Go spend some $MUSU just to get the hang of it. If you need directions, there’s a shop through the door a little north of the vending machine. I’ve heard it trades some interesting things! When you’re done shopping, I’ll give you something extra. It’s on the house. ",Complete MSQ007,Buy something from any vendor using $MUSU,2x Agency Reputation
-MSQ009,9,In Game,Building a Reputation,No,"You can gain a number of different rewards by completing Quests, from new items to new game mechanics. One type of quest reward might not seem useful immediately, but over time it will really pay off! I’m talking about Reputation. That number represents your status in the eyes of another: Me.
+MSQ009,9,To Update,Building a Reputation,No,"You can gain a number of different rewards by completing Quests, from new items to new game mechanics. One type of quest reward might not seem useful immediately, but over time it will really pay off! I’m talking about Reputation. That number represents your status in the eyes of another: Me.
 
 As the Menu, I’m the interface that you the Player uses to pilot your Operator around the Kamigotchi World. Straightforward, right? I’m as friendly as it gets, so raising your Reputation with me is easy. Usually I’ll always give between 2 to 6 Reputation for completing quests, but sometimes if it’s super difficult or I think it’s important, I’ll give out more.
 
 For example: I want to build new circuitry. If you give me the raw materials, I can fabricate it for myself. Please give me some Scrap Metal. I’d really appreciate it!",Complete MSQ008,Give 3 Scrap Metal,"6x Agency Reputation,1x “Paeon’s Field of Flowers” Spell Card"
-MSQ010,10,In Game,Kamigotchi World and You: Having a Normal One,No,"Almost every area in the Kamigotchi World has a Type just like your Kami. The “Normal” type is self-explanatory. Something with the Normal Type represents the essence of this world in its purest form. 
+MSQ010,10,To Update,Kamigotchi World and You: Having a Normal One,No,"Almost every area in the Kamigotchi World has a Type just like your Kami. The “Normal” type is self-explanatory. Something with the Normal Type represents the essence of this world in its purest form. 
 
 Scavenge three items in rooms with the Normal Type. When you’re done, I’ll give you a Spell Card to restore lost Stamina to your Operator.",Complete MSQ009,Make a Scavenging roll in 3 rooms of the Normal type,"4x Agency Reputation,1x ""Neith’s River of Life"" Spell Card"
-MSQ011,11,In Game,Kamigotchi World and You: That Eerie Feeling,No,"A Kami or Room with the “Eerie” type comes into being when the natural state of things gets changed by something supernatural. Like when humans have a bad day from a horrible nightmare, or witness a miracle, or celebrate an old holiday!
+MSQ011,11,To Update,Kamigotchi World and You: That Eerie Feeling,No,"A Kami or Room with the “Eerie” type comes into being when the natural state of things gets changed by something supernatural. Like when humans have a bad day from a horrible nightmare, or witness a miracle, or celebrate an old holiday!
 
 To understand more about this, scavenge three items in rooms with the Eerie type.",Complete MSQ010,Make a Scavenging roll in 3 rooms of the Eerie type,4x Agency Reputation
-MSQ012,12,In Game,Kamigotchi World and You: Insects in the Miasma,No,"The Insect type might make your skin crawl. It’s not always about seeing the bugs, you know? An Insect-Type Room is the kind of place that makes you feel defiled. But not always because of actual filth, either. It’s more of a vibe. 
+MSQ012,12,To Update,Kamigotchi World and You: Insects in the Miasma,No,"The Insect type might make your skin crawl. It’s not always about seeing the bugs, you know? An Insect-Type Room is the kind of place that makes you feel defiled. But not always because of actual filth, either. It’s more of a vibe. 
 
 If you want to really feel what I mean, scavenge three items in rooms with the Insect type.",Complete MSQ011,Make a Scavenging roll in 3 rooms of the Insect type,4x Agency Reputation
-MSQ013,13,In Game,Kamigotchi World and You: Tossed in the Scrap Heap,No,"Like they say, one person’s trash is another person’s treasure! I shouldn’t call it trash, though. A Scrap Type isn’t defined as waste material that has been discarded, but as a small part of a greater whole.
+MSQ013,13,To Update,Kamigotchi World and You: Tossed in the Scrap Heap,No,"Like they say, one person’s trash is another person’s treasure! I shouldn’t call it trash, though. A Scrap Type isn’t defined as waste material that has been discarded, but as a small part of a greater whole.
 
 People have the power to make tangible change by expressing their will, creating attachments with desire, leaving behind memories, and more. The remnants of those material attachments can end up as Scrap.
 
 Scavenge three items in rooms with the Scrap type and see what you find.",Complete MSQ012,Make a Scavenging roll in 3 rooms of the Scrap type,"4x Agency Reputation,1x ""Neith’s River of Life"" Spell Card"
-MSQ014,14,In Game,Identifying Materials: Wood,No,"Everything in the Kamigotchi World has a story, even the rocks and trees. You might have picked up some Wooden Sticks while Harvesting. There are trees all over, that’s nothing special, right?
+MSQ014,14,To Update,Identifying Materials: Wood,No,"Everything in the Kamigotchi World has a story, even the rocks and trees. You might have picked up some Wooden Sticks while Harvesting. There are trees all over, that’s nothing special, right?
 
 Well, here’s a rumor: Those trees are all branches of one huge tree, connected by the roots! That’s why all the Wooden Sticks you’ll find are pretty much the same, no matter where you pick them up.
 
 I’d like to analyze the wood’s structure in detail. Collect 5 Wooden Sticks for me, and I’ll give you a reward. ",Complete MSQ013,Give 5 Wooden Sticks,4x Agency Reputation
-MSQ015,15,In Game,Identifying Materials: Stone,No,"Nothing more basic than a rock, right? Well, sometimes a rock isn’t just a rock. Sometimes it really “rocks”!
+MSQ015,15,To Update,Identifying Materials: Stone,No,"Nothing more basic than a rock, right? Well, sometimes a rock isn’t just a rock. Sometimes it really “rocks”!
 
 …I’m sorry. What I mean is: The structure of these rocks doesn’t always make geological sense. It’s natural for them to look a little different, because the Kamigotchi World doesn’t follow the same rules as the physical world. But some of these rocks look more like pieces of bone!
 
 I don’t know what it means, but I’d like to take a closer look. Collect 5 Rocks for me, and I’ll give you a reward. ",Complete MSQ014,Give 5 Stone,4x Agency Reputation
-MSQ016,16,In Game,Identifying Materials: Metal,No,"I need to expand my capabilities, so I’d like to build myself some new processors.
+MSQ016,16,To Update,Identifying Materials: Metal,No,"I need to expand my capabilities, so I’d like to build myself some new processors.
 
 The Scrap Metal you can find lying around might look like a bunch of tin cans, but don’t be fooled by appearances: Those cans can be made of all kinds of metal. Tin, steel, lithium, silicon, orichalcum. Could be anything.
 
 Get me 5 pieces of Scrap Metal please. Hopefully I luck out and get what I need!",Complete MSQ015,Give 5 Scrap Metal,4x Agency Reputation
-MSQ017,17,In Game,Exploring Other Options,No,"Thank you for the help with that upgrade. I’ve gotten access to more information. Checking databases against each other has led me to discover this world is bigger than it seems! I know we’ll get into the labs one day, but there are even more sealed-off places to find here. Once I know where they are, I can help open them up.
+MSQ017,17,To Update,Exploring Other Options,No,"Thank you for the help with that upgrade. I’ve gotten access to more information. Checking databases against each other has led me to discover this world is bigger than it seems! I know we’ll get into the labs one day, but there are even more sealed-off places to find here. Once I know where they are, I can help open them up.
 
 Please move around the world 100 times. I’ll collect data as you go. We’ll find these hidden paths together.",Complete MSQ016,Move 100 times,"2x Agency Reputation,1x ""Neith’s River of Life"" Spell Card"
-MSQ018,18,In Game,Harvesting Data I,No,"I suspect something is buried behind all that scrap. Please hike to the deepest part of the scrapyard and dig through it for me. All that strange machinery piled up in the Scrap Confluence might be covering up something even more interesting.
+MSQ018,18,To Update,Harvesting Data I,No,"I suspect something is buried behind all that scrap. Please hike to the deepest part of the scrapyard and dig through it for me. All that strange machinery piled up in the Scrap Confluence might be covering up something even more interesting.
 
 Harvest for at least 12 hours in the Scrap Confluence so I can run an extended analysis. If we find anything interesting, I’ll let you know through a future quest.",Complete MSQ017,Harvest for >720 minutes in Scrap Confluence,"4x Agency Reputation,1x “Paeon’s Field of Flowers” Spell Card"
-MSQ019,19,In Game,Harvesting Data II,No,"Those labs should be open by now. I’m starting to believe a malicious actor is blocking our access! Get over there and plug into the Node so I can run some tests.
+MSQ019,19,To Update,Harvesting Data II,No,"Those labs should be open by now. I’m starting to believe a malicious actor is blocking our access! Get over there and plug into the Node so I can run some tests.
 
 Harvest for at least 12 hours at the Labs Entrance while I put my mind to this. Even if we can’t brute force the doors open right away, I’m sure we can find out where the event flag is hiding. If not… We need another plan. ",Complete MSQ018,Harvest for >720 minutes at Labs Entrance,"4x Agency Reputation,2x “Paeon’s Field of Flowers” Spell Card"
-MSQ020,20,In Game,Harvesting Data III,No,"It took a lot of work, but I finally found something! It looks like the Labs Entrance has an event flag hidden somewhere past the Temple by the Waterfall. How are we going to access it to open those doors? I don’t know yet. 
+MSQ020,20,To Update,Harvesting Data III,No,"It took a lot of work, but I finally found something! It looks like the Labs Entrance has an event flag hidden somewhere past the Temple by the Waterfall. How are we going to access it to open those doors? I don’t know yet. 
 
 Go the nearest Node by the temple on the Hollow Path and Harvest for at least 12 hours. I’ll run my tests from there. We’ll find some answers soon. ","Complete MSQ019,Complete SQ007",Harvest for >720 minutes at the Hollow Path,"4x Agency Reputation,1x “Paeon’s Field of Flowers” Spell Card,1x “Melkarth’s Heroic Awakening” Spell Card"
-MIN001,2001,In Game,Grand Opening,No,"Hello, whoever you are. Is this how you receive your letters? Functional, though inelegant.
+MIN001,2001,To Update,Grand Opening,No,"Hello, whoever you are. Is this how you receive your letters? Functional, though inelegant.
 
 Are you hungry? Tired? $MUSU burning a hole in your pocket? Bring your wallet to the Tunnel of Trees and knock on the blue door. I sell treats for you and your Kami. If you need Stamina to keep moving, if your pets have gotten low on Health, or even if the poor things have fallen apart and need a Revive, my shop is open.
 
 — Mina",Complete MSQ007,Enter Mina's Shop,2x Elders Loyalty
-MIN002,2002,In Game,Customer Loyalty Program,No,"I want you to be a repeat customer. If you trade enough $MUSU with me, I’ll give you something special. I don’t care how you get it. Bring me more and I’ll be happy.
+MIN002,2002,To Update,Customer Loyalty Program,No,"I want you to be a repeat customer. If you trade enough $MUSU with me, I’ll give you something special. I don’t care how you get it. Bring me more and I’ll be happy.
 
 — Mina",Complete MIN001,Spend 1000 $MUSU at Mina’s Shop,"4x Elders Loyalty,1x ""Neith’s River of Life"" Spell Card"
-MIN003,2003,In Game,Early Market Research - I,No,"Relics and mementos from the past are brought into this world with $MUSU. People grow attached to many things; the first coin they earned, a trowel used to plant food that fed their family, a transforming robot toy that made other children jealous. Those feelings linger.
+MIN003,2003,To Update,Early Market Research - I,No,"Relics and mementos from the past are brought into this world with $MUSU. People grow attached to many things; the first coin they earned, a trowel used to plant food that fed their family, a transforming robot toy that made other children jealous. Those feelings linger.
 
  Get me five pieces of Scrap Metal. I want to perform psychometry.
 
 — Mina",Complete MIN002,Give 5 Scrap Metal,"2x Elders Loyalty,1x “Cultivation II” Spell Card"
-MIN004,2004,In Game,Early Market Research - II,No,"Deep in the forest, there is a mound built over some ancient, stagnant defilement. The crawling insects thrive and grow more violent in filthy places like that. Whatever happened in the past to corrupt that place, those feelings linger.
+MIN004,2004,To Update,Early Market Research - II,No,"Deep in the forest, there is a mound built over some ancient, stagnant defilement. The crawling insects thrive and grow more violent in filthy places like that. Whatever happened in the past to corrupt that place, those feelings linger.
 
 Go harvest at the Insect Node until you get a feel for it.
 
 — Mina",Complete MIN003,Harvest for >720 minutes in Forest: Insect Node,"2x Elders Loyalty,2 “Cultivation I” Spell Card"
-MIN005,2005,In Game,Early Market Research - III,No,"The graves across this landscape are quite old and buried under heaps of garbage, yet their $MUSU has no scent of defilement. A strange phenomenon. Are they buried saints? Were they interred as some kind of builder’s rite for a stronger spiritual foundation? I suppose this is a mystery for later.
+MIN005,2005,To Update,Early Market Research - III,No,"The graves across this landscape are quite old and buried under heaps of garbage, yet their $MUSU has no scent of defilement. A strange phenomenon. Are they buried saints? Were they interred as some kind of builder’s rite for a stronger spiritual foundation? I suppose this is a mystery for later.
 
 Go get a sense of what I mean. Harvest at the graves until you understand.
 
 — Mina",Complete MIN004,Harvest for >720 minutes on Trash-Strewn Graves,"4x Elders Loyalty,2x “Neith’s River of Life” Spell Card"
-MIN006,2006,In Game,Community Outreach,No,"With all this garbage everywhere, I expected to see more humans. One was laying by the edge of the forest earlier, you know. It looked young, at least compared to the dusty old bodies in the local graves.
+MIN006,2006,To Update,Community Outreach,No,"With all this garbage everywhere, I expected to see more humans. One was laying by the edge of the forest earlier, you know. It looked young, at least compared to the dusty old bodies in the local graves.
 
 Go harvest $MUSU from its location. Maybe it will start to feel chatty.
 
 — Mina",Complete MIN005,Harvest for >720 minutes at the Lost Skeleton During Moonside,"2x Elders Loyalty,1x “Cultivation II” Spell Card"
-MIN007,2007,In Game,Restocking,No,"I've had so many new customers these days. Help me restock my spiritual goods. The flowers of death can be made into delicious treats for Kami and other beings. Collect a few and give them to me. 
+MIN007,2007,To Update,Restocking,No,"I've had so many new customers these days. Help me restock my spiritual goods. The flowers of death can be made into delicious treats for Kami and other beings. Collect a few and give them to me. 
 
 Raw materials can be broken down into ingredients for hexerei. One can craft potions, poultices, and other things if one knows the methods. I’m selling something in my shop to help you along with this: a device to break down ingredients for yourself. I won’t be doing it for you again.
 
 — Mina",Complete MIN006,"Give 5 Plastic Bottle,Give 5 Pine Cone","2x Elders Loyalty,2x “Cultivation III” Spell Card"
-SQ001,3001,In Game,Rejecting Fate,No,"All Kamigotchi can succeed, from the Commons to the Epics. When raising a Kami, take advantage of their strengths. Build on the foundation of their initial stats. Choose skills that boost what your Kami is already best at before shoring up weaknesses.
+SQ001,3001,To Update,Rejecting Fate,No,"All Kamigotchi can succeed, from the Commons to the Epics. When raising a Kami, take advantage of their strengths. Build on the foundation of their initial stats. Choose skills that boost what your Kami is already best at before shoring up weaknesses.
 
 If you would prefer to raise a different Kami entirely, the option is available. It might be the case that you love robots and want a team of Scrap Kami. Maybe you’re a dark, edgy person, so you want Kami that are inclined to maximum violence. It could even be that you’re searching for one of the rumored Legendary Kami.
 
 If you have $ONYX, you can use the Vending Machine in the scrapyard to Reroll a Kamigotchi. After you purchase a Reroll Ticket, you can use it to return one Kami to the pool. In exchange, a new Kami will emerge to join you. ",Complete MSQ003,Reroll one Kamigotchi,2x Agency Reputation
-SQ002,3002,In Game,Health & Safety,No,"While Kami don’t see Harvesting as labor, they still get tired and lose Health. Kamigotchi hold their bodies together with spiritual energy. As they expend energy, it gets harder to maintain their form. Low Health doesn’t mean a Kami is physically hurt, but it’s still a problem you should take care of.
+SQ002,3002,To Update,Health & Safety,No,"While Kami don’t see Harvesting as labor, they still get tired and lose Health. Kamigotchi hold their bodies together with spiritual energy. As they expend energy, it gets harder to maintain their form. Low Health doesn’t mean a Kami is physically hurt, but it’s still a problem you should take care of.
 
 When your Kami gets low on Health, return to the room where you left it, then use the Harvesting Menu to pick it up. A Kami will slowly regenerate Health on its own while being held. If you can’t wait, give your Kami a snack or use a Spell Card to restore health. Kamigotchi don’t need food to live, but they can draw energy from food to bolster their spirit.
 
 Use an item to heal a Kami and complete this quest. If you already used the Spell Card that I gave you, go buy some food or dig up a Cheeseburger. ",Complete MSQ004,Use an item to heal a Kamigotchi that has been reduced below 100% Health,"2x Agency Reputation,1x ""Neith’s River of Life"" Spell Card"
-SQ003,3003,In Game,There Are Levels to This,No,"Unlike humans, Kamigotchi have the potential to grow and change by using xenoplasticity, or “XP” for short. This means that they can assimilate many different things to form a new cohesive whole.
+SQ003,3003,To Update,There Are Levels to This,No,"Unlike humans, Kamigotchi have the potential to grow and change by using xenoplasticity, or “XP” for short. This means that they can assimilate many different things to form a new cohesive whole.
 
 Take a look at your roster. You can see a green progress bar with a percentage indicator beneath the portrait of each Kami. When one is ready to move to the next level, the bar will be full and read 100%. Just level up a Kami and you’ll be done. Take note of your new skill point and hold onto it for the next quest.
 
 When you complete this, I’ll give you a small reward to help encourage the process.",Complete MSQ005,Level up a Kami,"2x Agency Reputation,1x “Cultivation I” Spell Card"
-SQ004,3004,In Game,Skill Issue,No,"When you spend Skill Points to tell Kami what to focus on, you shape their personalities and temperaments. Think hard before you make a choice! You’ll only be able to respec with specific items that are difficult to acquire. This is a commitment.
+SQ004,3004,To Update,Skill Issue,No,"When you spend Skill Points to tell Kami what to focus on, you shape their personalities and temperaments. Think hard before you make a choice! You’ll only be able to respec with specific items that are difficult to acquire. This is a commitment.
 
 Click on a Kami that leveled up and gained a skill point recently and look over the skill tree. Remember, you can’t go wrong by improving what your Kami is already good at. Take your time, but don’t forget to pick something. ",Complete SQ003,Spend a point in any Skill Tree after levelling up,2x Agency Reputation
-SQ005,3005,In Game,Spring Rites,No,"I see one of your Kami got Liquidated. That sucks! Of course, that’s just a temporary condition. Usually in this world it’s possible to return to form no matter what happens. The essence of something remains unless it’s been totally erased from existence.
+SQ005,3005,To Update,Spring Rites,No,"I see one of your Kami got Liquidated. That sucks! Of course, that’s just a temporary condition. Usually in this world it’s possible to return to form no matter what happens. The essence of something remains unless it’s been totally erased from existence.
 
 Take this and use it on a Kami that has been Liquidated. Just read the incantation printed on the front, and presto! This powerful spell card brings your Kami back to action. 
 
 It’s the only freebie I’m allowed to give you. You’ll have to work for more spell cards like this one. Certain shopkeepers might sell different kinds of revival magic, but these cards are premium SSR.",Have one of your own Kami liquidated,,"2x Agency Reputation,1x “Melkarth’s Heroic Awakening” Spell Card"
-SQ006,3006,In Game,What’s In a Name?,No,"Southeast through the old forest you can find a small shrine by a mountain waterfall. That area was cultivated for spiritual power. With the rare Holy Dust item, you can perform a ritual there to grant your Kami a name.
+SQ006,3006,To Update,What’s In a Name?,No,"Southeast through the old forest you can find a small shrine by a mountain waterfall. That area was cultivated for spiritual power. With the rare Holy Dust item, you can perform a ritual there to grant your Kami a name.
 
 If you don’t have Holy Dust, a small donation of $ONYX to the shrine will suffice!",Complete MSQ008,Name a Kami,2x Agency Reputation
-SQ007,3007,In Game,Land Survey,No,"Your march helped find an interesting anomaly, but I’m positive something else is hidden around here. I’ve checked and re-checked more times than you’d care to hear about. Something still doesn’t line up! It’s going to take a lot of legwork to figure this one out.
+SQ007,3007,To Update,Land Survey,No,"Your march helped find an interesting anomaly, but I’m positive something else is hidden around here. I’ve checked and re-checked more times than you’d care to hear about. Something still doesn’t line up! It’s going to take a lot of legwork to figure this one out.
 
 Move 500 times. I’ll be going over everything again with a fine-tooth comb. We’re bound to find something by the end.",Complete MSQ017,Move 500 times,"2x Agency Reputation,2x “Neith’s River of Life” Spell Card"
-SQ008,3008,In Game,Peregrination,No,"They say measure twice, cut once, but that still means taking a risk. Best to measure a thousand times for the most accurate data. Sometimes the numbers might have changed.
+SQ008,3008,To Update,Peregrination,No,"They say measure twice, cut once, but that still means taking a risk. Best to measure a thousand times for the most accurate data. Sometimes the numbers might have changed.
 
 Even if you’ve already found something interesting, please move 1000 times more. Cover every inch of this world. I’ll scan as you go. We need to be sure.",Complete SQ007,Move 1000 times,"4x Agency Reputation,3x “Neith’s River of Life” Spell Card"
 TempQ01,10001,Defunct,mina test drop,No,,Missed Mina,,"25 Gum,10 Revives"

--- a/packages/contracts/deployment/world/data/rooms/nodes.csv
+++ b/packages/contracts/deployment/world/data/rooms/nodes.csv
@@ -1,36 +1,35 @@
-﻿.,Name,Index,Affinity,Level Limit,YieldIndex,Scav Cost,Drops
-,Misty Riverside,1,Eerie,15,1,100,Stones & Bottle
-,Tunnel of Trees,2,Normal,15,1,100,Sticks & Stones
-,Torii Gate,3,Normal,15,1,100,Stick Stone Rename
-,Restricted Area,5,Normal,,1,100,Sticks & Stones
-,Labs Entrance,6,Eerie,,1,100,Stone Only
-,Forest: Old Growth,9,Insect,,1,200,Stick Cone Poppy
-,Forest: Insect Node,10,Insect,,1,200,Stick Cone Rename
-,Scrap Confluence,12,Scrap,,1,500,Scrap Burger Rename Driver
-,Lost Skeleton,25,Eerie,,1,200,Stick Cone Berry
-,Trash-Strewn Graves,26,Eerie,,1,100,Stone Bottle Burger
-,Misty Forest Path,29,Insect,15,1,100,Stick Stone Resin
-,Scrapyard Entrance,30,Scrap,15,1,100,Stone Scrap Burger
-,Scrapyard Exit,31,Scrap,,1,100,Stone Scrap Burger
-,Road To Labs,32,Normal,,1,100,Sticks & Stones
-,Forest Entrance,33,Normal,,1,200,Sticks & Cones
-,Deeper Into Scrap,34,Scrap,,1,300,Scrap Burger
-,Elder Path,35,Normal,,1,200,Stick Cone Poppy
-,Parting Path,36,Insect,,1,200,Stick Resin Poppy
-,Hollow Path,37,Normal,,1,200,Sticks & Cones
-,Scrap Paths,47,Scrap,,1,100,Stone Scrap Burger
-,Murky Forest Path,48,Insect,,1,200,Stick Resin Poppy
-,Clearing,49,Normal,,1,300,Stick Stone Mint
-,Ancient Forest Entrance,50,Insect,,1,200,Stone Shroom
-,Scrap-Littered Undergrowth,51,Insect,,1,300,"Bottle Scrap Resin "
-,Airplane Crash,52,Eerie,,1,300,Bottle Scrap Jar
-,Blooming Tree,53,Eerie,,1,300,Stick Cone Amber
-,Shady Path,55,Normal,,1,200,Stick Stone Daffodil
-,Butterfly Forest,56,Insect,,1,200,Stick Stone Resin
-,River Crossing,57,Normal,,1,200,Stick Stone Cone
-,Scrap Trees,60,Scrap,,2,500,Scrap Daffodil Driver
-,Musty Forest Path,61,Normal,,2,200,Stick Cone Rename
-,Centipedes,62,Insect,,2,300,Stone Resin Mint
-,Deeper Forest Path,63,Normal,,2,300,Stone Daffodil Pinecone Poppy
-,Forest Hut,65,Eerie,,2,200,Bottle Stick Burger
-,,,,,,,
+﻿.,Status,Name,Index,Affinity,Level Limit,YieldIndex,Scav Cost,Drops
+,To Update,Misty Riverside,1,Eerie,15,1,100,Stones & Bottle
+,To Update,Tunnel of Trees,2,Normal,15,1,100,Sticks & Stones
+,To Update,Torii Gate,3,Normal,15,1,100,Stick Stone Rename
+,To Update,Restricted Area,5,Normal,,1,100,Sticks & Stones
+,To Update,Labs Entrance,6,Eerie,,1,100,Stone Only
+,To Update,Forest: Old Growth,9,Insect,,1,200,Stick Cone Poppy
+,To Update,Forest: Insect Node,10,Insect,,1,200,Stick Cone Rename
+,To Update,Scrap Confluence,12,Scrap,,1,500,Scrap Burger Rename Driver
+,To Update,Lost Skeleton,25,Eerie,,1,200,Stick Cone Berry
+,To Update,Trash-Strewn Graves,26,Eerie,,1,100,Stone Bottle Burger
+,To Update,Misty Forest Path,29,Insect,15,1,100,Stick Stone Resin
+,To Update,Scrapyard Entrance,30,Scrap,15,1,100,Stone Scrap Burger
+,To Update,Scrapyard Exit,31,Scrap,,1,100,Stone Scrap Burger
+,To Update,Road To Labs,32,Normal,,1,100,Sticks & Stones
+,To Update,Forest Entrance,33,Normal,,1,200,Sticks & Cones
+,To Update,Deeper Into Scrap,34,Scrap,,1,300,Scrap Burger
+,To Update,Elder Path,35,Normal,,1,200,Stick Cone Poppy
+,To Update,Parting Path,36,Insect,,1,200,Stick Resin Poppy
+,To Update,Hollow Path,37,Normal,,1,200,Sticks & Cones
+,To Update,Scrap Paths,47,Scrap,,1,100,Stone Scrap Burger
+,To Update,Murky Forest Path,48,Insect,,1,200,Stick Resin Poppy
+,To Update,Clearing,49,Normal,,1,300,Stick Stone Mint
+,To Update,Ancient Forest Entrance,50,Insect,,1,200,Stone Shroom
+,To Update,Scrap-Littered Undergrowth,51,Insect,,1,300,"Bottle Scrap Resin "
+,To Update,Airplane Crash,52,Eerie,,1,300,Bottle Scrap Jar
+,To Update,Blooming Tree,53,Eerie,,1,300,Stick Cone Amber
+,To Update,Shady Path,55,Normal,,1,200,Stick Stone Daffodil
+,To Update,Butterfly Forest,56,Insect,,1,200,Stick Stone Resin
+,To Update,River Crossing,57,Normal,,1,200,Stick Stone Cone
+,To Update,Scrap Trees,60,Scrap,,2,500,Scrap Daffodil Driver
+,To Update,Musty Forest Path,61,Normal,,2,200,Stick Cone Rename
+,To Update,Centipedes,62,Insect,,2,300,Stone Resin Mint
+,To Update,Deeper Forest Path,63,Normal,,2,300,Stone Daffodil Pinecone Poppy
+,To Update,Forest Hut,65,Eerie,,2,200,Bottle Stick Burger

--- a/packages/contracts/src/systems/_GoalRegistrySystem.sol
+++ b/packages/contracts/src/systems/_GoalRegistrySystem.sol
@@ -79,11 +79,12 @@ contract _GoalRegistrySystem is System, AuthRoles {
       uint256 value
     ) = abi.decode(arguments, (uint32, string, uint256, string, uint32, uint256));
 
-    require(LibGoal.getByIndex(components, goalIndex) != 0, "Goal does not exist");
+    uint256 goalID = LibGoal.getByIndex(components, goalIndex);
+    require(goalID != 0, "Goal does not exist");
 
     uint256 tierID = LibGoal.createTier(components, goalIndex, name, cutoff);
     uint256 anchorID = LibGoal.genAlloAnchor(tierID);
-    uint256 id = LibAllo.createBasic(components, anchorID, type_, index, value);
+    uint256 id = LibAllo.createBasic(components, goalID, anchorID, type_, index, value);
     return id;
   }
 
@@ -97,11 +98,12 @@ contract _GoalRegistrySystem is System, AuthRoles {
       uint256 value
     ) = abi.decode(arguments, (uint32, string, uint256, uint32[], uint256[], uint256));
 
-    require(LibGoal.getByIndex(components, goalIndex) != 0, "Goal does not exist");
+    uint256 goalID = LibGoal.getByIndex(components, goalIndex);
+    require(goalID != 0, "Goal does not exist");
 
     uint256 tierID = LibGoal.createTier(components, goalIndex, name, cutoff);
     uint256 anchorID = LibGoal.genAlloAnchor(tierID);
-    uint256 id = LibAllo.createDT(components, anchorID, keys, weights, value);
+    uint256 id = LibAllo.createDT(components, goalID, anchorID, keys, weights, value);
     return id;
   }
 
@@ -117,22 +119,33 @@ contract _GoalRegistrySystem is System, AuthRoles {
       int32 sync
     ) = abi.decode(arguments, (uint32, string, uint256, string, int32, int32, int32, int32));
 
-    require(LibGoal.getByIndex(components, goalIndex) != 0, "Goal does not exist");
+    uint256 goalID = LibGoal.getByIndex(components, goalIndex);
+    require(goalID != 0, "Goal does not exist");
 
     uint256 tierID = LibGoal.createTier(components, goalIndex, name, cutoff);
     uint256 anchorID = LibGoal.genAlloAnchor(tierID);
-    uint256 id = LibAllo.createStat(components, anchorID, statType, base, shift, boost, sync);
+    uint256 id = LibAllo.createStat(
+      components,
+      goalID,
+      anchorID,
+      statType,
+      base,
+      shift,
+      boost,
+      sync
+    );
     return id;
   }
 
   function addRewardDisplay(bytes memory arguments) public onlyAdmin(components) returns (uint256) {
     (uint32 goalIndex, string memory name) = abi.decode(arguments, (uint32, string));
 
-    require(LibGoal.getByIndex(components, goalIndex) != 0, "Goal does not exist");
+    uint256 goalID = LibGoal.getByIndex(components, goalIndex);
+    require(goalID != 0, "Goal does not exist");
 
     uint256 tierID = LibGoal.createTier(components, goalIndex, name, 0);
     uint256 anchorID = LibGoal.genAlloAnchor(tierID);
-    uint256 id = LibAllo.createEmpty(components, anchorID, "Community");
+    uint256 id = LibAllo.createEmpty(components, goalID, anchorID, "Community");
     return id;
   }
 

--- a/packages/contracts/src/systems/_ItemRegistrySystem.sol
+++ b/packages/contracts/src/systems/_ItemRegistrySystem.sol
@@ -84,11 +84,12 @@ contract _ItemRegistrySystem is System, AuthRoles {
       uint32 alloIndex,
       uint256 alloValue
     ) = abi.decode(arguments, (uint32, string, string, uint32, uint256));
-    require(LibItem.getByIndex(components, index) != 0, "ItemReg: item does not exist");
+    uint256 regID = LibItem.getByIndex(components, index);
+    require(regID != 0, "ItemReg: item does not exist");
 
     uint256 refID = LibItem.createUseCase(components, index, useCase);
     uint256 anchorID = LibItem.genAlloAnchor(refID);
-    return LibAllo.createBasic(components, anchorID, alloType, alloIndex, alloValue);
+    return LibAllo.createBasic(components, regID, anchorID, alloType, alloIndex, alloValue);
   }
 
   function addAlloBonus(bytes memory arguments) public onlyAdmin(components) returns (uint256) {
@@ -100,11 +101,13 @@ contract _ItemRegistrySystem is System, AuthRoles {
       uint256 duration,
       int256 bonusValue
     ) = abi.decode(arguments, (uint32, string, string, string, uint256, int256));
-    require(LibItem.getByIndex(components, index) != 0, "ItemReg: item does not exist");
+    uint256 regID = LibItem.getByIndex(components, index);
+    require(regID != 0, "ItemReg: item does not exist");
 
     uint256 refID = LibItem.createUseCase(components, index, useCase);
     uint256 anchorID = LibItem.genAlloAnchor(refID);
-    return LibAllo.createBonus(components, anchorID, bonusType, endType, duration, bonusValue);
+    return
+      LibAllo.createBonus(components, regID, anchorID, bonusType, endType, duration, bonusValue);
   }
 
   function addAlloDT(bytes memory arguments) public onlyAdmin(components) returns (uint256) {
@@ -115,11 +118,12 @@ contract _ItemRegistrySystem is System, AuthRoles {
       uint256[] memory weights,
       uint256 value
     ) = abi.decode(arguments, (uint32, string, uint32[], uint256[], uint256));
-    require(LibItem.getByIndex(components, index) != 0, "ItemReg: item does not exist");
+    uint256 regID = LibItem.getByIndex(components, index);
+    require(regID != 0, "ItemReg: item does not exist");
 
     uint256 refID = LibItem.createUseCase(components, index, useCase);
     uint256 anchorID = LibItem.genAlloAnchor(refID);
-    return LibAllo.createDT(components, anchorID, keys, weights, value);
+    return LibAllo.createDT(components, regID, anchorID, keys, weights, value);
   }
 
   function addAlloStat(bytes memory arguments) public onlyAdmin(components) returns (uint256) {
@@ -132,11 +136,12 @@ contract _ItemRegistrySystem is System, AuthRoles {
       int32 boost,
       int32 sync
     ) = abi.decode(arguments, (uint32, string, string, int32, int32, int32, int32));
-    require(LibItem.getByIndex(components, index) != 0, "ItemReg: item does not exist");
+    uint256 regID = LibItem.getByIndex(components, index);
+    require(regID != 0, "ItemReg: item does not exist");
 
     uint256 refID = LibItem.createUseCase(components, index, useCase);
     uint256 anchorID = LibItem.genAlloAnchor(refID);
-    return LibAllo.createStat(components, anchorID, statType, base, shift, boost, sync);
+    return LibAllo.createStat(components, regID, anchorID, statType, base, shift, boost, sync);
   }
 
   function remove(uint32 index) public onlyAdmin(components) {

--- a/packages/contracts/src/systems/_NodeRegistrySystem.sol
+++ b/packages/contracts/src/systems/_NodeRegistrySystem.sol
@@ -95,7 +95,7 @@ contract _NodeRegistrySystem is System, AuthRoles {
     require(scavID != 0, "Node: scav bar does not exist");
 
     uint256 anchorID = LibScavenge.genAlloAnchor(scavID);
-    return LibAllo.createBasic(components, anchorID, rwdType, rwdIndex, value);
+    return LibAllo.createBasic(components, scavID, anchorID, rwdType, rwdIndex, value);
   }
 
   function addScavRewardDT(bytes memory arguments) public onlyAdmin(components) returns (uint256) {
@@ -109,7 +109,7 @@ contract _NodeRegistrySystem is System, AuthRoles {
     require(scavID != 0, "Node: scav bar does not exist");
 
     uint256 anchorID = LibScavenge.genAlloAnchor(scavID);
-    return LibAllo.createDT(components, anchorID, keys, weights, value);
+    return LibAllo.createDT(components, scavID, anchorID, keys, weights, value);
   }
 
   // // NOTE(jb): unused atm. commented out to meet gas limits on the freelane

--- a/packages/contracts/src/systems/_QuestRegistrySystem.sol
+++ b/packages/contracts/src/systems/_QuestRegistrySystem.sol
@@ -94,7 +94,7 @@ contract _QuestRegistrySystem is System, AuthRoles {
 
     // create an empty Quest Reward and set any non-zero fields
     uint256 anchorID = LibQuestRegistry.genAlloAnchor(questIndex);
-    return LibAllo.createBasic(components, anchorID, type_, index, value);
+    return LibAllo.createBasic(components, questID, anchorID, type_, index, value);
   }
 
   function addRewardDT(bytes memory arguments) public onlyAdmin(components) returns (uint256) {
@@ -109,7 +109,7 @@ contract _QuestRegistrySystem is System, AuthRoles {
 
     // create an empty Quest Reward and set any non-zero fields
     uint256 anchorID = LibQuestRegistry.genAlloAnchor(questIndex);
-    return LibAllo.createDT(components, anchorID, keys, weights, value);
+    return LibAllo.createDT(components, questID, anchorID, keys, weights, value);
   }
 
   function addRewardStat(bytes memory arguments) public onlyAdmin(components) returns (uint256) {
@@ -128,7 +128,7 @@ contract _QuestRegistrySystem is System, AuthRoles {
 
     // create an empty Quest Reward and set any non-zero fields
     uint256 anchorID = LibQuestRegistry.genAlloAnchor(questIndex);
-    return LibAllo.createStat(components, anchorID, statType, base, shift, boost, sync);
+    return LibAllo.createStat(components, questID, anchorID, statType, base, shift, boost, sync);
   }
 
   function setDisabled(uint32 index, bool disabled) public onlyAdmin(components) {

--- a/packages/contracts/test/libs/Allo.t.sol
+++ b/packages/contracts/test/libs/Allo.t.sol
@@ -297,6 +297,7 @@ contract AlloTest is SetupTemplate {
   // UTILS
 
   // basic reward
+  // skips sourceID (not really relevant for contracts)
   function _createAllo(
     uint256 anchorID,
     string memory type_,
@@ -304,11 +305,12 @@ contract AlloTest is SetupTemplate {
     uint256 value
   ) internal returns (uint256 id) {
     vm.startPrank(deployer);
-    id = LibAllo.createBasic(components, anchorID, type_, index, value);
+    id = LibAllo.createBasic(components, 0, anchorID, type_, index, value);
     vm.stopPrank();
   }
 
   // droptable reward
+  // skips sourceID (not really relevant for contracts)
   function _createAllo(
     uint256 anchorID,
     uint32[] memory keys,
@@ -316,10 +318,11 @@ contract AlloTest is SetupTemplate {
     uint256 value
   ) internal returns (uint256 id) {
     vm.startPrank(deployer);
-    id = LibAllo.createDT(components, anchorID, keys, weights, value);
+    id = LibAllo.createDT(components, 0, anchorID, keys, weights, value);
     vm.stopPrank();
   }
 
+  // skips sourceID (not really relevant for contracts)
   function _createAlloStat(
     uint256 anchorID,
     string memory statType,
@@ -328,6 +331,7 @@ contract AlloTest is SetupTemplate {
     vm.startPrank(deployer);
     id = LibAllo.createStat(
       components,
+      0,
       anchorID,
       statType,
       value.base,
@@ -338,6 +342,7 @@ contract AlloTest is SetupTemplate {
     vm.stopPrank();
   }
 
+  // skips sourceID (not really relevant for contracts)
   function _createAlloBonus(
     uint256 anchorID,
     string memory bonusType,
@@ -346,7 +351,7 @@ contract AlloTest is SetupTemplate {
     int256 value
   ) internal returns (uint256 id) {
     vm.startPrank(deployer);
-    id = LibAllo.createBonus(components, anchorID, bonusType, endType, duration, value);
+    id = LibAllo.createBonus(components, 0, anchorID, bonusType, endType, duration, value);
     vm.stopPrank();
   }
 

--- a/packages/contracts/test/systems/Scavenge.t.sol
+++ b/packages/contracts/test/systems/Scavenge.t.sol
@@ -131,7 +131,7 @@ contract ScavengeTest is SetupTemplate {
   ) internal returns (uint256 id) {
     vm.startPrank(deployer);
     uint256 anchorID = LibScavenge.genAlloAnchor(scavBarID);
-    id = LibAllo.createBasic(components, anchorID, type_, rwdIndex, value);
+    id = LibAllo.createBasic(components, scavBarID, anchorID, type_, rwdIndex, value);
     vm.stopPrank();
   }
 
@@ -143,7 +143,7 @@ contract ScavengeTest is SetupTemplate {
   ) internal returns (uint256 id) {
     vm.startPrank(deployer);
     uint256 anchorID = LibScavenge.genAlloAnchor(scavBarID);
-    id = LibAllo.createDT(components, anchorID, keys, weights, value);
+    id = LibAllo.createDT(components, scavBarID, anchorID, keys, weights, value);
     vm.stopPrank();
   }
 


### PR DESCRIPTION
Adds `IdSource` on Allos. These point to the base registry entity (e.g. items, quests) for easy lookup on client. 

# To Deploy
- Goal, Item, Quest, and Node registry systems
- Goal, Item, Quest, and Node entries (Strictly speaking, only items will use this updated shape, but good to keep everything updated)