### PR TITLE
deployment scripts: node status

### DIFF
--- a/packages/contracts/deployment/world/state/auctions.ts
+++ b/packages/contracts/deployment/world/state/auctions.ts
@@ -28,6 +28,7 @@ export async function createAuction(api: AdminAPI, row: any) {
 export async function initAuctions(api: AdminAPI, indices?: number[]) {
   const csv = await getSheet('auctions', 'auctions');
   if (!csv) return console.log('No auctions/auctions.csv found');
+  if (indices && indices.length == 0) return console.log('No auctions given to initialize');
   console.log('\n==INITIALIZING AUCTIONS==');
 
   for (let i = 0; i < csv.length; i++) {

--- a/packages/contracts/deployment/world/state/factions.ts
+++ b/packages/contracts/deployment/world/state/factions.ts
@@ -26,6 +26,7 @@ async function initFaction(api: AdminAPI, entry: any) {
 export async function initFactions(api: AdminAPI, indices?: number[]) {
   const csv = await getSheet('factions', 'factions');
   if (!csv) return console.log('No factions/factions.csv found');
+  if (indices && indices.length == 0) return console.log('No factions given to initialize');
   console.log('\n==INITIALIZING FACTIONS==');
 
   // process factions

--- a/packages/contracts/deployment/world/state/index.ts
+++ b/packages/contracts/deployment/world/state/index.ts
@@ -26,7 +26,7 @@ export async function initAll(api: AdminAPI) {
   console.log('\n---------------------------------------------\n');
   await initFactions(api);
   console.log('\n---------------------------------------------\n');
-  await initItems(api, [], true);
+  await initItems(api, undefined, true);
   console.log('\n---------------------------------------------\n');
   await initNpcs(api);
   console.log('\n---------------------------------------------\n');
@@ -42,13 +42,13 @@ export async function initAll(api: AdminAPI) {
   console.log('\n---------------------------------------------\n');
   await initListings(api, undefined, true);
   console.log('\n---------------------------------------------\n');
-  await initNodes(api);
+  await initNodes(api, undefined, true);
   console.log('\n---------------------------------------------\n');
   await initGoals(api);
   console.log('\n---------------------------------------------\n');
   await initQuests(api, undefined, true);
   console.log('\n---------------------------------------------\n');
-  await initRecipes(api, [], true);
+  await initRecipes(api, undefined, true);
   console.log('\n---------------------------------------------\n');
   await initRelationships(api);
   console.log('\n---------------------------------------------\n');

--- a/packages/contracts/deployment/world/state/items/items.ts
+++ b/packages/contracts/deployment/world/state/items/items.ts
@@ -16,10 +16,11 @@ export async function initItems(api: AdminAPI, indices?: number[], all?: boolean
   if (!allosCSV) return console.log('No items/allos.csv found');
   const requirementsCSV = await getSheet('items', 'requirements');
   if (!requirementsCSV) return console.log('No items/requirements.csv found');
+  if (indices && indices.length == 0) return console.log('No items given to initialize');
   console.log('\n==INITIALIZING ITEMS==');
 
   const validStatuses = ['To Deploy'];
-  if (all || indices !== undefined) validStatuses.push('Ready', 'In Game');
+  if (all || indices !== undefined) validStatuses.push('Ready', 'In Game', 'To Update');
 
   // construct the map of allos for easier lookup
   const alloMap = new Map<string, any>();

--- a/packages/contracts/deployment/world/state/listings.ts
+++ b/packages/contracts/deployment/world/state/listings.ts
@@ -10,6 +10,7 @@ export async function initListings(api: AdminAPI, indices?: number[], all?: bool
   if (!pricingCSV) return console.log('No listings/pricing.csv found');
   const requirementCSV = await getSheet('listings', 'requirements');
   if (!requirementCSV) return console.log('No listings/requirements.csv found');
+  if (indices && indices.length == 0) return console.log('No listings given to initialize');
   console.log('\n==INITIALIZING LISTINGS==');
 
   const setBuy = api.listing.set.price.buy;

--- a/packages/contracts/deployment/world/state/quests/quests.ts
+++ b/packages/contracts/deployment/world/state/quests/quests.ts
@@ -34,6 +34,7 @@ export const initQuest = async (api: AdminAPI, entry: any): Promise<boolean> => 
 export async function initQuests(api: AdminAPI, indices?: number[], all?: boolean) {
   const csv = await getSheet('quests', 'quests');
   if (!csv) return console.log('No quests/quests.csv found');
+  if (indices && indices.length == 0) return console.log('No quests given to initialize');
   console.log('\n==INITIALIZING QUESTS==');
 
   // TODO: support test environment statuses
@@ -49,7 +50,7 @@ export async function initQuests(api: AdminAPI, indices?: number[], all?: boolea
     const status = row['Status'];
 
     // skip if quest isnt included in overridden indices
-    // if indices arent overriden, skip if status isnt valid
+    // if indices arent overridden, skip if status isnt valid
     if (indices && indices.length > 0) {
       if (!indices.includes(index)) continue;
     } else if (!validStatuses.includes(status)) continue;

--- a/packages/contracts/deployment/world/state/recipes/recipes.ts
+++ b/packages/contracts/deployment/world/state/recipes/recipes.ts
@@ -47,12 +47,13 @@ export async function initRecipe(api: AdminAPI, entry: any) {
 export async function initRecipes(api: AdminAPI, indices?: number[], all?: boolean) {
   const csv = await getSheet('crafting', 'recipes');
   if (!csv) return console.log('No crafting/recipes.csv found');
+  if (indices && indices.length == 0) return console.log('No recipes given to initialize');
   console.log('\n==INITIALIZING RECIPES==');
 
   // TODO: support test world status
   const validStatuses = ['To Deploy'];
   if (process.env.NODE_ENV !== 'production') validStatuses.push('Test');
-  if (all || indices !== undefined) validStatuses.push('In Game');
+  if (all || indices !== undefined) validStatuses.push('In Game', 'To Update');
 
   // process recipes
   for (let i = 0; i < csv.length; i++) {

--- a/packages/contracts/deployment/world/state/rooms/rooms.ts
+++ b/packages/contracts/deployment/world/state/rooms/rooms.ts
@@ -5,6 +5,7 @@ import { createGates } from './gates';
 export async function initRooms(api: AdminAPI, indices?: number[], all?: boolean) {
   const roomsCSV = await getSheet('rooms', 'rooms');
   if (!roomsCSV) return console.log('No rooms/rooms.csv found');
+  if (indices && indices.length == 0) return console.log('No rooms given to initialize');
   console.log('\n==INITIALIZING ROOMS==');
 
   // Status-based processing
@@ -14,7 +15,7 @@ export async function initRooms(api: AdminAPI, indices?: number[], all?: boolean
   // - Prod: To Deploy
   let validStatuses = ['To Deploy'];
   if (all || indices !== undefined) {
-    validStatuses.push('In Game');
+    validStatuses.push('In Game', 'To Update');
     validStatuses.push('Ready');
   }
 

--- a/packages/contracts/deployment/world/state/skills.ts
+++ b/packages/contracts/deployment/world/state/skills.ts
@@ -5,6 +5,9 @@ import { readFile, toDelete, toRevise } from './utils';
 export async function initSkills(api: AdminAPI, indices?: number[]) {
   const skillsCSV = await readFile('skills/skills.csv');
   const effectsCSV = await readFile('skills/effects.csv');
+  if (indices && indices.length == 0) return console.log('No skills given to initialize');
+  console.log('\n==INITIALIZING SKILLS==');
+
   for (let i = 0; i < skillsCSV.length; i++) {
     const skill = skillsCSV[i];
     const index = Number(skill['Index']);

--- a/packages/contracts/deployment/world/state/utils.ts
+++ b/packages/contracts/deployment/world/state/utils.ts
@@ -39,13 +39,13 @@ export const toCreate = (entry: any): boolean => {
 
 export const toDelete = (entry: any): boolean => {
   const status = entry['Status'];
-  return status === 'Revise Deployment' || status === 'In Game';
+  return status === 'To Remove';
 };
 
 /// @dev check if entry should be revised. assume all entries that are valid should be revised
 export const toRevise = (entry: any): boolean => {
   const status = entry['Status'];
-  return status === 'Revise Deployment' || status === 'Ingame' || status === 'For Implementation';
+  return status === 'Revise Deployment' || status === 'To Update';
 };
 
 export const getCreationStatuses = (env: string): string[] => {


### PR DESCRIPTION
adds node `status` in world state, allowing it to get updated/revised like other shapes.

some minor bug fixes
- now deploys `To Update` status on new worlds (mainly for local)
- remove ` "type": "module"` on `contracts/package.json`. It broke some cjs/esm interactions with ts-node. Everything works fine without this i think, but @JirAcheron to confirm