### PR TITLE
check which mouse button got clicked

### DIFF
--- a/packages/client/src/app/components/library/poppers/Popover.tsx
+++ b/packages/client/src/app/components/library/poppers/Popover.tsx
@@ -1,11 +1,13 @@
-import { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
+
+import { mouseBttnClicked } from 'app/utils';
 
 export const Popover = ({
   children,
   content,
   cursor = 'pointer',
-  mouseButton = 0,
+  mouseButton = 'left',
   closeOnClick = true,
   onClose,
   forceClose,
@@ -14,7 +16,7 @@ export const Popover = ({
   children: React.ReactNode;
   content: any;
   cursor?: string;
-  mouseButton?: 0 | 2;
+  mouseButton?: 'left' | 'right';
   closeOnClick?: boolean;
   onClose?: () => void; // execute a function when the popover closes
   forceClose?: boolean; // forceclose the popover
@@ -122,12 +124,12 @@ export const Popover = ({
   };
 
   return (
-    <PopoverContainer onContextMenu={(e) => mouseButton === 2 && e.preventDefault()}>
+    <PopoverContainer>
       <PopoverTrigger
         cursor={cursor}
         ref={triggerRef}
         onMouseDown={(e) => {
-          if (disabled || content.length === 0 || e.button !== mouseButton) return;
+          if (disabled || content.length === 0 || mouseBttnClicked(e) !== mouseButton) return;
           handlePosition();
           setIsVisible(!isVisible);
         }}

--- a/packages/client/src/app/components/modals/chat/feed/Message.tsx
+++ b/packages/client/src/app/components/modals/chat/feed/Message.tsx
@@ -14,13 +14,8 @@ import { ActionSystem } from 'network/systems';
 
 export const Message = ({
   previousEqual,
-  utils: {
-    getAccount,
-    getEntityIndex
-  },
-  data: {
-    message,
-  },
+  utils: { getAccount, getEntityIndex },
+  data: { message },
   player,
   actionSystem,
   api,
@@ -118,7 +113,7 @@ export const Message = ({
             {player.id != getAccountFunc().id ? (
               <>
                 <PfpAuthor id='pfp-author' ref={pfpRef}>
-                  <Popover content={optionsMap()} mouseButton={2}>
+                  <Popover content={optionsMap()} mouseButton={'right'}>
                     <Pfp
                       author={false}
                       onClick={() => {

--- a/packages/client/src/app/utils.ts
+++ b/packages/client/src/app/utils.ts
@@ -1,7 +1,30 @@
+import React from 'react';
+
 import { playClick } from 'utils/sounds';
 
 // copy a string to clipboard
 export const copy = (str: string) => {
   playClick();
   navigator.clipboard.writeText(str);
+};
+
+// returns which mouse button was clicked
+export const mouseBttnClicked = (e: React.MouseEvent<HTMLDivElement>): string => {
+  switch (e.button) {
+    case 0:
+      return 'left';
+    case 1:
+      return 'middle';
+    case 2:
+      document.addEventListener('contextmenu', (contextEvent) => contextEvent.preventDefault(), {
+        once: true,
+      });
+      return 'right';
+    case 3:
+      return 'back';
+    case 4:
+      return 'forward';
+    default:
+      return 'unknown';
+  }
 };


### PR DESCRIPTION
```is it easy enough to capture right-clicks on the UI and display our own options for specific buttons?```

the func in this pr will return which button was clicked, use it inside a components onMouseDown property (not onClick, that one only triggers on left click)

updated Popover to use it :
<img width="811" height="264" alt="image" src="https://github.com/user-attachments/assets/45b89b5e-3443-450b-ba4a-4578abd3716e" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Popovers can be configured to trigger explicitly on left or right clicks.
  * Added a utility to detect which mouse button was clicked to standardize click handling.

* **Bug Fixes**
  * Right-click popovers open reliably without showing the browser context menu.

* **Refactor**
  * Component prop handling streamlined; message UI updated to use the explicit right-click trigger.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->