### PR TITLE
make embedded account query warnings optional

### DIFF
--- a/packages/client/src/app/components/validators/WalletConnector/WalletConnector.tsx
+++ b/packages/client/src/app/components/validators/WalletConnector/WalletConnector.tsx
@@ -10,6 +10,7 @@ import { isEqual } from 'lodash';
 import { useEffect, useState } from 'react';
 import { of } from 'rxjs';
 import styled from 'styled-components';
+import { Address } from 'viem';
 import { useAccount, useConnect } from 'wagmi';
 
 import { ActionButton, ValidatorWrapper } from 'app/components/library';
@@ -19,7 +20,6 @@ import { wagmiConfig } from 'clients/wagmi';
 import { DefaultChain } from 'constants/chains';
 import { createNetworkInstance, updateNetworkLayer } from 'network/';
 import { abbreviateAddress } from 'utils/address';
-import { Address } from 'viem';
 import { Progress } from './Progress';
 
 // Detects network changes and populates network clients for inidividual addresses.
@@ -168,6 +168,7 @@ export function registerWalletConnecter() {
         }
       };
 
+      // NOTE: connect() fails silently if user has no connectors (connector[0] == null)
       const handleClick = () => {
         if (state === 'disconnected') connect({ connector: connectors[0] });
         else if (state === 'wrongChain') switchChain(wagmiConfig, { chainId: DefaultChain.id });

--- a/packages/client/src/network/shapes/Account/queries.ts
+++ b/packages/client/src/network/shapes/Account/queries.ts
@@ -63,15 +63,22 @@ export const queryByName = (comps: Components, name: string) => {
 
 // query for an account entity by its attached operator address
 // NOTE: we format to match MUD's abbreviated style. fix, eventually
-export const queryByOperator = (comps: Components, operator: string) => {
+export const queryByOperator = (comps: Components, operator: string, debug = false) => {
   if (!OperatorCache.has(operator)) {
     const formatted = BigNumber.from(operator).toHexString();
     const results = query(comps, { operator: formatted });
+
+    // report on multiple matches if in debug mode
+    // NOTE: there has to be a better way to do this..
     const length = results.length;
-    if (length != 1) console.warn(`found ${length} entities for account operator: ${operator}`);
+    if (debug && length != 1) {
+      console.warn(`found ${length} entities for account operator: ${operator}`);
+    }
+
     const result = results[0];
     if (length > 0 && result != 0) OperatorCache.set(operator, result);
   }
+
   return OperatorCache.get(operator);
 };
 


### PR DESCRIPTION
seems to be slowing down load by quite a bit (many modals)