### PR TITLE
2 to 3 on grid

### DIFF
--- a/packages/client/src/app/components/modals/account/party/Kamis.tsx
+++ b/packages/client/src/app/components/modals/account/party/Kamis.tsx
@@ -53,17 +53,18 @@ export const Kamis = (props: Props) => {
 };
 
 const Container = styled.div`
-  display: flex;
-  flex-flow: wrap;
-  justify-content: center;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  justify-items: center;
   align-items: flex-start;
+  gap: 0.6vw;
 `;
 
 const CellContainer = styled.div`
   border: solid 0.15vw black;
   border-radius: 0.25vw;
 
-  margin: 0.3vh 0.4vw;
+  margin: 0;
   position: relative;
 `;
 


### PR DESCRIPTION
modifies the display logic on the kami cards on the party modal from flex to a default grid of 3
(having it display flex grids of 2 always felt off to me)

<img width="1031" height="829" alt="b4" src="https://github.com/user-attachments/assets/79f8b8b1-f6f2-4944-a987-f84e31233f75" />
<img width="1031" height="829" alt="after" src="https://github.com/user-attachments/assets/bdd2a3ca-6519-423d-9d9b-991635dc7976" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Kamis section in the Account > Party modal to a consistent three-column grid for clearer organization.
  * Centered items and applied uniform gaps for a cleaner, more balanced appearance.
  * Removed external margins around cells to achieve tighter, consistent spacing.
  * Visual update only—no changes to interactions; clicking and behavior remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->