### PR TITLE
update privy config to enforce only wallet login

### DIFF
--- a/packages/client/src/clients/privy/config.ts
+++ b/packages/client/src/clients/privy/config.ts
@@ -4,6 +4,7 @@ import { DefaultChain } from 'constants/chains';
 export const config: PrivyClientConfig = {
   supportedChains: [DefaultChain],
   defaultChain: DefaultChain,
+  loginMethods: ['wallet'],
   embeddedWallets: {
     createOnLogin: 'all-users',
     noPromptOnSignature: true,


### PR DESCRIPTION
Enforce only wallet login via privy. Allows us to enable various account linking methods (twitter, github, etc) without having those options show up in the initial privy login modal during user login

before
<img width="378" height="514" alt="Screenshot 2025-09-08 at 22 41 13" src="https://github.com/user-attachments/assets/b8ec510e-5f07-49ac-8692-a05f4d81bc35" />

after
<img width="373" height="507" alt="Screenshot 2025-09-08 at 22 41 19" src="https://github.com/user-attachments/assets/94f67a94-b644-4f87-89a7-deb7fdbad64c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added wallet-based login option. Users can now authenticate directly with their crypto wallet, offering a faster, Web3-friendly sign-in experience.
  - Preserves existing login flows while expanding choices for authentication, improving flexibility for both new and returning users.
  - Enhances onboarding for users who prefer using wallets, reducing friction and streamlining access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->