### PR TITLE
pass withBonus = true to getStats

### DIFF
--- a/packages/client/src/network/shapes/Kami/types.ts
+++ b/packages/client/src/network/shapes/Kami/types.ts
@@ -104,7 +104,7 @@ export const get = (
   if (options?.progress) kami.progress = getProgress(comps, entity);
   if (options?.rerolls) kami.rerolls = getRerolls(comps, entity);
   if (options?.skills) kami.skills = getSkills(world, comps, entity);
-  if (options?.stats) kami.stats = getStats(world, comps, entity);
+  if (options?.stats) kami.stats = getStats(world, comps, entity, true);
   if (options?.time) kami.time = getTimes(comps, entity);
   if (options?.traits) kami.traits = getTraits(world, comps, entity);
 


### PR DESCRIPTION
to account for the new Ash item

<img width="441" height="98" alt="shift stats" src="https://github.com/user-attachments/assets/7d11eee3-1c32-4f68-8b4c-f40d3cc56400" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Kami stats in the public view when stats are requested, offering expanded details and improved accuracy. This affects only standard Kami retrieval; gacha Kami remains unchanged. Users may notice richer stat breakdowns and more consistent values in contexts where stats are included. No action required; existing flows continue to work, with added information visible when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->