### PR TITLE
Show tooltip on IconList trigger, not on the whole popover

### DIFF
--- a/packages/client/src/app/components/fixtures/menu/buttons/More.tsx
+++ b/packages/client/src/app/components/fixtures/menu/buttons/More.tsx
@@ -1,7 +1,7 @@
 import { usePrivy } from '@privy-io/react-auth';
 import { useEffect, useState } from 'react';
 
-import { IconListButton, TextTooltip } from 'app/components/library';
+import { IconListButton } from 'app/components/library';
 import { useVisibility } from 'app/stores';
 import { LogoutIcon } from 'assets/images/icons/actions';
 import { HelpIcon, MoreIcon, ResetIcon, SettingsIcon } from 'assets/images/icons/menu';
@@ -91,19 +91,18 @@ export const MoreMenuButton = () => {
   };
 
   return (
-    <TextTooltip text={['More']}>
-      <IconListButton
-        img={MoreIcon}
-        options={[
-          { text: 'Settings', disabled, image: SettingsIcon, onClick: toggleSettings },
-          { text: 'Help', image: HelpIcon, onClick: toggleHelp },
-          { text: 'Reset State', image: ResetIcon, onClick: handleResetState },
-          { text: 'Logout', disabled, image: LogoutIcon, onClick: handleLogout },
-        ]}
-        scale={4.5}
-        scaleOrientation='vh'
-        radius={0.9}
-      />
-    </TextTooltip>
+    <IconListButton
+      img={MoreIcon}
+      options={[
+        { text: 'Settings', disabled, image: SettingsIcon, onClick: toggleSettings },
+        { text: 'Help', image: HelpIcon, onClick: toggleHelp },
+        { text: 'Reset State', image: ResetIcon, onClick: handleResetState },
+        { text: 'Logout', disabled, image: LogoutIcon, onClick: handleLogout },
+      ]}
+      scale={4.5}
+      scaleOrientation='vh'
+      radius={0.9}
+      tooltipProps={{ text: ['More'] }}
+    />
   );
 };

--- a/packages/client/src/app/components/library/buttons/IconListButton.tsx
+++ b/packages/client/src/app/components/library/buttons/IconListButton.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from 'react';
 import styled from 'styled-components';
 
 import { playClick } from 'utils/sounds';
+import { TextTooltip } from '../poppers';
 import { Popover } from '../poppers/Popover';
 import { IconButton } from './IconButton';
 
