### PR TITLE
update account modal with friend actions (add,block,etc)

### DIFF
--- a/packages/client/src/app/components/modals/account/Account.tsx
+++ b/packages/client/src/app/components/modals/account/Account.tsx
@@ -212,9 +212,10 @@ export function registerAccountModal() {
           <Header
             key='header'
             account={account} // account selected for viewing
-            actions={{ handlePfpChange, setBio }}
+            actions={{ handlePfpChange, setBio, requestFren, cancelFren, blockFren, acceptFren }}
             isLoading={isLoading}
             isSelf={isSelf}
+            player={player}
             utils={utils}
           />
           <Tabs tab={tab} setTab={setTab} isSelf={isSelf} />

--- a/packages/client/src/app/components/modals/account/friends/Friends.tsx
+++ b/packages/client/src/app/components/modals/account/friends/Friends.tsx
@@ -42,6 +42,10 @@ export const Friends = (props: Props) => {
       isSelf && { text: 'Remove', onClick: () => actions.removeFren(friendship) },
     ].filter((o) => !!o);
 
+    // Hide the action button if no actions are available.
+    // This prevents showing the button on our own profile card when viewing on a friend's list.
+    if (options.length === 0) return null;
+
     return (
       <ActionListButton id={`friendship-options-${friendship.entity}`} text='' options={options} />
     );

--- a/packages/client/src/app/components/modals/account/friends/Friends.tsx
+++ b/packages/client/src/app/components/modals/account/friends/Friends.tsx
@@ -6,6 +6,8 @@ import { Account as PlayerAccount } from 'app/stores';
 import { Account } from 'network/shapes';
 import { Friends as FriendsType } from 'network/shapes/Account/friends';
 import { Friendship } from 'network/shapes/Friendship';
+import { getFriendshipStatus } from 'utils/friendship';
+
 interface Props {
   data: { isSelf: boolean; player: PlayerAccount };
   actions: {
@@ -28,18 +30,8 @@ export const Friends = (props: Props) => {
   const { player, isSelf } = data;
 
   const Actions = (friendship: Friendship) => {
-    const playerGetFriends = getFriends(player.entity);
-
-    const incomingEntities = playerGetFriends?.incomingReqs?.map((req) => req.account.entity);
-    const isIncoming = incomingEntities?.includes(friendship.target.entity);
-
-    const outgoingEntities = playerGetFriends?.outgoingReqs?.map((req) => req.target.entity);
-    const isOutgoing = outgoingEntities?.includes(friendship.target.entity);
-
-    const playerFriends = playerGetFriends?.friends?.map((fren) => fren.target.entity);
-    const isFriend = playerFriends?.includes(friendship.target.entity);
-
-    const isOther = player.entity !== friendship.target.entity;
+    const friendshipStatus = getFriendshipStatus(player.entity, friendship.target.entity, getFriends);
+    const { isFriend, isOther, isIncoming, isOutgoing } = friendshipStatus;
 
     // if user is not already friend, is not the player, has not sent/recieved a friend request to/from the player we can add them
     const showAdd = !isFriend && isOther && !isIncoming && !isOutgoing;

--- a/packages/client/src/app/components/modals/account/header/Header.tsx
+++ b/packages/client/src/app/components/modals/account/header/Header.tsx
@@ -335,7 +335,7 @@ const FriendActionLabel = styled.div<{ size?: 'small' | 'medium'; tone?: 'neutra
     font-size: .8vw;
     padding: .35vw .7vw;
     border-radius: .4vw;
-    margin: 0 .16vw; /* match ActionListButton medium margin */
+    margin: 0 .16vw; 
     line-height: 1.1;
   `}
 `;

--- a/packages/client/src/app/components/modals/account/header/Header.tsx
+++ b/packages/client/src/app/components/modals/account/header/Header.tsx
@@ -140,7 +140,7 @@ export const Header = (props: Props) => {
               {/* pending inbound request */}   
               {isIncoming && incomingRequest && (
                 <>
-                  <ActionButton size='small' text='Requested You' disabled onClick={() => {}} />
+                  <FriendActionLabel size='small' tone='warning'>Requested You</FriendActionLabel>
                   <ActionListButton
                     id={`friendship-options-${account.entity}-header`}
                     text=''
@@ -157,7 +157,7 @@ export const Header = (props: Props) => {
               {/* friends */}
               {isFriend && friendFriendship && (
                 <>
-                  <ActionButton size='small' text='Friends' disabled onClick={() => {}} />
+                  <FriendActionLabel size='small' tone='success'>Friends</FriendActionLabel>
                   <ActionListButton
                     id={`friendship-options-${account.entity}-friend-header`}
                     text=''
@@ -173,7 +173,7 @@ export const Header = (props: Props) => {
               {/* pending outbound request */}
               {isOutgoing && outgoingRequest && (
                 <>
-                  <ActionButton size='small' text='Request Sent' disabled onClick={() => {}} />
+                  <FriendActionLabel size='small' tone='warning'>Request Sent</FriendActionLabel>
                   <ActionListButton
                     id={`friendship-options-${account.entity}-outgoing-header`}
                     text=''
@@ -189,7 +189,7 @@ export const Header = (props: Props) => {
               {/* blocked */}
               {isBlocked && blockedFriendship && (
                 <>
-                  <ActionButton size='small' text='Blocked' disabled onClick={() => {}} />
+                  <FriendActionLabel size='small' tone='danger'>Blocked</FriendActionLabel>
                   <ActionButton size='small' text='Unblock' onClick={() => cancelFren(blockedFriendship)} />
                 </>
               )}
@@ -303,6 +303,41 @@ const FriendActions = styled.div`
   gap: 0.24vw;
   align-items: center;
   margin-top: 0.3vw;
+`;
+
+const FriendActionLabel = styled.div<{ size?: 'small' | 'medium'; tone?: 'neutral' | 'success' | 'warning' | 'danger' }>`
+  background-color: ${({ tone }) =>
+    tone === 'success' ? '#eaf7ea' : tone === 'warning' ? '#fff7da' : tone === 'danger' ? '#fdeaea' : '#f0f0f0'};
+  color: ${({ tone }) =>
+    tone === 'success' ? '#2f6f2f' : tone === 'warning' ? '#6b5a00' : tone === 'danger' ? '#7a2f2f' : '#555'};
+  user-select: none;
+  font-family: Pixel;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
+  box-sizing: border-box;
+  cursor: default;
+  border: solid
+    ${({ tone }) =>
+      tone === 'success' ? '#bfe5bf' : tone === 'warning' ? '#f0dda1' : tone === 'danger' ? '#f2bcbc' : '#bcbcbc'}
+    0.15vw;
+  ${({ size }) =>
+    (size ?? 'medium') === 'small'
+      ? `
+    font-size: .6vw;
+    padding: .2vw .5vw;
+    border-radius: .3vw;
+    margin: 0 .12vw;
+    line-height: 1;
+  `
+      : `
+    font-size: .8vw;
+    padding: .35vw .7vw;
+    border-radius: .4vw;
+    margin: 0 .16vw; /* match ActionListButton medium margin */
+    line-height: 1.1;
+  `}
 `;
 
 const Subtitle = styled.div`

--- a/packages/client/src/utils/friendship.ts
+++ b/packages/client/src/utils/friendship.ts
@@ -1,0 +1,76 @@
+import { EntityIndex } from '@mud-classic/recs'
+import { Friends as FriendsType } from 'network/shapes/Account/friends'
+import { Friendship } from 'network/shapes/Friendship'
+
+/**
+ * Friendship status between the local player and another account.
+ */
+export type FriendRequestStatus = {
+  /** True if the viewed account is the player's own account. */
+  isSelf: boolean
+  /** True if the viewed account is not the player's own account. */
+  isOther: boolean
+  /** True if there is an incoming friend request from the account. */
+  isIncoming: boolean
+  /** True if there is an outgoing friend request to the account. */
+  isOutgoing: boolean
+  /** True if the account is a friend. */
+  isFriend: boolean
+  /** True if the account is blocked. */
+  isBlocked: boolean
+  /** The friendship object for an incoming request, if it exists. */
+  incomingRequest?: Friendship
+  /** The friendship object for an outgoing request, if it exists. */
+  outgoingRequest?: Friendship
+  /** The friendship object for an established friendship, if it exists. */
+  friendFriendship?: Friendship
+  /** The friendship object for a blocked user, if it exists. */
+  blockedFriendship?: Friendship
+}
+
+/**
+ * Find friendship status between the local player and a target account.
+ * @param playerEntity The entity index of the local player.
+ * @param accountEntity The entity index of the target account.
+ * @param getFriends A utility function to retrieve the friends data for a given account entity.
+ * @returns A `FriendRequestStatus` object detailing the relationship between the two accounts.
+ */
+export function getFriendshipStatus(
+  playerEntity: EntityIndex,
+  accountEntity: EntityIndex,
+  getFriends: (accEntity: EntityIndex) => FriendsType
+): FriendRequestStatus {
+  const data = getFriends(playerEntity)
+
+  const isSelf = playerEntity === accountEntity
+  const isOther = !isSelf
+
+  const incomingEntities = data?.incomingReqs?.map((req) => req.account.entity)
+  const isIncoming = !!incomingEntities?.includes(accountEntity)
+  const incomingRequest = data?.incomingReqs?.find((req) => req.account.entity === accountEntity)
+
+  const outgoingEntities = data?.outgoingReqs?.map((req) => req.target.entity)
+  const isOutgoing = !!outgoingEntities?.includes(accountEntity)
+  const outgoingRequest = data?.outgoingReqs?.find((req) => req.target.entity === accountEntity)
+
+  const friendEntities = data?.friends?.map((f) => f.target.entity)
+  const isFriend = !!friendEntities?.includes(accountEntity)
+  const friendFriendship = data?.friends?.find((f) => f.target.entity === accountEntity)
+
+  const blockedEntities = data?.blocked?.map((b) => b.target.entity)
+  const isBlocked = !!blockedEntities?.includes(accountEntity)
+  const blockedFriendship = data?.blocked?.find((b) => b.target.entity === accountEntity)
+
+  return {
+    isSelf,
+    isOther,
+    isIncoming,
+    isOutgoing,
+    isFriend,
+    isBlocked,
+    incomingRequest,
+    outgoingRequest,
+    friendFriendship,
+    blockedFriendship,
+  }
+}


### PR DESCRIPTION
- update `account` and `header` modal to include friend actions (add,accept,block,etc) 

new friend account
<img width="329" height="215" alt="nonfriends-1" src="https://github.com/user-attachments/assets/18bd22f7-9da7-4a24-91c3-e3387a8a8cae" />

blocked account 
<img width="329" height="215" alt="blocked-2" src="https://github.com/user-attachments/assets/5d6b4450-c602-4c55-b957-cf86a6aabec8" />

outbound request 
<img width="329" height="215" alt="pending-outbound-3" src="https://github.com/user-attachments/assets/2cea25c4-902f-445c-94c6-79b7a93acc4d" />

inbound request
<img width="329" height="215" alt="pending-inbound-3" src="https://github.com/user-attachments/assets/8ca61360-87ef-4a23-8508-d7aa840439b5" />


- update `friend` modal to not show actionListButton if no options are available (when viewing your own profile on a friends profile, you cant add/block yourself - don't show the button)
Before vs After

<img width="302" height="505" alt="Screenshot 2025-08-11 at 22 48 59" src="https://github.com/user-attachments/assets/49be1195-9e62-47d4-a483-6872a3d92a4b" />
<img width="302" height="505" alt="friendslist-non-showing-self-add-1" src="https://github.com/user-attachments/assets/0c010d73-7332-493e-97a9-ff7edb099719" />




