### PR TITLE
preload tx queue to be visible in advance

### DIFF
--- a/packages/client/src/app/components/index.ts
+++ b/packages/client/src/app/components/index.ts
@@ -44,6 +44,10 @@ export const allComponents: UIComponentWithGrid[] = [
     uiComponent: LoadingState,
     gridConfig: { colStart: 1, colEnd: 13, rowStart: 1, rowEnd: 13 },
   },
+  {
+    uiComponent: ActionQueue,
+    gridConfig: { colStart: 66, colEnd: 99, rowStart: 90, rowEnd: 100 },
+  },
 
   // validators
   {
@@ -83,10 +87,6 @@ export const allComponents: UIComponentWithGrid[] = [
   {
     uiComponent: NotificationFixture,
     gridConfig: { colStart: 72, colEnd: 100, rowStart: 8, rowEnd: 30 },
-  },
-  {
-    uiComponent: ActionQueue,
-    gridConfig: { colStart: 66, colEnd: 99, rowStart: 90, rowEnd: 100 },
   },
 
   // canvas

--- a/packages/client/src/app/root/components/MainWindow.tsx
+++ b/packages/client/src/app/root/components/MainWindow.tsx
@@ -11,9 +11,12 @@ import { useStream } from 'network/utils';
 export const MainWindow = observer(({ ready }: { ready: boolean }) => {
   const layers = useLayers();
 
+  // this includes the LoadingState and ActionQueue components when not ready
+  const toRender = ready ? allComponents : allComponents.slice(0, 2);
+
   return (
     <UIGrid>
-      {(ready ? allComponents : allComponents.slice(0, 1)).map((componentWithGrid) => (
+      {toRender.map((componentWithGrid) => (
         <UIComponentRenderer
           key={componentWithGrid.uiComponent.id}
           layers={layers}


### PR DESCRIPTION
action queue relies on changes to network state (loading state or new tx) to pop up.
but we cannot depend on this interaction if we wait until after state load to mount 

this is the lazy fix (just premount alongside loadingstate. should be ok for now