### PR TITLE
fix kami bridge

### DIFF
--- a/packages/client/src/app/components/modals/kamiBridge/KamiBridge.tsx
+++ b/packages/client/src/app/components/modals/kamiBridge/KamiBridge.tsx
@@ -114,9 +114,9 @@ export function registerKamiBridge() {
       // TOTO: properly typecast the result of the abi call
       useEffect(() => {
         const result = (nftData?.[0]?.result ?? []) as number[];
-        const entities = result?.map((index: number) => queryKamiByIndex(index));
-        const filtered = entities?.filter((entity) => !!entity) as EntityIndex[];
-        const externalKamis = filtered?.map((entity: EntityIndex) => getKami(entity));
+        const entities = result.map((index: number) => queryKamiByIndex(index));
+        const filtered = entities.filter((entity) => !!entity) as EntityIndex[];
+        const externalKamis = filtered.map((entity: EntityIndex) => getKami(entity));
         setWildKamis(externalKamis);
       }, [nftData]);
 


### PR DESCRIPTION
moves account entity query to update inside of rxjs subscription