### PR TITLE
add images to iconlistbutton options

### DIFF
--- a/packages/client/src/app/components/fixtures/menu/buttons/More.tsx
+++ b/packages/client/src/app/components/fixtures/menu/buttons/More.tsx
@@ -102,7 +102,7 @@ export const MoreMenuButton = () => {
       scale={4.5}
       scaleOrientation='vh'
       radius={0.9}
-      tooltipProps={{ text: ['More'] }}
+      tooltip={{ text: ['More'] }}
     />
   );
 };

--- a/packages/client/src/app/components/fixtures/menu/buttons/Sudo.tsx
+++ b/packages/client/src/app/components/fixtures/menu/buttons/Sudo.tsx
@@ -21,7 +21,7 @@ export const SudoMenuButton = () => {
       scale={4.5}
       scaleOrientation='vh'
       radius={0.9}
-      tooltipProps={{ text: ['External Apps'] }}
+      tooltip={{ text: ['External Apps'] }}
     />
   );
 };

--- a/packages/client/src/app/components/library/buttons/IconListButton.tsx
+++ b/packages/client/src/app/components/library/buttons/IconListButton.tsx
@@ -169,6 +169,10 @@ const MenuOption = styled.div<{ disabled?: boolean }>`
 
 const OptionIcon = styled.img`
   height: 2.4vw;
+  padding: 0.2vw;
+  image-rendering: pixelated;
+  image-rendering: -moz-crisp-edges;
+  image-rendering: crisp-edges;
   user-drag: none;
 `;
 

--- a/packages/client/src/app/components/library/buttons/IconListButton.tsx
+++ b/packages/client/src/app/components/library/buttons/IconListButton.tsx
@@ -181,5 +181,4 @@ const OptionText = styled.div`
 
   font-size: 0.9vw;
   line-height: 1.5vw;
-  overflow-x: scroll;
 `;

--- a/packages/client/src/app/components/library/buttons/IconListButton.tsx
+++ b/packages/client/src/app/components/library/buttons/IconListButton.tsx
@@ -18,7 +18,6 @@ export function IconListButton({
   options,
   text,
   balance,
-  disabled,
   width,
   fullWidth,
   radius,
@@ -26,21 +25,25 @@ export function IconListButton({
   scaleOrientation,
   searchable,
   icon,
-  tooltipProps,
+  tooltip,
+  disabled,
 }: {
-  img?: string;
   options: Option[];
+  searchable?: boolean;
+
+  // button
+  img?: string;
   text?: string;
-  balance?: number;
-  disabled?: boolean;
-  width?: number;
-  fullWidth?: boolean;
+  icon?: { inset?: { px?: number; x?: number; y?: number } };
   radius?: number;
   scale?: number;
   scaleOrientation?: 'vw' | 'vh';
-  searchable?: boolean;
-  icon?: { inset?: { px?: number; x?: number; y?: number } };
-  tooltipProps?: {
+  width?: number;
+  fullWidth?: boolean;
+  balance?: number;
+
+  // tooltip
+  tooltip?: {
     text: string[] | React.ReactNode[];
     title?: string;
     children?: React.ReactNode;
@@ -53,6 +56,8 @@ export function IconListButton({
     color?: string;
     fullWidth?: boolean;
   };
+
+  disabled?: boolean;
 }) {
   const toggleRef = useRef<HTMLButtonElement>(null);
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
@@ -102,8 +107,8 @@ export function IconListButton({
   };
 
   return (
-    <Popover fullWidth={fullWidth} content={OptionsMap()} disabled={disabled}>
-      <TextTooltip {...tooltipProps} text={tooltipProps?.text ?? ['']}>
+    <Popover content={OptionsMap()} maxHeight={33} fullWidth={fullWidth} disabled={disabled}>
+      <TextTooltip {...tooltip} text={tooltip?.text ?? ['']}>
         <IconButton
           img={img}
           text={text}
@@ -168,11 +173,9 @@ const MenuOption = styled.div<{ disabled?: boolean }>`
 `;
 
 const OptionIcon = styled.img`
