### PR TITLE
inventory tooltip: fix multiple effect description

### DIFF
--- a/packages/client/src/app/components/modals/inventory/ItemGridTooltip.tsx
+++ b/packages/client/src/app/components/modals/inventory/ItemGridTooltip.tsx
@@ -45,8 +45,14 @@ export const ItemGridTooltip = (props: Props) => {
           Requirements: <p>{requirements?.use?.length > 0 ? display(item) : 'None'}</p>
         </Section>
         <Section>
-          Effects:
-          <p>{effects?.use?.length > 0 ? parseAllos(effects.use)[0].description : 'None'}</p>
+          {item.type === 'LOOTBOX' ? 'Drops:' : 'Effects:'}
+          <p>
+            {effects?.use?.length > 0
+              ? parseAllos(effects.use)
+                  .map((entry) => entry.description)
+                  .join('\n')
+              : 'None'}
+          </p>
         </Section>
       </BottomSection>
     </Container>
@@ -87,7 +93,7 @@ const SubSection = styled.span`
 const BottomSection = styled.div`
   display: flex;
   flex-direction: row;
-  aligg-items: center;
+  align-items: center;
   gap: 0.5vw;
   padding: 0.5vw;
 `;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inventory item tooltips now list all effect descriptions instead of only the first. For loot box items, the section label switches to “Drops:”; if no effects are present, it clearly shows “None” for consistency and clarity.

* **Bug Fixes**
  * Corrected content alignment in the tooltip’s bottom section to center elements, improving visual consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->