### PR TITLE
fix excessive re-renders on account modal (party + social tabs) and Kami modal 

### DIFF
--- a/packages/client/src/app/components/fixtures/menu/buttons/Account.tsx
+++ b/packages/client/src/app/components/fixtures/menu/buttons/Account.tsx
@@ -3,8 +3,8 @@ import { OperatorIcon } from 'assets/images/icons/menu';
 import { MenuButton } from './MenuButton';
 
 export const AccountMenuButton = () => {
-  const { setAccount } = useSelected();
-  const { account } = useAccount();
+  const setAccount = useSelected((s) => s.setAccount);
+  const accountIndex = useAccount((s) => s.account.index);
 
   const modalsToHide: Partial<Modals> = {
     bridgeERC20: false,
@@ -26,7 +26,7 @@ export const AccountMenuButton = () => {
       tooltip={`Account`}
       targetModal='account'
       hideModals={modalsToHide}
-      onClick={() => setAccount(account.index)}
+      onClick={() => setAccount(accountIndex)}
     />
   );
 };

--- a/packages/client/src/app/components/fixtures/menu/buttons/Node.tsx
+++ b/packages/client/src/app/components/fixtures/menu/buttons/Node.tsx
@@ -7,7 +7,8 @@ export const NodeMenuButton = ({
 }: {
   disabled?: boolean
 }) => {
-  const { roomIndex, setNode } = useSelected(); // roomIndex == nodeIndex
+  const roomIndex = useSelected((s) => s.roomIndex); // roomIndex == nodeIndex
+  const setNode = useSelected((s) => s.setNode);
 
   const modalsToHide: Partial<Modals> = {
     goal: false,

--- a/packages/client/src/app/components/library/cards/AccountCard/AccountCard.tsx
+++ b/packages/client/src/app/components/library/cards/AccountCard/AccountCard.tsx
@@ -25,7 +25,7 @@ export const AccountCard = ({
   actions?: React.ReactNode;
 }) => {
   const { modals, setModals } = useVisibility();
-  const { setAccount } = useSelected();
+  const setAccount = useSelected((s) => s.setAccount);
 
   // ticking
   const [_, setLastRefresh] = useState(Date.now());

--- a/packages/client/src/app/components/modals/account/party/Kamis.tsx
+++ b/packages/client/src/app/components/modals/account/party/Kamis.tsx
@@ -21,7 +21,8 @@ export const Kamis = ({
   const { getAccountKamis } = utils;
 
   const { modals, setModals } = useVisibility();
-  const { kamiIndex, setKami } = useSelected();
+  const kamiIndex = useSelected((s) => s.kamiIndex);
+  const setKami = useSelected((s) => s.setKami);
   const [kamis, setKamis] = useState<Kami[]>([]);
 
   useEffect(() => {

--- a/packages/client/src/app/components/modals/kami/Kami.tsx
+++ b/packages/client/src/app/components/modals/kami/Kami.tsx
@@ -89,7 +89,7 @@ export const KamiModal: UIComponent = {
     const { actions, api } = network;
     const { account, onyxItem, spender } = data;
     const { getKami, getOwner, queryKamiByIndex, getSkillUpgradeError, getTreePoints } = utils;
-    const { kamiIndex } = useSelected();
+    const kamiIndex = useSelected((s) => s.kamiIndex);
     const { selectedAddress, apis: ownerAPIs } = useNetwork();
     const { modals } = useVisibility();
 

--- a/packages/client/src/app/components/modals/kami/battles/AdversaryColumn.tsx
+++ b/packages/client/src/app/components/modals/kami/battles/AdversaryColumn.tsx
@@ -17,7 +17,7 @@ export const AdversaryColumn = ({
   };
 }) => {
   const { getKamiByID } = utils;
-  const { setKami } = useSelected();
+  const setKami = useSelected((s) => s.setKami);
 
   const selectKami = (index: number) => {
     setKami(index);

--- a/packages/client/src/app/components/modals/kami/battles/LocationColumn.tsx
+++ b/packages/client/src/app/components/modals/kami/battles/LocationColumn.tsx
@@ -19,7 +19,7 @@ export const LocationColumn = ({
   };
 }) => {
   const { getNodeByIndex } = utils;
-  const { setNode } = useSelected();
+  const setNode = useSelected((s) => s.setNode);
   const { setModals } = useVisibility();
 
   const showNode = (node: Node) => {

--- a/packages/client/src/app/components/modals/kami/battles/OwnerColumn.tsx
+++ b/packages/client/src/app/components/modals/kami/battles/OwnerColumn.tsx
@@ -19,7 +19,8 @@ export const OwnerColumn = ({
   };
 }) => {
   const { getAccountByID, getKamiByID, getOwner } = utils;
-  const { accountIndex, setAccount } = useSelected();
+  const accountIndex = useSelected((s) => s.accountIndex);
+  const setAccount = useSelected((s) => s.setAccount);
   const { modals, setModals } = useVisibility();
 
   const selectAccount = (index: number) => {

--- a/packages/client/src/app/components/modals/kami/header/Header.tsx
+++ b/packages/client/src/app/components/modals/kami/header/Header.tsx
@@ -31,7 +31,7 @@ export const Header = ({
   };
 }) => {
   const { account, kami, owner } = data;
-  const { setAccount } = useSelected();
+  const setAccount = useSelected((s) => s.setAccount);
   const { setModals } = useVisibility();
 
   const isMine = () => {

--- a/packages/client/src/app/components/modals/kami/header/KamiImage.tsx
+++ b/packages/client/src/app/components/modals/kami/header/KamiImage.tsx
@@ -33,7 +33,7 @@ export const KamiImage = ({
   const { levelUp } = actions;
   const { account, kami, owner } = data;
   const { calcExpRequirement } = utils;
-  const { setKami } = useSelected();
+  const setKami = useSelected((s) => s.setKami);
   const { modals } = useVisibility();
 
   const [isSearching, setIsSearching] = useState(false);


### PR DESCRIPTION
- continuation of PR https://github.com/Asphodel-OS/kamigotchi/pull/1986
- Before vs After 
	- 	yellow outline indicate constant re-renders 

https://github.com/user-attachments/assets/985499f7-a6c0-4881-866e-dfce575d65ac

- TODO: kami party, map, node 
	- will be creating additional PR(s) for the TODOs ( don't want to change to many files within a single PR) 