### PR TITLE
fix/mina-goal-removal-on-dev

### DIFF
--- a/packages/client/src/constants/dialogue/13_giftshop.ts
+++ b/packages/client/src/constants/dialogue/13_giftshop.ts
@@ -14,7 +14,7 @@ export const clock: DialogueNode = {
 
 export const mina: DialogueNode = {
   index: 132,
-  text: [LoyaltyText, `I need your help. Interested in supporting new product development?`],
+  text: [LoyaltyText, `Welcome to the gift shop.`],
   npc: {
     name: 'Mina',
     background: `   
@@ -29,17 +29,6 @@ export const mina: DialogueNode = {
     background-position: 0 0, 15px 15px;
  `,
   },
-  action: {
-    type: 'goal',
-    label: 'Support Mina',
-    input: 5,
-  },
-  args: [
-    {
-      type: 'REPUTATION',
-      index: 2,
-    },
-  ],
 };
 
 const exit: DialogueNode = {


### PR DESCRIPTION
**Removes Mina's goal prompt on Dev and adds simple flavor text instead**

- (also fixed my git setup to pr on main and to always not include previous commits)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Mina now greets players with “Welcome to the gift shop.”
* Changes
  * Removed the “Support Mina” goal/action option from the gift shop interaction.
  * Removed the associated reputation prompt tied to that option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->