### PR TITLE
Overlapping trade tooltip fix

### DIFF
--- a/packages/client/src/app/components/modals/trading/library/OfferCard.tsx
+++ b/packages/client/src/app/components/modals/trading/library/OfferCard.tsx
@@ -13,11 +13,7 @@ import { getTypeColor } from '../helpers';
 // TODO: add support for Trades you're the Taker for (disable action)
 export const OfferCard = ({
   button,
-  data: {
-    account,
-    trade,
-    type,
-  },
+  data: { account, trade, type },
   utils,
   reverse,
 }: {
@@ -124,8 +120,8 @@ export const OfferCard = ({
         </TextTooltip>
       </Side>
 
-      <TextTooltip title='status' text={utils?.getStateTooltip() || []} alignText='left'>
-        <Controls>
+      <Controls>
+        <TextTooltip title='status' text={utils?.getStateTooltip() || []} alignText='left'>
           {trade.state === 'CANCELLED' && <CancelOverlay>Cancelled</CancelOverlay>}
           <TagContainer>
             <Overlay top={0.21} left={0.21}>
@@ -136,13 +132,13 @@ export const OfferCard = ({
             </Overlay>
             <TypeTag color={getTypeColor(type)}>{type}</TypeTag>
           </TagContainer>
-          <TextTooltip text={button.tooltip} fullWidth>
-            <Button onClick={handleClick} disabled={button.disabled}>
-              {button.text}
-            </Button>
-          </TextTooltip>
-        </Controls>
-      </TextTooltip>
+        </TextTooltip>
+        <TextTooltip text={button.tooltip} fullWidth>
+          <Button onClick={handleClick} disabled={button.disabled}>
+            {button.text}
+          </Button>
+        </TextTooltip>
+      </Controls>
 
       <Side span={getSpan()} borderLeft>
         <TextTooltip
@@ -242,13 +238,14 @@ const Button = styled.button`
   }
   &:disabled {
     background-color: #bbb;
-    cursor: default;
+    cursor: help;
   }
 `;
 
 const TagContainer = styled.div`
   position: relative;
-  width: 100%;
+  width: 15vw;
+  height: 4vw;
   flex-grow: 1;
 
   display: flex;


### PR DESCRIPTION
fixes this:
<img width="745" height="756" alt="image" src="https://github.com/user-attachments/assets/3c68e707-8866-4d3c-9bfe-d31cf8e656b6" />
