### PR TITLE
fix excessive re-renders - zustand performance

### DIFF
--- a/packages/client/src/app/components/canvas/Room.tsx
+++ b/packages/client/src/app/components/canvas/Room.tsx
@@ -20,8 +20,9 @@ export const Room = ({
 }: {
   index: number
 }) => {
-  const { modals, setModals } = useVisibility();
-  const { setNode } = useSelected();
+  const tradingModalOpen = useVisibility((s) => s.modals.trading);
+  const setModals = useVisibility((s) => s.setModals);
+  const setNode = useSelected((s) => s.setNode);
   const [room, setRoom] = useState(rooms[0]);
   const [bgm, setBgm] = useState<Howl>();
   const [settings] = useLocalStorage('settings', { volume: { fx: 0.5, bgm: 0.5 } });
@@ -142,7 +143,7 @@ export const Room = ({
         x2={x2}
         y2={y2}
         onClick={() => {
-          setModals({ trading: !modals.trading });
+          setModals({ trading: !tradingModalOpen });
         }}
       />
     );

--- a/packages/client/src/app/components/canvas/Scene.tsx
+++ b/packages/client/src/app/components/canvas/Scene.tsx
@@ -42,7 +42,8 @@ export const Scene: UIComponent = {
   Render: ({ data, utils }) => {
     const { accountEntity } = data;
     const { getRoomIndex } = utils;
-    const { roomIndex, setRoom } = useSelected();
+    const roomIndex = useSelected((s) => s.roomIndex);
+    const setRoom = useSelected((s) => s.setRoom);
     const [lastRefresh, setLastRefresh] = useState(Date.now());
 
     // ticking

--- a/packages/client/src/app/components/fixtures/clock/Clock.tsx
+++ b/packages/client/src/app/components/fixtures/clock/Clock.tsx
@@ -36,7 +36,7 @@ export const ClockFixture: UIComponent = {
   Render: ({ data, utils }) => {
       const { account } = data;
       const { calcCurrentStamina } = utils;
-      const { fixtures } = useVisibility();
+      const menuVisible = useVisibility((s) => s.fixtures.menu);
       const [staminaCurr, setStaminaCurr] = useState(0);
       const [rotateClock, setRotateClock] = useState(0);
       const [rotateBand, setRotateBand] = useState(0);
@@ -100,7 +100,7 @@ export const ClockFixture: UIComponent = {
       //Render
       return (
         <TextTooltip text={getClockTooltip()}>
-          <Container style={{ display: fixtures.menu ? 'flex' : 'none' }}>
+          <Container style={{ display: menuVisible ? 'flex' : 'none' }}>
             <Circle rotation={rotateClock}>
               <CircleContent>
                 <TicksPosition>{Ticks()}</TicksPosition>
@@ -130,7 +130,7 @@ export const ClockFixture: UIComponent = {
             <Time
               rotation={rotateClock}
               viewBox='0 0 30 6'
-              style={{ display: fixtures.menu ? 'flex' : 'none' }}
+              style={{ display: menuVisible ? 'flex' : 'none' }}
             >
               <path id='MyPath' fill='none' d='M 2.5 3.5 Q 13 -3.5 27 3.5' pathLength='2' />
               <text fill='white' fontSize='3' dominantBaseline='hanging' textAnchor='middle'>

--- a/packages/client/src/app/components/fixtures/menu/Left.tsx
+++ b/packages/client/src/app/components/fixtures/menu/Left.tsx
@@ -27,10 +27,10 @@ export const LeftMenuFixture: UIComponent = {
       })
     ),
   Render: ({ nodeEntity }) => {
-    const { fixtures } = useVisibility();
+    const menuVisible = useVisibility((s) => s.fixtures.menu);
 
     return (
-      <Wrapper style={{ display: fixtures.menu ? 'flex' : 'none' }}>
+      <Wrapper style={{ display: menuVisible ? 'flex' : 'none' }}>
         <AccountMenuButton />
         <PartyMenuButton />
         <MapMenuButton />

--- a/packages/client/src/app/components/fixtures/menu/Right.tsx
+++ b/packages/client/src/app/components/fixtures/menu/Right.tsx
@@ -15,17 +15,17 @@ export const RightMenuFixture: UIComponent = {
   id: 'RightMenuFixture',
   requirement: (layers) => of(layers),
   Render: () => {
-    const { fixtures } = useVisibility();
+    const menuVisible = useVisibility((s) => s.fixtures.menu);
     return (
       <>
-        <Wrapper style={{ display: fixtures.menu ? 'flex' : 'none' }}>
+        <Wrapper style={{ display: menuVisible ? 'flex' : 'none' }}>
           <CraftMenuButton />
           <InventoryMenuButton />
           <QuestMenuButton />
           <ChatMenuButton />
           <MoreMenuButton />
         </Wrapper>
-        <Wrapper style={{ display: fixtures.menu ? 'none' : 'flex' }}>
+        <Wrapper style={{ display: menuVisible ? 'none' : 'flex' }}>
           <MoreMenuButton />
         </Wrapper>
       </>

--- a/packages/client/src/app/components/fixtures/menu/buttons/Chat.tsx
+++ b/packages/client/src/app/components/fixtures/menu/buttons/Chat.tsx
@@ -15,8 +15,8 @@ const ModalsToHide: Partial<Modals> = {
 };
 
 export const ChatMenuButton = () => {
-  const { modals } = useVisibility();
-  const { roomIndex } = useSelected();
+  const chatModalOpen = useVisibility((s) => s.modals.chat);
+  const roomIndex = useSelected((s) => s.roomIndex);
   const [lastRefresh, setLastRefresh] = useState(Date.now());
   const [notification, setNotification] = useState(false);
 
@@ -34,18 +34,18 @@ export const ChatMenuButton = () => {
   }, []);
 
   useEffect(() => {
-    if (modals.chat) {
+    if (chatModalOpen) {
       setNotification(false);
     } else {
       const lastChatTs = getChatLastTimestamp(roomIndex);
       const lastClearTs = LastClearTs.get(roomIndex) ?? 0;
       setNotification(lastChatTs > lastClearTs);
     }
-  }, [lastRefresh, modals.chat, roomIndex]);
+  }, [lastRefresh, chatModalOpen, roomIndex]);
 
   useEffect(() => {
     LastClearTs.set(roomIndex, Date.now());
-  }, [modals.chat]);
+  }, [chatModalOpen]);
 
   // added (!LastClearTs.has(roomIndex)) to not overwrite the last clear timestamp each time an already visited room is visited again
   useEffect(() => {

--- a/packages/client/src/app/components/fixtures/menu/buttons/MenuButton.tsx
+++ b/packages/client/src/app/components/fixtures/menu/buttons/MenuButton.tsx
@@ -23,7 +23,8 @@ export const MenuButton = ({
   onClick?: () => void;
   disabled?: boolean;
 }) => {
-  const { modals, setModals } = useVisibility();
+  const setModals = useVisibility((s) => s.setModals);
+  const isModalOpen = useVisibility((s) => (targetModal ? s.modals[targetModal] : false));
 
   // toggles the target modal open and closed
   const handleToggle = () => {
@@ -31,7 +32,6 @@ export const MenuButton = ({
     if (onClick) onClick();
     if (!targetModal) return;
 
-    const isModalOpen = modals[targetModal];
     let nextModals = { [targetModal]: !isModalOpen };
     if (!isModalOpen) nextModals = { ...nextModals, ...hideModals };
     setModals(nextModals);

--- a/packages/client/src/app/components/fixtures/menu/buttons/More.tsx
+++ b/packages/client/src/app/components/fixtures/menu/buttons/More.tsx
@@ -8,7 +8,9 @@ import { HelpIcon, MoreIcon, ResetIcon, SettingsIcon } from 'assets/images/icons
 
 export const MoreMenuButton = () => {
   const { ready, authenticated, logout } = usePrivy();
-  const { modals, setModals } = useVisibility();
+  const setModals = useVisibility((s) => s.setModals);
+  const settingsVisible = useVisibility((s) => s.modals.settings);
+  const helpVisible = useVisibility((s) => s.modals.help);
   const [disabled, setDisabled] = useState(true);
 
   useEffect(() => {
@@ -61,7 +63,7 @@ export const MoreMenuButton = () => {
   };
 
   const toggleSettings = () => {
-    if (modals.settings) setModals({ settings: false });
+    if (settingsVisible) setModals({ settings: false });
     else {
       setModals({
         chat: false,
@@ -75,7 +77,7 @@ export const MoreMenuButton = () => {
   };
 
   const toggleHelp = () => {
-    if (modals.help) setModals({ help: false });
+    if (helpVisible) setModals({ help: false });
     else {
       setModals({
         chat: false,

--- a/packages/client/src/app/components/fixtures/menu/buttons/Studio.tsx
+++ b/packages/client/src/app/components/fixtures/menu/buttons/Studio.tsx
@@ -3,7 +3,8 @@ import { IconButton, TextTooltip } from 'app/components/library';
 import { useVisibility } from 'app/stores';
 
 export const StudioMenuButton = () => {
-  const { modals, setModals } = useVisibility();
+  const setModals = useVisibility((s) => s.setModals);
+  const isStudioOpen = useVisibility((s) => s.modals.animationStudio);
   
   // Only show in development mode (localhost:3000); SSR-safe
   const isDev =
@@ -14,8 +15,7 @@ export const StudioMenuButton = () => {
   if (!isDev) return null;
 
   const handleClick = () => {
-    const isOpen = modals.animationStudio;
-    setModals({ animationStudio: !isOpen });
+    setModals({ animationStudio: !isStudioOpen });
   };
 
   return (
@@ -31,5 +31,3 @@ export const StudioMenuButton = () => {
     </TextTooltip>
   );
 };
-
-

--- a/packages/client/src/app/components/fixtures/notifications/Notifications.tsx
+++ b/packages/client/src/app/components/fixtures/notifications/Notifications.tsx
@@ -23,7 +23,8 @@ export const NotificationFixture: UIComponent = {
       );
   },
   Render: ({ notifications, list }) => {
-      const { fixtures, modals, setModals } = useVisibility();
+      const notificationsVisible = useVisibility((s) => s.fixtures.notifications);
+      const setModals = useVisibility((s) => s.setModals);
 
       /////////////////
       // INTERACTION
@@ -59,7 +60,7 @@ export const NotificationFixture: UIComponent = {
       };
 
       const isVisible = () => {
-        return fixtures.notifications && list.length > 0;
+        return notificationsVisible && list.length > 0;
       };
 
       /////////////////

--- a/packages/client/src/app/components/fixtures/queue/ActionQueue.tsx
+++ b/packages/client/src/app/components/fixtures/queue/ActionQueue.tsx
@@ -23,7 +23,7 @@ export const ActionQueue: UIComponent = {
   },
   Render: ({ network }) => {
     const ActionComponent = network.actions.Action;
-    const { fixtures } = useVisibility();
+    const actionQueueVisible = useVisibility((s) => s.fixtures.actionQueue);
     const [mode, setMode] = useState<number>(1);
     const [actionIndices, setActionIndices] = useState<EntityIndex[]>([]);
 
@@ -34,7 +34,7 @@ export const ActionQueue: UIComponent = {
 
     const sizes = ['none', '23vh', '90vh'];
     return (
-      <Wrapper style={{ display: fixtures.actionQueue ? 'block' : 'none' }}>
+      <Wrapper style={{ display: actionQueueVisible ? 'block' : 'none' }}>
         <Content style={{ pointerEvents: 'auto', maxHeight: sizes[mode] }}>
           {mode !== 0 && <Logs actionIndices={actionIndices} network={network} />}
           <Controls mode={mode} setMode={setMode} />

--- a/packages/client/src/app/components/fixtures/queue/GasGauge.tsx
+++ b/packages/client/src/app/components/fixtures/queue/GasGauge.tsx
@@ -9,11 +9,12 @@ export const GasGauge = ({
 }: {
   level: number; // [0, 1]
 }) => {
-  const { modals, setModals } = useVisibility();
+  const setModals = useVisibility((s) => s.setModals);
+  const operatorFundVisible = useVisibility((s) => s.modals.operatorFund);
 
   const handleClick = () => {
     playClick();
-    setModals({ operatorFund: !modals.operatorFund });
+    setModals({ operatorFund: !operatorFundVisible });
   };
 
   const levelToAngle = (level: number) => {

--- a/packages/client/src/app/components/library/KamiBlock.tsx
+++ b/packages/client/src/app/components/library/KamiBlock.tsx
@@ -19,14 +19,16 @@ export const KamiBlock = ({
   tooltip?: string[];
 }) => {
   const { index, progress, name } = kami;
-  const { kamiIndex, setKami } = useSelected();
-  const { modals, setModals } = useVisibility();
+  const kamiIndex = useSelected((s) => s.kamiIndex);
+  const setKami = useSelected((s) => s.setKami);
+  const kamiModalOpen = useVisibility((s) => s.modals.kami);
+  const setModals = useVisibility((s) => s.setModals);
 
   // toggle the kami modal depending on its current state
   const handleClick = () => {
     const sameKami = kamiIndex === kami.index;
     if (!sameKami) setKami(kami.index);
-    if (modals.kami && sameKami) setModals({ kami: false });
+    if (kamiModalOpen && sameKami) setModals({ kami: false });
     else setModals({ kami: true });
     playClick();
   };

--- a/packages/client/src/app/components/library/bars/KamiBar.tsx
+++ b/packages/client/src/app/components/library/bars/KamiBar.tsx
@@ -50,8 +50,10 @@ export const KamiBar = ({
   };
 }) => {
 
-  const { kamiIndex, setKami } = useSelected();
-  const { modals, setModals } = useVisibility();
+  const kamiIndex = useSelected((s) => s.kamiIndex);
+  const setKami = useSelected((s) => s.setKami);
+  const kamiModalOpen = useVisibility((s) => s.modals.kami);
+  const setModals = useVisibility((s) => s.setModals);
   const [currentHealth, setCurrentHealth] = useState(0);
 
   useEffect(() => {
@@ -66,7 +68,7 @@ export const KamiBar = ({
     const sameKami = kamiIndex === kami.index;
     setKami(kami.index);
 
-    if (modals.kami && sameKami) setModals({ kami: false });
+    if (kamiModalOpen && sameKami) setModals({ kami: false });
     else setModals({ kami: true });
     playClick();
   };

--- a/packages/client/src/app/components/library/cards/AccountCard/AccountCard.tsx
+++ b/packages/client/src/app/components/library/cards/AccountCard/AccountCard.tsx
@@ -24,7 +24,8 @@ export const AccountCard = ({
   subtextOnClick?: () => void;
   actions?: React.ReactNode;
 }) => {
-  const { modals, setModals } = useVisibility();
+  const accountModalOpen = useVisibility((s) => s.modals.account);
+  const setModals = useVisibility((s) => s.setModals);
   const setAccount = useSelected((s) => s.setAccount);
 
   // ticking
@@ -45,7 +46,7 @@ export const AccountCard = ({
   // toggle the kami modal settings depending on its current state
   const handleClick = () => {
     setAccount(account.index);
-    if (!modals.account) setModals({ account: true });
+    if (!accountModalOpen) setModals({ account: true });
     playClick();
   };
 

--- a/packages/client/src/app/components/library/cards/KamiCard/KamiCard.tsx
+++ b/packages/client/src/app/components/library/cards/KamiCard/KamiCard.tsx
@@ -50,8 +50,10 @@ export const KamiCard = ({
     getTempBonuses?: (kami: Kami) => Bonus[];
   };
 }) => {
-  const { modals, setModals } = useVisibility();
-  const { kamiIndex, setKami } = useSelected();
+  const setModals = useVisibility((s) => s.setModals);
+  const kamiModalOpen = useVisibility((s) => s.modals.kami);
+  const setKami = useSelected((s) => s.setKami);
+  const kamiIndex = useSelected((s) => s.kamiIndex);
   const [canLevel, setCanLevel] = useState(false);
 
   /////////////////
@@ -70,7 +72,7 @@ export const KamiCard = ({
     const sameKami = kamiIndex === kami.index;
     setKami(kami.index);
 
-    if (modals.kami && sameKami) setModals({ kami: false });
+    if (kamiModalOpen && sameKami) setModals({ kami: false });
     else setModals({ kami: true });
     playClick();
   };

--- a/packages/client/src/app/components/library/modals/ExitButton.tsx
+++ b/packages/client/src/app/components/library/modals/ExitButton.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { useVisibility } from 'app/stores';
 import { playClick } from 'utils/sounds';
 
-// ExitButton is a rendering o fan exit button, which closes the modal it's on
+// ExitButton is a rendering of an exit button, which closes the modal it's on
 export const ExitButton = ({
   divName,
   position,
@@ -13,7 +13,8 @@ export const ExitButton = ({
   position?: string;
   isValidator?: boolean;
 }) => {
-  const { setModals, setValidators } = useVisibility();
+  const setModals = useVisibility((s) => s.setModals);
+  const setValidators = useVisibility((s) => s.setValidators);
 
   // closes the modal this exit button is on
   const handleClose = () => {

--- a/packages/client/src/app/components/library/modals/ModalWrapper.tsx
+++ b/packages/client/src/app/components/library/modals/ModalWrapper.tsx
@@ -37,7 +37,7 @@ export const ModalWrapper = ({
     position: 'fixed' | 'absolute';
   };
 }) => {
-  const { modals } = useVisibility();
+  const isVisible = useVisibility((s) => s.modals[id]);
   const [gridStyle, setGridStyle] = useState<React.CSSProperties>({});
 
   useEffect(() => {
@@ -58,8 +58,8 @@ export const ModalWrapper = ({
   }, [positionOverride]);
 
   return (
-    <Wrapper id={id} isOpen={modals[id]} overlay={!!overlay} style={gridStyle}>
-      <Content isOpen={modals[id]} truncate={truncate}>
+    <Wrapper id={id} isOpen={isVisible} overlay={!!overlay} style={gridStyle}>
+      <Content isOpen={isVisible} truncate={truncate}>
         {canExit && (
           <ButtonRow>
             <ExitButton divName={id} />

--- a/packages/client/src/app/components/library/validators/ValidatorWrapper.tsx
+++ b/packages/client/src/app/components/library/validators/ValidatorWrapper.tsx
@@ -24,19 +24,18 @@ export const ValidatorWrapper = ({
   errorPrimary?: string;
   errorSecondary?: string;
 }) => {
-  const { validators } = useVisibility();
+  const isVisible = useVisibility((s) => s.validators[divName]);
 
   // update modal visibility according to store settings
   useEffect(() => {
     const element = document.getElementById(id);
     if (element) {
-      const isVisible = validators[divName];
       element.style.display = isVisible ? 'block' : 'none';
     }
-  }, [validators[divName]]);
+  }, [isVisible]);
 
   return (
-    <Wrapper id={id} isOpen={validators[divName]}>
+    <Wrapper id={id} isOpen={isVisible}>
       {canExit && (
         <ButtonRow>
           <ExitButton divName={id} isValidator />

--- a/packages/client/src/app/components/modals/account/Account.tsx
+++ b/packages/client/src/app/components/modals/account/Account.tsx
@@ -62,7 +62,7 @@ export const AccountModal: UIComponent = {
     const { getAccount } = utils;
     const { account: player } = useAccount();
     const accountIndex = useSelected((s) => s.accountIndex);
-    const { modals } = useVisibility();
+    const accountModalVisible = useVisibility((s) => s.modals.account);
     const { selectedAddress, apis } = useNetwork();
 
     const [subTab, setSubTab] = useState('frens'); //  frens | requests | blocked
@@ -77,7 +77,7 @@ export const AccountModal: UIComponent = {
 
     // update data of the selected account when account index or data changes
     useEffect(() => {
-      if (!modals.account) return;
+      if (!accountModalVisible) return;
       const accountEntity = queryAccountByIndex(components, accountIndex);
       const account = getAccount(accountEntity ?? (0 as EntityIndex));
       setAccount(account);
@@ -89,7 +89,7 @@ export const AccountModal: UIComponent = {
       setIsSelf(isSelf);
       if (isSelf) setSubTab('frens');
       setTab('stats');
-    }, [accountIndex, modals.account]);
+    }, [accountIndex, accountModalVisible]);
 
     /////////////////
     // INTERACTION

--- a/packages/client/src/app/components/modals/chat/Chat.tsx
+++ b/packages/client/src/app/components/modals/chat/Chat.tsx
@@ -48,7 +48,7 @@ export const ChatModal: UIComponent = {
       const { accountEntity } = data;
       const { actions, api } = network;
       const { getAccount } = utils;
-      const { modals } = useVisibility();
+      const chatModalVisible = useVisibility((s) => s.modals.chat);
 
       const [messages, setMessages] = useState<KamiMessage[]>([]);
       const [blocked, setBlocked] = useState<EntityID[]>([]);
@@ -59,11 +59,11 @@ export const ChatModal: UIComponent = {
 
       // update data of the selected account when account index or data changes
       useEffect(() => {
-        if (!modals.chat) return;
+        if (!chatModalVisible) return;
         // const accountEntity = queryAccountByIndex(components, accountIndex);
         const account = getAccount(accountEntity ?? (0 as EntityIndex));
         setAccount(account);
-      }, [accountEntity, modals.chat]);
+      }, [accountEntity, chatModalVisible]);
       //TODO
       useEffect(() => {
         if (account.friends?.blocked) {

--- a/packages/client/src/app/components/modals/chat/feed/Feed.tsx
+++ b/packages/client/src/app/components/modals/chat/feed/Feed.tsx
@@ -59,7 +59,7 @@ export const Feed = ({
   };
 }) => {
   const { getAccount, getEntityIndex, getKami, getRoomByIndex } = utils;
-  const { modals } = useVisibility();
+  const chatModalVisible = useVisibility((s) => s.modals.chat);
   const [kamidenMessages, setKamidenMessages] = useState<KamiMessage[]>([]);
   const [feedData, setFeedData] = useState<String[]>([]);
   const [isPolling, setIsPolling] = useState(false);
@@ -221,7 +221,7 @@ export const Feed = ({
 
     node.scrollTop = scrollHeight;
     setScrollDown(false);
-  }, [scrollDown, player.roomIndex, activeTab, modals.chat]);
+  }, [scrollDown, player.roomIndex, activeTab, chatModalVisible]);
 
   /////////////////
   // RENDER

--- a/packages/client/src/app/components/modals/chat/feed/Message.tsx
+++ b/packages/client/src/app/components/modals/chat/feed/Message.tsx
@@ -44,8 +44,9 @@ export const Message = ({
   };
 }) => {
   const [yours, setYours] = useState(false);
-  const { modals, setModals } = useVisibility();
-  const { setAccount } = useSelected();
+  const accountModalOpen = useVisibility((s) => s.modals.account);
+  const setModals = useVisibility((s) => s.setModals);
+  const setAccount = useSelected((s) => s.setAccount);
   const pfpRef = useRef<HTMLDivElement>(null);
 
   /////////////////
@@ -61,7 +62,7 @@ export const Message = ({
 
   const showUser = () => {
     setAccount(getAccountFunc().index);
-    if (!modals.account) setModals({ account: true, party: false, map: false });
+    if (!accountModalOpen) setModals({ account: true, party: false, map: false });
   };
 
   const blockFren = (account: BaseAccount) => {

--- a/packages/client/src/app/components/modals/crafting/Crafting.tsx
+++ b/packages/client/src/app/components/modals/crafting/Crafting.tsx
@@ -47,17 +47,18 @@ export const CraftingModal: UIComponent = {
     const { account } = data;
     const { actions, api, components, world } = network;
     const { hasIngredients } = utils;
-    const { modals, setModals } = useVisibility();
+    const setModals = useVisibility((s) => s.setModals);
+    const craftingModalVisible = useVisibility((s) => s.modals.crafting);
     const [recipes, setRecipes] = useState<Recipe[]>([]);
     const [showAll, setShowAll] = useState<boolean>(true);
     const [tab, setTab] = useState('consumable'); //  consumable | material | reagent | special
 
     /////////////////
     useEffect(() => {
-      if (!modals.crafting) return;
+      if (!craftingModalVisible) return;
       // close lootbox modal
       setModals({ lootBox: false });
-    }, [modals.crafting]);
+    }, [craftingModalVisible]);
 
     // update the list of recipes depending on the filter
     useEffect(() => {
@@ -65,7 +66,7 @@ export const CraftingModal: UIComponent = {
       const currentTabRecipes = recipes.filter((recipe) => recipe.type === tab.toUpperCase());
       if (showAll) setRecipes(currentTabRecipes);
       else setRecipes(currentTabRecipes.filter((recipe) => hasIngredients(recipe)));
-    }, [showAll, tab, modals.crafting]);
+    }, [showAll, tab, craftingModalVisible]);
 
     /////////////////
     // INTERPRETATION

--- a/packages/client/src/app/components/modals/dialogue/Dialogue.tsx
+++ b/packages/client/src/app/components/modals/dialogue/Dialogue.tsx
@@ -28,8 +28,8 @@ export const DialogueModal: UIComponent = {
     ),
   Render: ({ data, network }) => {
       const { actions, components, world } = network;
-      const { modals } = useVisibility();
-      const { dialogueIndex } = useSelected();
+      const dialogueModalOpen = useVisibility((s) => s.modals.dialogue);
+      const dialogueIndex = useSelected((s) => s.dialogueIndex);
       const [dialogueNode, setDialogueNode] = React.useState({
         text: [''],
       } as DialogueNode);
@@ -43,7 +43,7 @@ export const DialogueModal: UIComponent = {
       }, [dialogueNode.text[step]]);
 
       // reset the step to 0 whenever the dialogue modal is toggled
-      useEffect(() => setStep(0), [modals.dialogue]);
+      useEffect(() => setStep(0), [dialogueModalOpen]);
 
       // set the current dialogue node when the dialogue index changes
       useEffect(() => {

--- a/packages/client/src/app/components/modals/gacha/Gacha.tsx
+++ b/packages/client/src/app/components/modals/gacha/Gacha.tsx
@@ -80,7 +80,8 @@ export const GachaModal: UIComponent = {
       const { getAccount, getAuction, getItemBalance } = utils;
       const { getMintConfig, getMintData, isWhitelisted } = utils;
 
-      const { modals, setModals } = useVisibility();
+      const setModals = useVisibility((s) => s.setModals);
+      const gachaModalVisible = useVisibility((s) => s.modals.gacha);
       const { selectedAddress, apis } = useNetwork();
 
       // modal controls
@@ -150,7 +151,7 @@ export const GachaModal: UIComponent = {
 
       // update the data when the modal is open
       useEffect(() => {
-        if (!modals.gacha) return;
+        if (!gachaModalVisible) return;
         const account = getAccount();
         setAccount(account);
 
@@ -165,7 +166,7 @@ export const GachaModal: UIComponent = {
           setGachaMintData(getMintData('0' as EntityID));
           setWhitelisted(isWhitelisted(account.entity));
         }
-      }, [modals.gacha, tab, mode, accountEntity, tick]);
+      }, [gachaModalVisible, tab, mode, accountEntity, tick]);
 
       // open the party modal when the reveal is triggered
       useEffect(() => {

--- a/packages/client/src/app/components/modals/gacha/display/pool/KamiView.tsx
+++ b/packages/client/src/app/components/modals/gacha/display/pool/KamiView.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 import { EmptyText, KamiBlock, TextTooltip } from 'app/components/library';
-import { useSelected, useVisibility } from 'app/stores';
+import { useVisibility } from 'app/stores';
 import { Auction } from 'network/shapes/Auction';
 import { KamiStats } from 'network/shapes/Kami';
 import { Kami } from 'network/shapes/Kami/types';
@@ -45,8 +45,7 @@ export const KamiView = ({
   const { tick } = state;
   const { getKami } = utils;
 
-  const { kamiIndex, setKami } = useSelected();
-  const { modals, setModals } = useVisibility();
+  const gachaModalOpen = useVisibility((s) => s.modals.gacha);
   const containerRef = useRef<HTMLDivElement>(null);
 
   const [filtered, setFiltered] = useState<Kami[]>([]);
@@ -56,14 +55,14 @@ export const KamiView = ({
 
   // filter (and implicitly populate) the pool of kamis on initial lod
   useEffect(() => {
-    if (isLoaded || isLoading || !modals.gacha) return;
+    if (isLoaded || isLoading || !gachaModalOpen) return;
     setIsLoading(true);
     loadKamis();
-  }, [modals.gacha]);
+  }, [gachaModalOpen]);
 
   // when the entities or filters change, update the list of filtered kamis
   useEffect(() => {
-    const isOpen = modals.gacha && isVisible;
+    const isOpen = gachaModalOpen && isVisible;
     if (isOpen) filterKamis();
   }, [filters, entities.length]);
 
@@ -74,7 +73,7 @@ export const KamiView = ({
       container.addEventListener('scroll', handleScroll);
       return () => container.removeEventListener('scroll', handleScroll);
     }
-  }, [filtered.length, limit, modals.gacha]);
+  }, [filtered.length, limit, gachaModalOpen]);
 
   //////////////////
   // INTERACTION

--- a/packages/client/src/app/components/modals/gacha/display/reroll/KamiView.tsx
+++ b/packages/client/src/app/components/modals/gacha/display/reroll/KamiView.tsx
@@ -29,16 +29,16 @@ export const KamiView = ({
   const { account } = data;
   const { setQuantity, selectedKamis, setSelectedKamis, tick } = state;
   const { getAccountKamis } = utils;
-  const { modals } = useVisibility();
+  const gachaModalVisible = useVisibility((s) => s.modals.gacha);
 
   const [partyKamis, setPartyKamis] = useState<Kami[]>([]);
 
   // update the list of kamis when the account changes (if visible)
   useEffect(() => {
-    if (!isVisible || !modals.gacha) return;
+    if (!isVisible || !gachaModalVisible) return;
     const party = getAccountKamis();
     setPartyKamis(party);
-  }, [account, tick]);
+  }, [account, tick, gachaModalVisible]);
 
   /////////////////
   // INTERACTION

--- a/packages/client/src/app/components/modals/gacha/sidebar/Sidebar.tsx
+++ b/packages/client/src/app/components/modals/gacha/sidebar/Sidebar.tsx
@@ -84,7 +84,7 @@ export const Sidebar = ({
   const { tick, quantity, setQuantity } = state;
   const { getItem, getItemBalance } = utils;
   const { balances: tokenBal } = useTokens(); // ERC20
-  const { modals } = useVisibility();
+  const gachaModalVisible = useVisibility((s) => s.modals.gacha);
 
   const [payItem, setPayItem] = useState<Item>(NullItem);
   const [saleItem, setSaleItem] = useState<Item>(NullItem);
@@ -96,22 +96,22 @@ export const Sidebar = ({
 
   // update context when changed
   useEffect(() => {
-    if (!modals.gacha) return;
+    if (!gachaModalVisible) return;
     updatePayItem();
     updateSaleItem();
     setQuantity(1); // default to 1 on context switch
-  }, [modals.gacha, tab, mode]);
+  }, [gachaModalVisible, tab, mode]);
 
   // maybe consider controlling this hook and the one below with a dedicated payItem vs buyItem
   useEffect(() => {
-    if (!modals.gacha) return;
+    if (!gachaModalVisible) return;
     updatePrice();
-  }, [tab, mode, quantity, tick]);
+  }, [gachaModalVisible, tab, mode, quantity, tick]);
 
   useEffect(() => {
-    if (!modals.gacha) return;
+    if (!gachaModalVisible) return;
     updateBalance();
-  }, [payItem, tick]);
+  }, [gachaModalVisible, payItem, tick]);
 
   /////////////////
   // STATE

--- a/packages/client/src/app/components/modals/goals/Goal.tsx
+++ b/packages/client/src/app/components/modals/goals/Goal.tsx
@@ -60,8 +60,8 @@ export const GoalModal: UIComponent = {
       const { actions, api, world, components } = network;
       const { account } = data;
       const { canContribute, getContribution, getContributions } = utils;
-      const { modals } = useVisibility();
-      const { goalIndex } = useSelected(); // only support 1 goal type for now
+      const goalModalOpen = useVisibility((s) => s.modals.goal);
+      const goalIndex = useSelected((s) => s.goalIndex); // only support 1 goal type for now
 
       const [tab, setTab] = useState('GOAL');
       const [step, setStep] = useState(0);
@@ -71,7 +71,7 @@ export const GoalModal: UIComponent = {
 
       // update details based on selected
       useEffect(() => {
-        if (!modals.goal) return;
+        if (!goalModalOpen) return;
         const goal = getGoalByIndex(world, components, goalIndex[0]);
         setGoal(goal);
 
@@ -80,7 +80,7 @@ export const GoalModal: UIComponent = {
 
         const contributions = getContributions(goal);
         setScores(contributions);
-      }, [goalIndex, modals.goal, step, account.coin]);
+      }, [goalIndex, goalModalOpen, step, account.coin]);
 
       /////////////////
       // INTERACTIONS

--- a/packages/client/src/app/components/modals/goals/Leaderboard.tsx
+++ b/packages/client/src/app/components/modals/goals/Leaderboard.tsx
@@ -16,8 +16,9 @@ export const Leaderboard = ({
   };
 }) => {
   const { getAccountByID } = utils;
-  const { modals, setModals } = useVisibility();
-  const { setAccount } = useSelected();
+  const accountModalOpen = useVisibility((s) => s.modals.account);
+  const setModals = useVisibility((s) => s.setModals);
+  const setAccount = useSelected((s) => s.setAccount);
 
   /////////////////
   // INTERACTION
@@ -25,7 +26,7 @@ export const Leaderboard = ({
   // toggle the account modal settings depending on its current state
   const handleClick = (account: Account) => {
     setAccount(account.index);
-    if (!modals.account) setModals({ account: true });
+    if (!accountModalOpen) setModals({ account: true });
     playClick();
   };
 

--- a/packages/client/src/app/components/modals/leaderboard/Leaderboard.tsx
+++ b/packages/client/src/app/components/modals/leaderboard/Leaderboard.tsx
@@ -33,8 +33,8 @@ export const LeaderboardModal: UIComponent = {
   },
   Render: ({ network, data, utils }) => {
       const { components } = network;
-      const { modals } = useVisibility();
-      const { leaderboardKey } = useSelected();
+      const leaderboardModalOpen = useVisibility((s) => s.modals.leaderboard);
+      const leaderboardKey = useSelected((s) => s.leaderboardKey);
       const [filter, setFilter] = useState<ScoresFilter>({
         epoch: 1,
         index: 1,
@@ -57,10 +57,10 @@ export const LeaderboardModal: UIComponent = {
 
       // table data update
       useEffect(() => {
-        if (!modals.leaderboard) return;
+        if (!leaderboardModalOpen) return;
         const tableData = getScoresByFilter(components, filter);
         setTableData(tableData);
-      }, [filter, modals.leaderboard]);
+      }, [filter, leaderboardModalOpen]);
 
       return (
         <ModalWrapper id='leaderboard' canExit overlay>

--- a/packages/client/src/app/components/modals/leaderboard/Table.tsx
+++ b/packages/client/src/app/components/modals/leaderboard/Table.tsx
@@ -19,8 +19,9 @@ export const Table = ({
   };
 }) => {
   const { getAccountByID } = utils;
-  const { modals, setModals } = useVisibility();
-  const { setAccount } = useSelected();
+  const accountModalOpen = useVisibility((s) => s.modals.account);
+  const setModals = useVisibility((s) => s.setModals);
+  const setAccount = useSelected((s) => s.setAccount);
 
   /////////////////
   // INTERACTION
@@ -28,7 +29,7 @@ export const Table = ({
   // toggle the account modal settings depending on its current state
   const handleClick = (account: Account) => {
     setAccount(account.index);
-    if (!modals.account) setModals({ account: true });
+    if (!accountModalOpen) setModals({ account: true });
     playClick();
   };
 

--- a/packages/client/src/app/components/modals/map/Map.tsx
+++ b/packages/client/src/app/components/modals/map/Map.tsx
@@ -66,8 +66,8 @@ export const MapModal: UIComponent = {
   Render: ({ network, data, utils }) => {
       const { getRoom, getRoomByIndex, queryAllRooms } = utils;
       const { actions, api } = network;
-      const { roomIndex } = useSelected();
-      const { modals } = useVisibility();
+      const roomIndex = useSelected((s) => s.roomIndex);
+      const mapModalOpen = useVisibility((s) => s.modals.map);
 
       const [roomMap, setRoomMap] = useState<Map<number, Room>>(new Map());
       const [zone, setZone] = useState(0);
@@ -83,7 +83,7 @@ export const MapModal: UIComponent = {
       // query the set of rooms whenever the zone changes
       // NOTE: roomIndex is controlled by canvas/Scene.tsx
       useEffect(() => {
-        if (!modals.map) return;
+        if (!mapModalOpen) return;
         const newRoom = getRoomByIndex(roomIndex);
         const newZone = newRoom.location.z;
         if (zone == newZone) return;
@@ -96,7 +96,7 @@ export const MapModal: UIComponent = {
 
         setZone(newZone);
         setRoomMap(roomMap);
-      }, [modals.map, roomIndex]);
+      }, [mapModalOpen, roomIndex]);
 
       ///////////////////
       // ACTIONS

--- a/packages/client/src/app/components/modals/map/Players.tsx
+++ b/packages/client/src/app/components/modals/map/Players.tsx
@@ -13,8 +13,8 @@ export const Players = ({
 }) => {
   const room = rooms.get(index)!;
 
-  const { setAccount } = useSelected();
-  const { modals, setModals } = useVisibility();
+  const setAccount = useSelected((s) => s.setAccount);
+  const setModals = useVisibility((s) => s.setModals);
 
   ///////////////////
   // INTERACTION

--- a/packages/client/src/app/components/modals/merchant/Merchant.tsx
+++ b/packages/client/src/app/components/modals/merchant/Merchant.tsx
@@ -47,8 +47,8 @@ export const MerchantModal: UIComponent = {
     const { accountEntity } = data;
     const { getAccount, getNPC, cleanListings, refreshListings, getMusuBalance } = utils;
     const { actions, api } = network;
-    const { npcIndex } = useSelected();
-    const { modals } = useVisibility();
+    const npcIndex = useSelected((s) => s.npcIndex);
+    const merchantModalOpen = useVisibility((s) => s.modals.merchant);
 
     const [account, setAccount] = useState<Account>(NullAccount);
     const [merchant, setMerchant] = useState<NPC>(NullNPC);
@@ -66,7 +66,7 @@ export const MerchantModal: UIComponent = {
 
     // update the listings on each tick
     useEffect(() => {
-      if (!modals.merchant) return;
+      if (!merchantModalOpen) return;
       if (!merchant || npcIndex != merchant.index) return;
       setMusuBalance(getMusuBalance(account.inventories ?? []));
       refreshListings(merchant);
@@ -80,11 +80,11 @@ export const MerchantModal: UIComponent = {
 
     // updates from selected Merchant updates
     useEffect(() => {
-      if (!modals.merchant || npcIndex == merchant.index) return;
+      if (!merchantModalOpen || npcIndex == merchant.index) return;
       const newMerchant = getNPC(npcIndex) ?? NullNPC;
       setMerchant(newMerchant);
       setListings(cleanListings(newMerchant.listings, account));
-    }, [modals.merchant, npcIndex, account]);
+    }, [merchantModalOpen, npcIndex, account]);
 
     // buy from a listing
     const buy = (cart: CartItem[]) => {

--- a/packages/client/src/app/components/modals/naming/EmaBoard.tsx
+++ b/packages/client/src/app/components/modals/naming/EmaBoard.tsx
@@ -58,7 +58,7 @@ export const EmaBoardModal: UIComponent = {
     const { getAccount, getItem, getKamis } = utils;
     const { selectedAddress, apis: ownerAPIs } = useNetwork();
     const { balances: tokenBals } = useTokens();
-    const { modals } = useVisibility();
+    const emaBoardVisible = useVisibility((s) => s.modals.emaBoard);
 
     const [tick, setTick] = useState(Date.now());
     const [kamis, setKamis] = useState<Kami[]>([]);
@@ -81,10 +81,10 @@ export const EmaBoardModal: UIComponent = {
     }, []);
 
     useEffect(() => {
-      if (!modals.emaBoard) return;
+      if (!emaBoardVisible) return;
       setAccount(getAccount());
       setKamis(getKamis());
-    }, [modals.emaBoard, accountEntity, tick]);
+    }, [emaBoardVisible, accountEntity, tick]);
 
     useEffect(() => {
       const onyxInfo = tokenBals.get(onyxItem.address!);

--- a/packages/client/src/app/components/modals/naming/Stage.tsx
+++ b/packages/client/src/app/components/modals/naming/Stage.tsx
@@ -47,7 +47,7 @@ export const Stage = ({
   const { account, kami, onyxInfo, onyxItem, holyDustItem } = data;
   const { tick } = state;
   const { getItemBalance } = utils;
-  const { modals } = useVisibility();
+  const emaBoardVisible = useVisibility((s) => s.modals.emaBoard);
 
   const [holyBalance, setHolyBalance] = useState(0);
   const [name, setName] = useState('');
@@ -59,9 +59,9 @@ export const Stage = ({
   }, [tick]);
 
   useEffect(() => {
-    if (!modals.emaBoard) return;
-    if (kami.index === 0 || modals.emaBoard) setName('');
-  }, [kami.index, modals.emaBoard]);
+    if (!emaBoardVisible) return;
+    if (kami.index === 0 || emaBoardVisible) setName('');
+  }, [kami.index, emaBoardVisible]);
 
   /////////////////
   // INTERPRETATION

--- a/packages/client/src/app/components/modals/node/Node.tsx
+++ b/packages/client/src/app/components/modals/node/Node.tsx
@@ -136,8 +136,9 @@ export const NodeModal: UIComponent = {
         localSystems: { DTRevealer },
       } = network;
       const { getAccount, getNode } = utils;
-      const { nodeIndex } = useSelected();
-      const { modals, setModals } = useVisibility();
+      const nodeIndex = useSelected((s) => s.nodeIndex);
+      const nodeModalOpen = useVisibility((s) => s.modals.node);
+      const setModals = useVisibility((s) => s.setModals);
 
       const [account, setAccount] = useState<Account>(NullAccount);
       const [node, setNode] = useState<Node>(NullNode);
@@ -152,9 +153,9 @@ export const NodeModal: UIComponent = {
 
       // refresh account data whenever the modal is opened
       useEffect(() => {
-        if (!modals.node) return;
+        if (!nodeModalOpen) return;
         setAccount(getAccount());
-      }, [modals.node, lastRefresh]);
+      }, [nodeModalOpen, lastRefresh]);
 
       // updates from selected Node updates
       useEffect(() => {

--- a/packages/client/src/app/components/modals/node/header/Header.tsx
+++ b/packages/client/src/app/components/modals/node/header/Header.tsx
@@ -48,7 +48,7 @@ export const Header = ({
   const { queryScavInstance } = utils;
   const { parseConditionalText, passesNodeReqs } = utils;
 
-  const { modals } = useVisibility();
+  const nodeModalVisible = useVisibility((s) => s.modals.node);
   const [kamis, setKamis] = useState<Kami[]>([]);
   const [room, setRoom] = useState<Room>(NullRoom);
   const [scavenge, setScavenge] = useState<ScavBar>(NullScavenge);
@@ -63,17 +63,17 @@ export const Header = ({
 
   // update the scavenge whenever the node changes
   useEffect(() => {
-    if (!modals.node) return;
+    if (!nodeModalVisible) return;
 
     const scavenge = node.scavenge;
     if (scavenge) setScavenge(scavenge);
     if (node.roomIndex !== room.index) setRoom(getRoom(node.roomIndex));
-  }, [node.index, modals.node]);
+  }, [node.index, nodeModalVisible]);
 
   // keep the account kamis up to date whenever the modal is open
   useEffect(() => {
-    if (modals.node) setKamis(getAccountKamis());
-  }, [modals.node, lastRefresh]);
+    if (nodeModalVisible) setKamis(getAccountKamis());
+  }, [nodeModalVisible, lastRefresh]);
 
   /////////////////
   // INTERPRETATION

--- a/packages/client/src/app/components/modals/node/header/ScavengeBar.tsx
+++ b/packages/client/src/app/components/modals/node/header/ScavengeBar.tsx
@@ -23,7 +23,7 @@ export const ScavengeBar = ({
   };
 }) => {
   const { getPoints, queryScavInstance } = utils;
-  const { modals } = useVisibility();
+  const nodeModalVisible = useVisibility((s) => s.modals.node);
 
   const [lastSync, setLastSync] = useState(Date.now());
   const [points, setPoints] = useState(0);
@@ -42,9 +42,9 @@ export const ScavengeBar = ({
 
   // periodically update the number of rolls and points if modal is open
   useEffect(() => {
-    if (!modals.node || !scavenge) return;
+    if (!nodeModalVisible || !scavenge) return;
     update();
-  }, [lastSync, scavenge.index]);
+  }, [lastSync, scavenge.index, nodeModalVisible]);
 
   const update = () => {
     const instanceEntity = queryScavInstance();

--- a/packages/client/src/app/components/modals/node/kards/EnemyKards.tsx
+++ b/packages/client/src/app/components/modals/node/kards/EnemyKards.tsx
@@ -49,8 +49,11 @@ export const EnemyCards = ({
   };
 }) => {
   const { getOwner, getKami } = utils;
-  const { modals, setModals } = useVisibility();
-  const { accountIndex, setAccount, nodeIndex } = useSelected();
+  const accountModalOpen = useVisibility((s) => s.modals.account);
+  const setModals = useVisibility((s) => s.setModals);
+  const accountIndex = useSelected((s) => s.accountIndex);
+  const setAccount = useSelected((s) => s.setAccount);
+  const nodeIndex = useSelected((s) => s.nodeIndex);
 
   const [isCollapsed, setIsCollapsed] = useState(true);
   const [isUpdating, setIsUpdating] = useState(false);
@@ -188,7 +191,7 @@ export const EnemyCards = ({
 
   // toggle the node modal to the selected one
   const selectAccount = (index: number) => {
-    if (!modals.account) setModals({ account: true, party: false, map: false });
+    if (!accountModalOpen) setModals({ account: true, party: false, map: false });
     if (accountIndex !== index) setAccount(index);
     playClick();
   };

--- a/packages/client/src/app/components/modals/node/kards/Kards.tsx
+++ b/packages/client/src/app/components/modals/node/kards/Kards.tsx
@@ -38,7 +38,7 @@ export const Kards = ({
   };
 }) => {
   const { getKami } = utils;
-  const { modals } = useVisibility();
+  const nodeModalVisible = useVisibility((s) => s.modals.node);
   const containerRef = useRef<HTMLDivElement>(null);
 
   const [allies, setAllies] = useState<Kami[]>([]);
@@ -70,19 +70,19 @@ export const Kards = ({
 
   // populate the ally kami data as new ones come in
   useEffect(() => {
-    if (!modals.node) return;
+    if (!nodeModalVisible) return;
     setAlliesUpdating(true);
     setAllies(allyEntities.map((entity) => getKami(entity, true)));
 
     setAlliesUpdating(false);
-  }, [modals.node, allyEntities]);
+  }, [nodeModalVisible, allyEntities]);
 
   // check to refresh ally data at each interval
   useEffect(() => {
-    if (!modals.node || alliesUpdating) return;
+    if (!nodeModalVisible || alliesUpdating) return;
     const newAllies = allies.map((ally) => getKami(ally.entity));
     setAllies(newAllies);
-  }, [modals.node, lastRefresh]);
+  }, [nodeModalVisible, lastRefresh]);
 
   // scrolling effects for enemy kards
   useEffect(() => {

--- a/packages/client/src/app/components/modals/obol/Obol.tsx
+++ b/packages/client/src/app/components/modals/obol/Obol.tsx
@@ -43,18 +43,19 @@ export const ObolModal: UIComponent = {
     const { actions, api } = network;
     const { getObolsBalance } = utils;
 
-    const { modals, setModals } = useVisibility();
+    const lootBoxModalVisible = useVisibility((s) => s.modals.lootBox);
+    const setModals = useVisibility((s) => s.setModals);
     const [eggsQuantity, setEggsQuantity] = useState(1);
     const [isDisabled, setIsDisabled] = useState(false);
 
     /////////////////
     useEffect(() => {
-      if (!modals.lootBox) return;
+      if (!lootBoxModalVisible) return;
       // reset eggsQuantity on modal close
       setEggsQuantity(1);
       // close crafting modal
       setModals({ crafting: false });
-    }, [modals.lootBox]);
+    }, [lootBoxModalVisible, setModals]);
 
     /////////////////
     // HELPERS

--- a/packages/client/src/app/components/modals/party/KamiList.tsx
+++ b/packages/client/src/app/components/modals/party/KamiList.tsx
@@ -59,7 +59,7 @@ export const KamiList = ({
     getAllAccounts: () => Account[];
   };
 }) => {
-  const { modals } = useVisibility();
+  const partyModalVisible = useVisibility((s) => s.modals.party);
 
   /////////////////
   // DISPLAY
@@ -89,7 +89,7 @@ export const KamiList = ({
         display={display}
         state={{ displayedKamis }}
         utils={utils}
-        isVisible={modals.party && view === 'expanded'}
+        isVisible={partyModalVisible && view === 'expanded'}
       />
 
       <KamisCollapsed
@@ -98,14 +98,14 @@ export const KamiList = ({
         display={display}
         state={{ displayedKamis, tick }}
         utils={utils}
-        isVisible={modals.party && view === 'collapsed'}
+        isVisible={partyModalVisible && view === 'collapsed'}
       />
       <KamisExternal
         actions={actions}
         controls={{ view }}
         data={{ ...data, kamis: data.wildKamis }}
         utils={utils}
-        isVisible={modals.party && view === 'external'}
+        isVisible={partyModalVisible && view === 'external'}
       />
     </Container>
   );

--- a/packages/client/src/app/components/modals/party/KamisExpanded.tsx
+++ b/packages/client/src/app/components/modals/party/KamisExpanded.tsx
@@ -56,8 +56,10 @@ export const KamisExpanded = ({
 
   isVisible: boolean;
 }) => {
-  const { modals, setModals } = useVisibility();
-  const { nodeIndex, setNode: setSelectedNode } = useSelected(); // node selected by user
+  const nodeModalOpen = useVisibility((s) => s.modals.node);
+  const setModals = useVisibility((s) => s.setModals);
+  const nodeIndex = useSelected((s) => s.nodeIndex);
+  const setSelectedNode = useSelected((s) => s.setNode);
 
   /////////////////
   // INTERPRETATION
@@ -125,7 +127,7 @@ export const KamisExpanded = ({
   // toggle the node modal to the selected one
   const selectNode = (index: number) => {
     if (nodeIndex !== index) setSelectedNode(index);
-    if (!modals.node) setModals({ node: true });
+    if (!nodeModalOpen) setModals({ node: true });
     else if (nodeIndex == index) setModals({ node: false });
     playClick();
   };

--- a/packages/client/src/app/components/modals/party/Party.tsx
+++ b/packages/client/src/app/components/modals/party/Party.tsx
@@ -96,9 +96,10 @@ export const PartyModal: UIComponent = {
     const { getAccount, getItem, getNode } = utils;
     const { getKami, getWorldKamis, queryKamiByIndex, queryAllAccounts } = utils;
 
-    const { modals } = useVisibility();
-    const { selectedAddress, apis: ownerAPIs } = useNetwork();
-    const { balances: tokenBals } = useTokens();
+    const partyModalVisible = useVisibility((s) => s.modals.party);
+    const selectedAddress = useNetwork((s) => s.selectedAddress);
+    const ownerAPIs = useNetwork((s) => s.apis);
+    const tokenBals = useTokens((s) => s.balances);
     const { writeContract } = useWriteContract();
 
     const [account, setAccount] = useState<Account>(NullAccount);
@@ -150,7 +151,7 @@ export const PartyModal: UIComponent = {
 
     // update account and kamis every tick or if the connnected account changes
     useEffect(() => {
-      if (!modals.party) return;
+      if (!partyModalVisible) return;
 
       // update the connected account if it changes
       if (accountEntity != account.entity) {
@@ -168,7 +169,7 @@ export const PartyModal: UIComponent = {
         const accountsSorted = newAccounts.sort((a, b) => a.name.localeCompare(b.name));
         setAccounts(accountsSorted);
       }
-    }, [modals.party, accountEntity, tick]);
+    }, [partyModalVisible, accountEntity, tick]);
 
     // update node if the account or room changes
     useEffect(() => {

--- a/packages/client/src/app/components/modals/party/Toolbar.tsx
+++ b/packages/client/src/app/components/modals/party/Toolbar.tsx
@@ -50,7 +50,7 @@ export const Toolbar = ({
   const { kamis, wildKamis } = data;
   const { passesNodeReqs } = utils;
   const { displayedKamis, setDisplayedKamis, tick } = state;
-  const { modals } = useVisibility();
+  const partyModalVisible = useVisibility((s) => s.modals.party);
 
   const [addOptions, setAddOptions] = useState<DropdownOption[]>([]);
   const [collectOptions, setCollectOptions] = useState<DropdownOption[]>([]);
@@ -60,7 +60,7 @@ export const Toolbar = ({
   // SUBSCRIPTIONS
 
   useEffect(() => {
-    if (!modals.party) return;
+    if (!partyModalVisible) return;
     if (view === 'external') return;
 
     const addOptions = displayedKamis
@@ -78,13 +78,13 @@ export const Toolbar = ({
     setAddOptions(addOptions);
     setCollectOptions(collectOptions);
     setStopOptions(stopOptions);
-  }, [displayedKamis, tick, modals.party]);
+  }, [displayedKamis, tick, partyModalVisible]);
 
   // sort kamis when changes are detected
   // TODO: trigger updates after successful state updates
   // NOTE: sorts in place (setDisplayedKamis is just used to trigger a rendering update)
   useEffect(() => {
-    if (!modals.party) return;
+    if (!partyModalVisible) return;
 
     let sorted = view === 'external' ? wildKamis : kamis;
     if (sort === 'name') {
@@ -109,7 +109,7 @@ export const Toolbar = ({
     }
 
     setDisplayedKamis(sorted);
-  }, [modals.party, kamis.length, sort, view]);
+  }, [partyModalVisible, kamis.length, sort, view]);
 
   /////////////////
   // INTERACTION

--- a/packages/client/src/app/components/modals/presale/Presale.tsx
+++ b/packages/client/src/app/components/modals/presale/Presale.tsx
@@ -40,7 +40,7 @@ export const Presale: UIComponent = {
       const { selectedAddress, apis } = useNetwork();
       const { actions } = network;
 
-      const { modals } = useVisibility();
+      const presaleModalVisible = useVisibility((s) => s.modals.presale);
       const [tick, setTick] = useState(Date.now());
 
       // ticking
@@ -52,7 +52,7 @@ export const Presale: UIComponent = {
 
       useWatchBlockNumber({
         onBlockNumber: () => {
-          if (modals.presale) {
+          if (presaleModalVisible) {
             refetchInfo();
             refetchToken();
           }

--- a/packages/client/src/app/components/modals/quests/Quests.tsx
+++ b/packages/client/src/app/components/modals/quests/Quests.tsx
@@ -86,7 +86,7 @@ export const QuestModal: UIComponent = {
     const { actions, api, notifications } = network;
     const { ongoing, completed, registry } = data.quests;
     const { getItem, populate, filterByAvailable } = utils;
-    const { modals } = useVisibility();
+    const questsModalVisible = useVisibility((s) => s.modals.quests);
 
     const isUpdating = useRef(false);
     const [tab, setTab] = useState<TabType>('ONGOING');
@@ -108,7 +108,7 @@ export const QuestModal: UIComponent = {
       if (populated.length > available.length) setTab('AVAILABLE');
 
       isUpdating.current = false;
-    }, [modals.quests, registry.length, completed.length, ongoing.length]);
+    }, [questsModalVisible, registry.length, completed.length, ongoing.length]);
 
     // update the Notifications when the number of available quests changes
     useEffect(() => {

--- a/packages/client/src/app/components/modals/quests/list/Completed.tsx
+++ b/packages/client/src/app/components/modals/quests/list/Completed.tsx
@@ -26,7 +26,7 @@ export const CompletedQuests = ({
   isVisible: boolean;
 }) => {
   const { describeEntity, populate, getItemBalance } = utils;
-  const { modals } = useVisibility();
+  const questsModalVisible = useVisibility((s) => s.modals.quests);
   const [cleaned, setCleaned] = useState<Quest[]>([]);
   const [lastUpdate, setLastUpdate] = useState(0);
 
@@ -38,8 +38,8 @@ export const CompletedQuests = ({
   // update when this tab is opened or data changes if stale
   useEffect(() => {
     const isStale = Date.now() - lastUpdate > STALE_TIME;
-    if (modals.quests && isVisible && isStale) update();
-  }, [modals.quests, isVisible]);
+    if (questsModalVisible && isVisible && isStale) update();
+  }, [questsModalVisible, isVisible]);
 
   const update = async () => {
     const fullQuests = quests.map((q) => populate(q));

--- a/packages/client/src/app/components/modals/quests/list/Ongoing.tsx
+++ b/packages/client/src/app/components/modals/quests/list/Ongoing.tsx
@@ -30,7 +30,7 @@ export const OngoingQuests = ({
   isVisible: boolean;
 }) => {
   const { populate, parseObjectives } = utils;
-  const { modals } = useVisibility();
+  const questsModalVisible = useVisibility((s) => s.modals.quests);
   const [cleaned, setCleaned] = useState<Quest[]>([]);
   const [lastRefresh, setLastRefresh] = useState(Date.now());
   const [lastUpdate, setLastUpdate] = useState(0);
@@ -49,13 +49,13 @@ export const OngoingQuests = ({
   // update when this tab is opened or data changes if stale
   useEffect(() => {
     const isStale = Date.now() - lastUpdate > STALE_TIME;
-    if (modals.quests && isVisible && isStale) update();
-  }, [modals.quests, isVisible]);
+    if (questsModalVisible && isVisible && isStale) update();
+  }, [questsModalVisible, isVisible]);
 
   // update data every cycle when this list is visible
   useEffect(() => {
-    if (modals.quests && isVisible) update();
-  }, [lastRefresh]);
+    if (questsModalVisible && isVisible) update();
+  }, [lastRefresh, questsModalVisible, isVisible]);
 
   const update = async () => {
     const fullQuests = quests.map((q) => populate(q));

--- a/packages/client/src/app/components/modals/settings/Account.tsx
+++ b/packages/client/src/app/components/modals/settings/Account.tsx
@@ -7,7 +7,7 @@ import { abbreviateAddress } from 'utils/address';
 
 export const Account = () => {
   const { account: kamiAccount } = useAccount();
-  const { modals, setModals } = useVisibility();
+  const setModals = useVisibility((s) => s.setModals);
   const { exportWallet } = usePrivy();
 
   const FieldRow = (label: string, value: string) => {

--- a/packages/client/src/app/components/modals/trading/Trading.tsx
+++ b/packages/client/src/app/components/modals/trading/Trading.tsx
@@ -66,7 +66,7 @@ export const TradingModal: UIComponent = {
     const { actions } = network;
     const { account } = data;
     const { getTrade, queryTrades } = utils;
-    const { modals } = useVisibility();
+    const tradingModalVisible = useVisibility((s) => s.modals.trading);
     const { selectedAddress, apis } = useNetwork();
 
     const [items, setItems] = useState<Item[]>([]);
@@ -92,14 +92,14 @@ export const TradingModal: UIComponent = {
 
     // sets trades upon opening modal
     useEffect(() => {
-      if (!modals.trading) return;
+      if (!tradingModalVisible) return;
       refreshTrades();
       getTradeHistoryKamiden(account.id);
-    }, [modals.trading, tick]);
+    }, [tradingModalVisible, tick]);
 
     useEffect(() => {
       refreshItemRegistry();
-    }, [modals.trading]);
+    }, [tradingModalVisible]);
 
     /////////////////
     // GETTERS

--- a/packages/client/src/app/components/modals/trading/management/offers/Offers.tsx
+++ b/packages/client/src/app/components/modals/trading/management/offers/Offers.tsx
@@ -39,21 +39,21 @@ export const Offers = ({
 }) => {
   const { tab } = controls;
   const { account, trades } = data;
-  const { modals } = useVisibility();
+  const tradingModalVisible = useVisibility((s) => s.modals.trading);
 
   const [openTrades, setOpenTrades] = useState<Trade[]>([]);
   const [executedTrades, setExecutedTrades] = useState<Trade[]>([]);
 
   // keep the list of open and executed trades updated'
   useEffect(() => {
-    if (!modals.trading || tab !== `Management`) return;
+    if (!tradingModalVisible || tab !== `Management`) return;
     const openTrades = trades.filter((trade) => trade.state === 'PENDING');
     const executedTrades = trades.filter(
       (trade) => trade.state === 'EXECUTED' && trade.maker?.entity === account.entity
     );
     setOpenTrades(openTrades);
     setExecutedTrades(executedTrades);
-  }, [trades, modals.trading, tab]);
+  }, [trades, tradingModalVisible, tab]);
 
   /////////////////
   // DISPLAY

--- a/packages/client/src/app/components/validators/AccountRegistrar/AccountRegistrar.tsx
+++ b/packages/client/src/app/components/validators/AccountRegistrar/AccountRegistrar.tsx
@@ -70,8 +70,11 @@ export const AccountRegistrar: UIComponent = {
         apis,
         validations: networkValidations,
       } = useNetwork();
-      const { toggleModals, toggleFixtures } = useVisibility();
-      const { validators, setValidators } = useVisibility();
+      const toggleModals = useVisibility((s) => s.toggleModals);
+      const toggleFixtures = useVisibility((s) => s.toggleFixtures);
+      const accountRegistrarVisible = useVisibility((s) => s.validators.accountRegistrar);
+      const walletConnectorVisible = useVisibility((s) => s.validators.walletConnector);
+      const setValidators = useVisibility((s) => s.setValidators);
       const { validations, setValidations } = useAccount();
       const { setAccount } = useAccount();
 
@@ -102,7 +105,7 @@ export const AccountRegistrar: UIComponent = {
           toggleFixtures(true);
         }
 
-        if (isVisible != validators.accountRegistrar) {
+        if (isVisible != accountRegistrarVisible) {
           setValidators({
             walletConnector: false,
             accountRegistrar: isVisible,
@@ -110,7 +113,7 @@ export const AccountRegistrar: UIComponent = {
             gasHarasser: false,
           });
         }
-      }, [networkValidations, validations.accountExists, validators.walletConnector]);
+      }, [networkValidations, validations.accountExists, walletConnectorVisible]);
 
       /////////////////
       // ACTION


### PR DESCRIPTION
- fix constant re-renders by replacing broad zustand sub `useSelected()` and `useVisibiliity()` with focused selector 
- decouble modals renders (before if I clicked on craft button, it would trigger a unnecessary render on a web of modals with that have a broad zustand sub via `useVisibility()` like clock, gasGauge, etc)

**spam clicking craft button cause constant rerender of other modals using `useVisibility()`** 
- **note: yellow outline indicate constant rerenders**
- <img width="1256" height="569" alt="Screenshot 2025-09-02 at 19 15 37" src="https://github.com/user-attachments/assets/53a9def1-2b59-43e8-b51e-55a668545e31" />

**kami party (after vs before)** 

https://github.com/user-attachments/assets/cd4cc411-4db0-40a1-99b4-84cc54895d1c

**map and chat (after vs before)**

https://github.com/user-attachments/assets/900874f7-1c58-4a83-b34e-a9e690d2cc07

**gacha (after vs before)**

https://github.com/user-attachments/assets/b3d8887a-9297-4268-ad71-67e1e64d772f

**mina (after vs before)**

https://github.com/user-attachments/assets/1e62a71e-90c6-4cbc-a302-90555bd274a7

--------------

todo:
- revisit scene to see if ticking is needed (can we just update whenever the account changes)
- revisit kards and enemykards (ticking logic)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Migrated components to selector-based state access for modal visibility and selections, updating effect dependencies and toggle logic accordingly.
  - Improves responsiveness by reducing unnecessary re-renders across menus, modals (chat, gacha, map, node, party, quests, trading, etc.), fixtures, and library components.
  - No public APIs changed; behavior remains consistent.

- Documentation
  - Fixed a typo in the ExitButton component comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->