-  height: 2.4vw;
-  padding: 0.2vw;
-  image-rendering: pixelated;
-  image-rendering: -moz-crisp-edges;
-  image-rendering: crisp-edges;
+  border-radius: 0.3vw;
+  height: 1.8vw;
+  margin: 0.3vw;
   user-drag: none;
 `;
 

--- a/packages/client/src/app/components/library/buttons/IconListButton.tsx
+++ b/packages/client/src/app/components/library/buttons/IconListButton.tsx
@@ -154,18 +154,21 @@ const MenuOption = styled.div<{ disabled?: boolean }>`
   position: relative;
   background-color: ${({ disabled }) => (disabled ? '#bbb' : '#fff')};
   border-radius: 0.45vw;
+
   width: 100%;
-  padding: 0.3vw;
+  padding: 0.45vw;
+  gap: 0.6vw;
 
   display: flex;
   align-items: center;
-  gap: 0.45vw;
 
   cursor: ${({ disabled }) => (disabled ? 'none' : 'pointer')};
   pointer-events: ${({ disabled }) => (disabled ? 'none' : 'auto')};
 
   &:hover {
     background-color: #ddd;
+    outline: 0.15vw solid black;
+    z-index: 1;
   }
   &:active {
     background-color: #bbb;
@@ -175,7 +178,6 @@ const MenuOption = styled.div<{ disabled?: boolean }>`
 const OptionIcon = styled.img`
   border-radius: 0.3vw;
   height: 1.8vw;
-  margin: 0.3vw;
   user-drag: none;
 `;
 
@@ -183,7 +185,7 @@ const OptionText = styled.div`
   height: 100%;
 
   display: flex;
-  justify-content: left;
+  justify-content: flex-start;
   align-items: center;
 
   font-size: 0.9vw;

--- a/packages/client/src/app/components/library/buttons/IconListButton.tsx
+++ b/packages/client/src/app/components/library/buttons/IconListButton.tsx
@@ -30,7 +30,6 @@ export function IconListButton({
 }: {
   img?: string;
   options: Option[];
-
   text?: string;
   balance?: number;
   disabled?: boolean;
@@ -94,8 +93,8 @@ export function IconListButton({
           .filter((option) => !searchable || option.text.toLowerCase().includes(search))
           .map((option, i) => (
             <MenuOption key={i} disabled={option.disabled} onClick={() => onSelect(option)}>
-              {option.image && <MenuIcon src={option.image} />}
-              {option.text}
+              {option.image && <OptionIcon src={option.image} />}
+              {option.text && <OptionText>{option.text}</OptionText>}
             </MenuOption>
           ))}
       </MenuWrapper>
@@ -124,31 +123,9 @@ export function IconListButton({
   );
 }
 
-const MenuOption = styled.div<{ disabled?: boolean }>`
-  display: flex;
-  align-items: center;
-  gap: 0.4vw;
-
-  border-radius: 0.4vw;
-  padding: 0.6vw;
-  justify-content: left;
-  font-size: 0.8vw;
-
-  cursor: ${({ disabled }) => (disabled ? 'none' : 'pointer')};
-  pointer-events: ${({ disabled }) => (disabled ? 'none' : 'auto')};
-  background-color: ${({ disabled }) => (disabled ? '#bbb' : '#fff')};
-
-  &:hover {
-    background-color: #ddd;
-  }
-  &:active {
-    background-color: #bbb;
-  }
-`;
-
-const MenuIcon = styled.img`
-  height: 1.4vw;
-  user-drag: none;
+const MenuWrapper = styled.div`
+  position: relative;
+  max-width: 30vw;
 `;
 
 const MenuInput = styled.input`
@@ -168,6 +145,41 @@ const MenuInput = styled.input`
   font-size: 0.75vw;
 `;
 
-const MenuWrapper = styled.div`
+const MenuOption = styled.div<{ disabled?: boolean }>`
   position: relative;
+  background-color: ${({ disabled }) => (disabled ? '#bbb' : '#fff')};
+  border-radius: 0.45vw;
+  width: 100%;
+  padding: 0.3vw;
+
+  display: flex;
+  align-items: center;
+  gap: 0.45vw;
+
+  cursor: ${({ disabled }) => (disabled ? 'none' : 'pointer')};
+  pointer-events: ${({ disabled }) => (disabled ? 'none' : 'auto')};
+
+  &:hover {
+    background-color: #ddd;
+  }
+  &:active {
+    background-color: #bbb;
+  }
+`;
+
+const OptionIcon = styled.img`
+  height: 2.4vw;
+  user-drag: none;
+`;
+
+const OptionText = styled.div`
+  height: 100%;
+
+  display: flex;
+  justify-content: left;
+  align-items: center;
+
+  font-size: 0.9vw;
+  line-height: 1.5vw;
+  overflow-x: scroll;
 `;

--- a/packages/client/src/app/components/library/buttons/IconListButton.tsx
+++ b/packages/client/src/app/components/library/buttons/IconListButton.tsx
@@ -166,8 +166,9 @@ const MenuOption = styled.div<{ disabled?: boolean }>`
   pointer-events: ${({ disabled }) => (disabled ? 'none' : 'auto')};
 
   &:hover {
+    background-color: #7d7;
     background-color: #ddd;
-    outline: 0.15vw solid black;
+    outline: 0.15vw solid #444;
     z-index: 1;
   }
   &:active {

--- a/packages/client/src/app/components/library/buttons/actions/HarvestButton.tsx
+++ b/packages/client/src/app/components/library/buttons/actions/HarvestButton.tsx
@@ -48,7 +48,7 @@ export const HarvestButton = ({
       img={HarvestIcon}
       options={options}
       disabled={disabled}
-      tooltipProps={{ text: [tooltip] }}
+      tooltip={{ text: [tooltip] }}
     />
   );
 };

--- a/packages/client/src/app/components/library/buttons/actions/LiquidateButton.tsx
+++ b/packages/client/src/app/components/library/buttons/actions/LiquidateButton.tsx
@@ -31,7 +31,7 @@ export const LiquidateButton = (
       img={LiquidateIcon}
       options={actionOptions}
       disabled={actionOptions.length == 0}
-      tooltipProps={{ text: [tooltipText] }}
+      tooltip={{ text: [tooltipText] }}
       width={width}
       icon={{ inset: { x: 2 } }}
     />

--- a/packages/client/src/app/components/library/buttons/actions/LiquidateButton.tsx
+++ b/packages/client/src/app/components/library/buttons/actions/LiquidateButton.tsx
@@ -18,6 +18,7 @@ export const LiquidateButton = (
     const recoil = calcLiqRecoil(myKami, target);
 
     return {
+      image: myKami.image,
       text: `${myKami.name} (+${spoils}MUSU; -${recoil}HP)`,
       onClick: () => triggerAction(myKami, target),
     };

--- a/packages/client/src/app/components/library/buttons/actions/UseItemButton.tsx
+++ b/packages/client/src/app/components/library/buttons/actions/UseItemButton.tsx
@@ -38,7 +38,7 @@ export const UseItemButton = (
   let disabled = !!tooltip;
   if (!disabled) {
     tooltip = `Feed Kami`;
-    options = getOptions(world, components, kami, account, triggerAction);
+    options = getOptions(world, components, kami, account, triggerAction, false);
     if (options.length === 0) {
       tooltip = `No items to feed`;
       disabled = true;
@@ -76,7 +76,8 @@ const getOptions = (
   components: Components,
   kami: Kami,
   account: Account,
-  triggerAction: Function
+  triggerAction: Function,
+  showEffects?: boolean
 ) => {
   let inventories = account.inventories ?? [];
   inventories = cleanInventories(inventories);
@@ -86,7 +87,7 @@ const getOptions = (
   );
 
   const options = inventories.map((inv: Inventory) => {
-    return getOption(world, components, kami, inv, triggerAction);
+    return getOption(world, components, kami, inv, triggerAction, showEffects);
   });
 
   return options.filter((option) => !!option.text);
@@ -99,13 +100,17 @@ const getOption = (
   components: Components,
   kami: Kami,
   inv: Inventory,
-  triggerAction: Function
+  triggerAction: Function,
+  showEffects?: boolean
 ) => {
+  let text = `${inv.item.name} `;
   // its not querying use correctly!
-  const effectsText = parseAllos(world, components, inv.item.effects.use)
-    .map((entry) => `${entry.description}`)
-    .join(', ');
-  const text = `${inv.item.name} (${effectsText})`;
+  if (!!showEffects) {
+    const effectsText = parseAllos(world, components, inv.item.effects.use)
+      .map((entry) => `${entry.description}`)
+      .join(', ');
+    text = `${text} (${effectsText})`;
+  }
 
   // const canEat = () => passesConditions(world, components, inv.item.requirements.use, kami);
 

--- a/packages/client/src/app/components/library/buttons/actions/UseItemButton.tsx
+++ b/packages/client/src/app/components/library/buttons/actions/UseItemButton.tsx
@@ -51,7 +51,7 @@ export const UseItemButton = (
       img={icon}
       options={options}
       disabled={disabled}
-      tooltipProps={{ text: [tooltip] }}
+      tooltip={{ text: [tooltip] }}
       width={width}
       icon={{ inset: { x: iconInsetXpx, y: iconInsetYpx } }}
     />

--- a/packages/client/src/app/components/library/poppers/Popover.tsx
+++ b/packages/client/src/app/components/library/poppers/Popover.tsx
@@ -185,7 +185,7 @@ const PopoverContent = styled.div<{
 
   background-color: white;
   border: 0.15vw solid black;
-  border-radius: 0.45vw;
+  border-radius: 0.75vw;
   z-index: 10;
   white-space: nowrap;
   max-width: fit-content;

--- a/packages/client/src/app/components/library/poppers/Popover.tsx
+++ b/packages/client/src/app/components/library/poppers/Popover.tsx
@@ -189,6 +189,9 @@ const PopoverContent = styled.div<{
   font-size: 0.6vw;
   top: ${({ popoverPosition }) => popoverPosition.y};
   left: ${({ popoverPosition }) => popoverPosition.x};
+  white-space: normal;
+  overflow-wrap: break-word;
+  word-break: break-word;
   ::-webkit-scrollbar {
     background: transparent;
     width: 0.9vw;

--- a/packages/client/src/app/components/library/poppers/Popover.tsx
+++ b/packages/client/src/app/components/library/poppers/Popover.tsx
@@ -191,7 +191,6 @@ const PopoverContent = styled.div<{
   left: ${({ popoverPosition }) => popoverPosition.x};
   white-space: normal;
   overflow-wrap: break-word;
-  word-break: break-word;
   ::-webkit-scrollbar {
     background: transparent;
     width: 0.9vw;

--- a/packages/client/src/app/components/library/poppers/Popover.tsx
+++ b/packages/client/src/app/components/library/poppers/Popover.tsx
@@ -13,6 +13,7 @@ export const Popover = ({
   forceClose,
   disabled,
   fullWidth,
+  maxHeight,
 }: {
   children: React.ReactNode;
   content: any;
@@ -23,6 +24,7 @@ export const Popover = ({
   forceClose?: boolean; // forceclose the popover
   disabled?: boolean; // disable the popover
   fullWidth?: boolean;
+  maxHeight?: number;
 }) => {
   const popoverRef = useRef<HTMLDivElement>(document.createElement('div'));
   const triggerRef = useRef<HTMLDivElement>(null);
@@ -142,6 +144,7 @@ export const Popover = ({
         isVisible={isVisible}
         ref={popoverRef}
         popoverPosition={popoverPosition}
+        maxHeight={maxHeight}
         onClick={(e) => {
           if (disabled) return;
           handleClick(e);
@@ -170,11 +173,11 @@ const PopoverTrigger = styled.div<{ cursor: string }>`
 
 const PopoverContent = styled.div<{
   position?: string[];
-  dimensions?: any;
   isVisible?: boolean;
   popoverPosition: any;
+  maxHeight?: number;
 }>`
-  max-height: 22vh;
+  max-height: ${({ maxHeight }) => maxHeight ?? 22}vh;
   overflow-y: auto;
   overflow-x: hidden;
   visibility: ${({ isVisible }) => (isVisible ? `visible` : `hidden`)};

--- a/packages/client/src/app/components/modals/inventory/items/ItemGrid.tsx
+++ b/packages/client/src/app/components/modals/inventory/items/ItemGrid.tsx
@@ -127,7 +127,7 @@ export const ItemGrid = ({
               balance={inv.balance}
               options={options}
               disabled={options.length == 0}
-              tooltipProps={{
+              tooltip={{
                 text: [<ItemGridTooltip key={item.index} item={item} utils={utils} />],
                 maxWidth: 25,
               }}

--- a/packages/client/src/app/components/modals/inventory/items/ItemGrid.tsx
+++ b/packages/client/src/app/components/modals/inventory/items/ItemGrid.tsx
@@ -77,6 +77,7 @@ export const ItemGrid = ({
     const available = kamis.filter((kami) => meetsRequirements(kami, item));
     return available.map((kami) => ({
       text: kami.name,
+      image: kami.image,
       onClick: () => useForKami(kami, item),
     }));
   };

--- a/packages/client/src/app/components/modals/inventory/transfer/LineItem.tsx
+++ b/packages/client/src/app/components/modals/inventory/transfer/LineItem.tsx
@@ -35,7 +35,7 @@ export const LineItem = ({
         scale={2.7}
         options={options}
         searchable
-        tooltipProps={{ text: [selected.description] }}
+        tooltip={{ text: [selected.description] }}
       />
 
       {!reverse && (

--- a/packages/client/src/app/components/modals/inventory/transfer/Transfer.tsx
+++ b/packages/client/src/app/components/modals/inventory/transfer/Transfer.tsx
@@ -224,7 +224,7 @@ export const Transfer = ({
           }))}
           searchable
           scale={2.8}
-          tooltipProps={{ text: [`Send ${item.name} to another account.`] }}
+          tooltip={{ text: [`Send ${item.name} to another account.`] }}
         />
       </Top>
       <Bottom>

--- a/packages/client/src/app/components/modals/node/header/Header.tsx
+++ b/packages/client/src/app/components/modals/node/header/Header.tsx
@@ -113,7 +113,7 @@ export const Header = ({
   const AddButton = (kamis: Kami[]) => {
     const options = kamis.filter((kami) => canAdd(kami));
     const actionOptions = options.map((kami) => {
-      return { text: `${kami.name}`, onClick: () => addKami(kami) };
+      return { text: `${kami.name}`, image: kami.image, onClick: () => addKami(kami) };
     });
 
     return (

--- a/packages/client/src/app/components/modals/node/header/Header.tsx
+++ b/packages/client/src/app/components/modals/node/header/Header.tsx
@@ -124,7 +124,7 @@ export const Header = ({
         text='Add Kami to Node'
         disabled={options.length == 0 || account.roomIndex !== node.roomIndex}
         fullWidth
-        tooltipProps={{ text: [getDisabledReason(kamis)], grow: true }}
+        tooltip={{ text: [getDisabledReason(kamis)], grow: true }}
       />
     );
   };

--- a/packages/client/src/app/components/modals/party/KamisExternal.tsx
+++ b/packages/client/src/app/components/modals/party/KamisExternal.tsx
@@ -102,7 +102,7 @@ export const KamisExternal = ({
         img={ArrowIcons.right}
         options={options}
         searchable
-        tooltipProps={{ text: getSendTooltip(kami) }}
+        tooltip={{ text: getSendTooltip(kami) }}
       />
     );
   };

--- a/packages/client/src/app/components/modals/trading/management/create/LineItem.tsx
+++ b/packages/client/src/app/components/modals/trading/management/create/LineItem.tsx
@@ -35,7 +35,7 @@ export const LineItem = ({
         scale={2.7}
         options={options}
         searchable
-        tooltipProps={{ text: [selected.description] }}
+        tooltip={{ text: [selected.description] }}
       />
 
       {!reverse && (


### PR DESCRIPTION
QoL improvement imo
- enlarge `IconListButton` menu images to better support kami images
- (attempt to) strike a balance in the padding for plaintext options vs imaged options
- limit the width to `30vw`. strictly the text portion of an option horizontally scrolls on overflow
- apply this for 
  - item options in party modal
  - kami options in the inventory modal
  - kami options in the node modal (for starting and liquidating)
 
concerns
- might look weird on computers that have auto-render scroll bar enabled 

<img width="575" height="497" alt="Screenshot 2025-08-28 at 4 37 06 AM" src="https://github.com/user-attachments/assets/c658d4d1-f1de-472b-8b33-2f135116267d" />
<img width="813" height="472" alt="Screenshot 2025-08-28 at 4 37 38 AM" src="https://github.com/user-attachments/assets/cc0f19af-a303-4aca-a140-201862afb255" />
<img width="676" height="396" alt="Screenshot 2025-08-28 at 4 44 59 AM" src="https://github.com/user-attachments/assets/c10f73c7-862e-4a8e-a023-14f2dd091ff6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Action menus now show icons next to option text where available.

- Improvements
  - Popovers support configurable max height and allow text wrapping/breaking for readability.
  - Disabled-state visuals, spacing, and alignment in option lists improved for clarity and clickability.
  - Popover corners are more rounded for a sleeker look.
  - Tooltips standardized across buttons (behavior unchanged).
  - Item-use options can include effect details but remain hidden by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->