### PR TITLE
remove lootbox drop info

### DIFF
--- a/packages/client/src/app/components/modals/inventory/ItemGridTooltip.tsx
+++ b/packages/client/src/app/components/modals/inventory/ItemGridTooltip.tsx
@@ -23,6 +23,8 @@ export const ItemGridTooltip = (props: Props) => {
   const requirements = item.requirements;
   const effects = item.effects;
 
+  const isLootbox = type === 'LOOTBOX';
+
   const display = (item: Item) => {
     const disp = displayRequirements(item);
     if (disp === '???') return 'None';
@@ -45,9 +47,9 @@ export const ItemGridTooltip = (props: Props) => {
           Requirements: <p>{requirements?.use?.length > 0 ? display(item) : 'None'}</p>
         </Section>
         <Section>
-          {item.type === 'LOOTBOX' ? 'Drops:' : 'Effects:'}
+          Effects:
           <p>
-            {effects?.use?.length > 0
+            {!isLootbox && effects?.use?.length > 0
               ? parseAllos(effects.use)
                   .map((entry) => entry.description)
                   .join('\n')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized tooltip label to “Effects:” for all items.
  * Lootbox items no longer display effect entries in the tooltip.
  * Non-lootbox items show clear effect descriptions; when none exist, display “None.”
  * Improves clarity and consistency of inventory item tooltips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->