@@ -25,6 +26,7 @@ export function IconListButton({
   scaleOrientation,
   searchable,
   icon,
+  tooltipProps,
 }: {
   img: string;
   options: Option[];
@@ -37,9 +39,21 @@ export function IconListButton({
   radius?: number;
   scale?: number;
   scaleOrientation?: 'vw' | 'vh';
-
   searchable?: boolean;
   icon?: { inset?: { px?: number; x?: number; y?: number } };
+  tooltipProps?: {
+    text: string[] | React.ReactNode[];
+    title?: string;
+    children?: React.ReactNode;
+    grow?: boolean;
+    direction?: 'row' | 'column';
+    delay?: number;
+    maxWidth?: number;
+    size?: number;
+    alignText?: 'left' | 'right' | 'center';
+    color?: string;
+    fullWidth?: boolean;
+  };
 }) {
   const toggleRef = useRef<HTMLButtonElement>(null);
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
@@ -89,21 +103,23 @@ export function IconListButton({
   };
 
   return (
-    <Popover content={OptionsMap()}>
-      <IconButton
-        img={img}
-        text={text}
-        onClick={handleOpen}
-        disabled={disabled}
-        radius={radius ?? 0.45}
-        scale={scale ?? 2.5}
-        scaleOrientation={scaleOrientation ?? 'vw'}
-        width={width}
-        fullWidth={fullWidth}
-        balance={balance}
-        corner={!balance}
-        icon={icon}
-      />
+    <Popover fullWidth={fullWidth} content={OptionsMap()} disabled={disabled}>
+      <TextTooltip {...tooltipProps} text={tooltipProps?.text ?? ['']}>
+        <IconButton
+          img={img}
+          text={text}
+          onClick={handleOpen}
+          disabled={disabled}
+          radius={radius ?? 0.45}
+          scale={scale ?? 2.5}
+          scaleOrientation={scaleOrientation ?? 'vw'}
+          width={width}
+          fullWidth={fullWidth}
+          balance={balance}
+          corner={!balance}
+          icon={icon}
+        />
+      </TextTooltip>
     </Popover>
   );
 }

--- a/packages/client/src/app/components/library/buttons/actions/HarvestButton.tsx
+++ b/packages/client/src/app/components/library/buttons/actions/HarvestButton.tsx
@@ -4,7 +4,6 @@ import { HarvestIcon, StopIcon } from 'assets/images/icons/actions';
 import { NetworkLayer } from 'network/create';
 import { Account } from 'network/shapes/Account';
 import { Node, passesNodeReqs } from 'network/shapes/Node';
-import { TextTooltip } from '../..';
 
 // if resting
 // - always display
@@ -34,7 +33,6 @@ export const HarvestButton = ({
   kami: Kami;
   node: Node;
 }) => {
-
   let options: IconListButtonOption[] = [];
   let tooltip = getDisabledTooltip(network, account, kami, node);
 
@@ -45,9 +43,13 @@ export const HarvestButton = ({
   }
 
   return (
-    <TextTooltip key='harvest-tooltip' text={[tooltip]}>
-      <IconListButton img={HarvestIcon} options={options} disabled={disabled} />
-    </TextTooltip>
+    <IconListButton
+      key='harvest-tooltip'
+      img={HarvestIcon}
+      options={options}
+      disabled={disabled}
+      tooltipProps={{ text: [tooltip] }}
+    />
   );
 };
 

--- a/packages/client/src/app/components/library/buttons/actions/LiquidateButton.tsx
+++ b/packages/client/src/app/components/library/buttons/actions/LiquidateButton.tsx
@@ -3,7 +3,6 @@ import { calcLiqRecoil, calcLiqSpoils } from 'app/cache/kami/calcs';
 import { IconListButton } from 'app/components/library';
 import { LiquidateIcon } from 'assets/images/icons/actions';
 import { Kami } from 'network/shapes/Kami';
-import { TextTooltip } from '../..';
 
 // button for liquidating a harvest
 // TODO: clean this up
@@ -26,16 +25,15 @@ export const LiquidateButton = (
 
   let tooltipText = getLiquidateTooltip(target, allies);
   return (
-    <TextTooltip key='liquidate-tooltip' text={[tooltipText]}>
-      <IconListButton
-        key='liquidate-button'
-        img={LiquidateIcon}
-        options={actionOptions}
-        disabled={actionOptions.length == 0}
-        width={width}
-        icon={{ inset: { x: 2 } }}
-      />
-    </TextTooltip>
+    <IconListButton
+      key='liquidate-button'
+      img={LiquidateIcon}
+      options={actionOptions}
+      disabled={actionOptions.length == 0}
+      tooltipProps={{ text: [tooltipText] }}
+      width={width}
+      icon={{ inset: { x: 2 } }}
+    />
   );
 };
 

--- a/packages/client/src/app/components/library/buttons/actions/UseItemButton.tsx
+++ b/packages/client/src/app/components/library/buttons/actions/UseItemButton.tsx
@@ -1,7 +1,6 @@
 import { World } from '@mud-classic/recs';
 import { cleanInventories, filterInventories, Inventory } from 'app/cache/inventory';
 import { calcCooldown, isHarvesting, Kami } from 'app/cache/kami';
-import { TextTooltip } from 'app/components/library';
 import { Components } from 'network/components';
 import { NetworkLayer } from 'network/create';
 import { Account } from 'network/shapes/Account';
@@ -47,15 +46,15 @@ export const UseItemButton = (
   }
 
   return (
-    <TextTooltip key='feed-tooltip' text={[tooltip]}>
-      <IconListButton
-        img={icon}
-        options={options}
-        disabled={disabled}
-        width={width}
-        icon={{ inset: { x: iconInsetXpx, y: iconInsetYpx } }}
-      />
-    </TextTooltip>
+    <IconListButton
+      key='feed-tooltip'
+      img={icon}
+      options={options}
+      disabled={disabled}
+      tooltipProps={{ text: [tooltip] }}
+      width={width}
+      icon={{ inset: { x: iconInsetXpx, y: iconInsetYpx } }}
+    />
   );
 };
 

--- a/packages/client/src/app/components/library/poppers/Popover.tsx
+++ b/packages/client/src/app/components/library/poppers/Popover.tsx
@@ -12,6 +12,7 @@ export const Popover = ({
   onClose,
   forceClose,
   disabled,
+  fullWidth,
 }: {
   children: React.ReactNode;
   content: any;
@@ -21,6 +22,7 @@ export const Popover = ({
   onClose?: () => void; // execute a function when the popover closes
   forceClose?: boolean; // forceclose the popover
   disabled?: boolean; // disable the popover
+  fullWidth?: boolean;
 }) => {
   const popoverRef = useRef<HTMLDivElement>(document.createElement('div'));
   const triggerRef = useRef<HTMLDivElement>(null);
@@ -124,7 +126,7 @@ export const Popover = ({
   };
 
   return (
-    <PopoverContainer>
+    <PopoverContainer $fullwidth={fullWidth}>
       <PopoverTrigger
         cursor={cursor}
         ref={triggerRef}
@@ -153,9 +155,10 @@ export const Popover = ({
   );
 };
 
-const PopoverContainer = styled.div`
+const PopoverContainer = styled.div<{ $fullwidth?: boolean }>`
   display: flex;
   position: relative;
+  ${({ $fullwidth }) => $fullwidth && 'width: 100%;'}
 `;
 
 const PopoverTrigger = styled.div<{ cursor: string }>`

--- a/packages/client/src/app/components/library/poppers/TextTooltip.tsx
+++ b/packages/client/src/app/components/library/poppers/TextTooltip.tsx
@@ -60,7 +60,7 @@ export const TextTooltip = ({
   );
 };
 
-const Text = styled.div<{ size: number; align: string }>`
+const Text = styled.div<{ size: number; align?: string }>`
   font-size: ${({ size }) => size}vw;
   line-height: ${({ size }) => size * 1.8}vw;
   text-align: ${({ align }) => align};

--- a/packages/client/src/app/components/library/poppers/TextTooltip.tsx
+++ b/packages/client/src/app/components/library/poppers/TextTooltip.tsx
@@ -46,7 +46,11 @@ export const TextTooltip = ({
       isDisabled={text.every((entry) => entry === '' || entry === null)}
       content={
         <>
-          {title && <Text size={textSize * 1.35}>{title}</Text>}
+          {title && (
+            <Text size={textSize * 1.35} align={alignText}>
+              {title}
+            </Text>
+          )}
           {text.map((line, idx) => (
             <Text key={idx} size={textSize} align={alignText}>
               {line}
@@ -63,7 +67,7 @@ export const TextTooltip = ({
 const Text = styled.div<{ size: number; align?: string }>`
   font-size: ${({ size }) => size}vw;
   line-height: ${({ size }) => size * 1.8}vw;
-  text-align: ${({ align }) => align};
+  text-align: ${({ align }) => align ?? 'center'};
   white-space: pre-line;
   img {
     vertical-align: middle;

--- a/packages/client/src/app/components/library/poppers/Tooltip.tsx
+++ b/packages/client/src/app/components/library/poppers/Tooltip.tsx
@@ -81,7 +81,7 @@ export const Tooltip = ({
       disabled={isDisabled}
       onMouseEnter={(e) => handleMouseEnter(e)}
       onMouseLeave={() => {
-        setIsActive(false), setIsVisible(false);
+        (setIsActive(false), setIsVisible(false));
       }}
       onMouseMove={(e) => {
         handleMouseMove(e);
@@ -124,12 +124,7 @@ const PopoverContainer = styled.div.attrs<{
   color?: string;
   tooltipPosition?: any;
   maxWidth?: number;
-}>(({
-  isVisible,
-  color,
-  tooltipPosition,
-  maxWidth,
-}) => ({
+}>(({ isVisible, color, tooltipPosition, maxWidth }) => ({
   style: {
     backgroundColor: color ?? '#fff',
     opacity: isVisible ? 1 : 0,
@@ -137,7 +132,12 @@ const PopoverContainer = styled.div.attrs<{
     left: tooltipPosition.x,
     maxWidth: maxWidth ? `${maxWidth}vw` : '36vw',
   },
-}))`
+}))<{
+  isVisible: boolean;
+  color?: string;
+  tooltipPosition?: any;
+  maxWidth?: number;
+}>`
   position: fixed;
   flex-direction: column;
   border: solid black 0.15vw;

--- a/packages/client/src/app/components/modals/inventory/ItemGrid.tsx
+++ b/packages/client/src/app/components/modals/inventory/ItemGrid.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { cleanInventories, Inventory } from 'app/cache/inventory';
-import { EmptyText, IconListButton, TextTooltip } from 'app/components/library';
+import { EmptyText, IconListButton } from 'app/components/library';
 import { ButtonListOption } from 'app/components/library/buttons';
 import { Option } from 'app/components/library/buttons/IconListButton';
 import { useVisibility } from 'app/stores';
@@ -123,20 +123,19 @@ export const ItemGrid = ({
     const options = getItemActions(item, inv.balance);
 
     return (
-      <TextTooltip
+      <IconListButton
         key={item.index}
-        text={item.index ? [<ItemGridTooltip key={item.index} item={item} utils={utils} />] : []}
-        maxWidth={25}
-      >
-        <IconListButton
-          key={item.index}
-          img={item.image}
-          scale={4.8}
-          balance={inv.balance}
-          options={options}
-          disabled={options.length == 0}
-        />
-      </TextTooltip>
+        img={item.image}
+        scale={4.8}
+        balance={inv.balance}
+        options={options}
+        disabled={options.length == 0}
+        tooltipProps={{
+          text: [<ItemGridTooltip key={item.index} item={item} utils={utils} />],
+          maxWidth: 25,
+          title: 'Item Info',
+        }}
+      />
     );
   };
 

--- a/packages/client/src/app/components/modals/inventory/ItemGrid.tsx
+++ b/packages/client/src/app/components/modals/inventory/ItemGrid.tsx
@@ -133,7 +133,6 @@ export const ItemGrid = ({
         tooltipProps={{
           text: [<ItemGridTooltip key={item.index} item={item} utils={utils} />],
           maxWidth: 25,
-          title: 'Item Info',
         }}
       />
     );

--- a/packages/client/src/app/components/modals/node/header/Header.tsx
+++ b/packages/client/src/app/components/modals/node/header/Header.tsx
@@ -117,16 +117,15 @@ export const Header = ({
     });
 
     return (
-      <TextTooltip text={[getDisabledReason(kamis)]} grow>
-        <IconListButton
-          key={`harvest-add`}
-          img={HarvestIcon}
-          options={actionOptions}
-          text='Add Kami to Node'
-          disabled={options.length == 0 || account.roomIndex !== node.roomIndex}
-          fullWidth
-        />
-      </TextTooltip>
+      <IconListButton
+        key={`harvest-add`}
+        img={HarvestIcon}
+        options={actionOptions}
+        text='Add Kami to Node'
+        disabled={options.length == 0 || account.roomIndex !== node.roomIndex}
+        fullWidth
+        tooltipProps={{ text: [getDisabledReason(kamis)], grow: true }}
+      />
     );
   };
 

--- a/packages/client/src/app/components/modals/party/KamisExternal.tsx
+++ b/packages/client/src/app/components/modals/party/KamisExternal.tsx
@@ -15,15 +15,8 @@ const StakeButtons = new Map<number, React.ReactNode>();
 const SendButtons = new Map<number, React.ReactNode>();
 
 export const KamisExternal = ({
-  actions: {
-    sendKamis,
-    stakeKamis,
-  },
-  data: {
-    account,
-    accounts,
-    kamis,
-  },
+  actions: { sendKamis, stakeKamis },
+  data: { account, accounts, kamis },
   isVisible,
   utils,
 }: {
@@ -104,9 +97,13 @@ export const KamisExternal = ({
     }));
 
     return (
-      <TextTooltip key='send-tooltip' text={getSendTooltip(kami)}>
-        <IconListButton img={ArrowIcons.right} options={options} searchable />
-      </TextTooltip>
+      <IconListButton
+        key='send-tooltip'
+        img={ArrowIcons.right}
+        options={options}
+        searchable
+        tooltipProps={{ text: getSendTooltip(kami) }}
+      />
     );
   };
 


### PR DESCRIPTION
Fixes this:

https://github.com/user-attachments/assets/1145fdd4-ee8c-4bf7-b50a-13d9a539c0f6



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Buttons now support built-in, customizable tooltips (text, title, size, alignment, delay), used across More, Harvest, Liquidate, Use Item, inventory items, node header, and party actions.
  - Popovers can optionally expand to full width for improved layouts.

- Refactor
  - Replaced external tooltip wrappers with integrated tooltipProps on buttons, simplifying markup and unifying behavior.
  - Inventory item tooltips are now always provided and include an “Item Info” title with constrained width.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->