### PR TITLE
account modal friends bio fixes

### DIFF
--- a/packages/client/src/app/components/modals/account/blocked/Blocked.tsx
+++ b/packages/client/src/app/components/modals/account/blocked/Blocked.tsx
@@ -41,6 +41,7 @@ export const Blocked = ({
 
 const Container = styled.div`
   width: 100%;
+  gap: 0.6vw;
   display: flex;
   flex-flow: column nowrap;
   justify-content: center;

--- a/packages/client/src/app/components/modals/account/requests/Inbound.tsx
+++ b/packages/client/src/app/components/modals/account/requests/Inbound.tsx
@@ -43,7 +43,7 @@ export const Inbound = ({
           <AccountCard
             key={friendship.account.index}
             account={friendship.account}
-            description={[friendship.account.bio ?? 'inbound friend request']}
+            description={[friendship.account.bio || 'inbound friend request']}
             actions={Actions(friendship)}
           />
         ))

--- a/packages/client/src/app/components/modals/account/requests/Outbound.tsx
+++ b/packages/client/src/app/components/modals/account/requests/Outbound.tsx
@@ -33,7 +33,7 @@ export const Outbound = ({
           <AccountCard
             key={friendship.target.index}
             account={friendship.target}
-            description={[friendship.account.bio ?? 'outbound friend request']}
+            description={[friendship.target.bio || 'outbound friend request']}
             actions={Actions(friendship)}
           />
         ))

--- a/packages/client/src/network/shapes/Account/friends.ts
+++ b/packages/client/src/network/shapes/Account/friends.ts
@@ -24,10 +24,10 @@ export interface Friends {
 export const getFriends = (world: World, components: Components, entity: EntityIndex) => {
   const id = world.entities[entity];
   return {
-    friends: getAccFriends(world, components, entity),
-    incomingReqs: getAccIncomingRequests(world, components, entity),
-    outgoingReqs: getAccOutgoingRequests(world, components, entity),
-    blocked: getAccBlocked(world, components, entity),
+    friends: getAccFriends(world, components, entity, { bio: true }),
+    incomingReqs: getAccIncomingRequests(world, components, entity, { bio: true }),
+    outgoingReqs: getAccOutgoingRequests(world, components, entity, { bio: true }),
+    blocked: getAccBlocked(world, components, entity, { bio: true }),
     limits: {
       friends:
         getConfigFieldValue(world, components, 'BASE_FRIENDS_LIMIT') * 1 +

--- a/packages/client/src/network/shapes/Friendship.ts
+++ b/packages/client/src/network/shapes/Friendship.ts
@@ -67,19 +67,21 @@ export const getAccFriends = (
 export const getAccIncomingRequests = (
   world: World,
   components: Components,
-  entity: EntityIndex
+  entity: EntityIndex,
+  accountOptions?: any
 ): Friendship[] => {
   const id = world.entities[entity];
-  return queryFriendshipX(world, components, { target: id, state: 'REQUEST' });
+  return queryFriendshipX(world, components, { target: id, state: 'REQUEST' }, accountOptions);
 };
 
 export const getAccOutgoingRequests = (
   world: World,
   components: Components,
-  entity: EntityIndex
+  entity: EntityIndex,
+  accountOptions?: any
 ): Friendship[] => {
   const id = world.entities[entity];
-  return queryFriendshipX(world, components, { account: id, state: 'REQUEST' });
+  return queryFriendshipX(world, components, { account: id, state: 'REQUEST' }, accountOptions);
 };
 
 export const getAccBlocked = (


### PR DESCRIPTION
bugs: 
- within account modal friends list (incoming, outgoing, blocked) bio always default to fallback `hi`, `outbound friend request`, `inbound friend request`, `hate crime enthusiast` instead of showing custom bio if set 

fixes:
- pass param to retrieve bios when getting friend list (inbound, outbound, blocked)
- catch empty '' (default) in friends bio so it correctly shows custom bio or fallback if not set
- fix gap to be consistent in blocked friends list with other friends list

before
<img width="407" height="301" alt="Screenshot 2025-09-03 at 03 00 04" src="https://github.com/user-attachments/assets/a6d3e5d8-e248-4c63-9f5e-ccc01a37ff22" />
<img width="401" height="420" alt="Screenshot 2025-09-03 at 05 22 43" src="https://github.com/user-attachments/assets/ac1d9181-a5ae-479d-a641-72cbdcd7fedc" />
<img width="445" height="502" alt="Screenshot 2025-09-03 at 02 59 55" src="https://github.com/user-attachments/assets/51d77118-f494-48b8-86f6-015877d58edb" />




after
<img width="411" height="362" alt="Screenshot 2025-09-03 at 03 47 57" src="https://github.com/user-attachments/assets/d2846d19-8b1d-4afa-85b0-547f33b2cf57" />
<img width="401" height="423" alt="Screenshot 2025-09-03 at 05 24 44" src="https://github.com/user-attachments/assets/82795ed0-3e1c-469d-b789-08f3d8477b9c" />
<img width="445" height="502" alt="Screenshot 2025-09-03 at 04 17 31" src="https://github.com/user-attachments/assets/a7558004-bdbe-4ddd-ad38-e1c5e93965cb" />

