### PR TITLE
fix stamina recovery calcs when incorrect config load

### DIFF
--- a/packages/client/src/app/cache/account/calcs.ts
+++ b/packages/client/src/app/cache/account/calcs.ts
@@ -8,7 +8,7 @@ import { Account } from '../account';
 // assume that Account Stamina and Config are populated
 export const calcCurrentStamina = (account: Account): number => {
   if (!account.config) return 0;
-  const recoveryPeriod = account.config.stamina.recovery ?? 300;
+  const recoveryPeriod = account.config.stamina.recovery ?? 60;
   const timeDelta = Date.now() / 1000 - account.time.action;
   const recovered = Math.floor(timeDelta / recoveryPeriod);
   return sync(account.stamina, recovered);

--- a/packages/client/src/network/shapes/Account/configs.ts
+++ b/packages/client/src/network/shapes/Account/configs.ts
@@ -44,8 +44,8 @@ interface StaminaConfig {
 export const getStaminaConfig = (world: World, components: Components): StaminaConfig => {
   const value = getConfigArray(world, components, 'ACCOUNT_STAMINA');
   return {
-    base: value[0],
-    recovery: value[1],
+    base: value[0] === 0 ? 100 : value[0], // will not be 0, hardcoded to fix race condition loads
+    recovery: value[1] === 0 ? 60 : value[1],
   };
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Sensible defaults applied to stamina settings for smoother gameplay.
- Bug Fixes
  - Stamina recovery now defaults to 60s when configuration is missing or set to zero, ensuring consistent regeneration.
  - Base stamina now defaults to 100 when loaded as zero, preventing stalled or invalid stamina states.
  - Improved resilience to transient configuration loading issues, reducing edge-case inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->