### PR TITLE
Align item tooltip boxes 

### DIFF
--- a/packages/client/src/app/components/modals/inventory/ItemGridTooltip.tsx
+++ b/packages/client/src/app/components/modals/inventory/ItemGridTooltip.tsx
@@ -95,7 +95,7 @@ const SubSection = styled.span`
 const BottomSection = styled.div`
   display: flex;
   flex-direction: row;
-  align-items: center;
+  align-items: stretch;
   gap: 0.5vw;
   padding: 0.5vw;
 `;


### PR DESCRIPTION
from this:
<img width="388" height="247" alt="image" src="https://github.com/user-attachments/assets/0e3a2ace-2a9b-4011-a089-958ab9a355f8" />

to this:
<img width="388" height="241" alt="image" src="https://github.com/user-attachments/assets/9cc736ac-61b1-4537-8459-4e94f86d7b4b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Map now includes a filter dropdown (My Kamis, Room Type, Kami Count, Operator Count) with per-tile floating indicators and color cues.
  - Account header gains friend management actions (add, accept, cancel, block) with contextual states.
  - Dropdowns support a simplified single-select mode.
  - Icons in buttons scale correctly for vector icons.

- UI/UX
  - Profile picture shows last-seen status with tooltip.
  - Grid tooltip highlights your Kamis.
  - Inventory item tooltip layout stretches content for better alignment.

- Documentation
  - Expanded Quick Start guides, build steps, and remote-client notes.

- Chores
  - Vercel build script and configuration updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->