### PR TITLE
cast item stacking

### DIFF
--- a/packages/client/src/app/components/library/buttons/actions/CastItemButton.tsx
+++ b/packages/client/src/app/components/library/buttons/actions/CastItemButton.tsx
@@ -1,6 +1,6 @@
 import { World } from '@mud-classic/recs';
 import { cleanInventories, filterInventories, Inventory } from 'app/cache/inventory';
-import { calcCooldown, isHarvesting, Kami } from 'app/cache/kami';
+import { isHarvesting, Kami } from 'app/cache/kami';
 import { TextTooltip } from 'app/components/library';
 import { Components } from 'network/components';
 import { NetworkLayer } from 'network/create';
@@ -61,12 +61,12 @@ export const CastItemButton = (
 
 // generate a tooltip for any reason the kami cannot be cast on
 const getDisabledTooltip = (kami: Kami, account: Account): string => {
-  const cooldown = calcCooldown(kami);
+  const stamina = account.stamina;
   const inRoom = kami.harvest?.node?.roomIndex == account.roomIndex;
 
   let tooltip = '';
   if (isHarvesting(kami) && !inRoom) tooltip = `too far away`;
-  else if (cooldown > 0) tooltip = `on cooldown (${cooldown.toFixed(0)}s)`;
+  else if (stamina.sync < 10) tooltip = `insufficient stamina`; // costs 10 stamina to cast
 
   return tooltip;
 };

--- a/packages/contracts/src/systems/KamiCastItemSystem.sol
+++ b/packages/contracts/src/systems/KamiCastItemSystem.sol
@@ -22,11 +22,13 @@ contract KamiCastItemSystem is System {
 
     // pet checks
     LibKami.verifyRoom(components, kamiID, accID);
-    LibKami.verifyCooldown(components, kamiID);
 
     // item checks
     LibItem.verifyForShape(components, itemIndex, "ENEMY_KAMI");
     LibItem.verifyRequirements(components, itemIndex, "USE", kamiID);
+
+    // use stamina from caster
+    LibAccount.depleteStamina(components, accID, 10); // implicit stamina check
 
     // use item
     LibKami.sync(components, kamiID);


### PR DESCRIPTION
- allows `cast` items to stack
- casting items now cost 10 stamina

### To Update
- KamiCastItemSystem

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Casting now uses stamina instead of cooldown. Each cast consumes 10 stamina.
  * The cast button is disabled when stamina is insufficient, with an updated tooltip explaining why.
  * Distance requirements for casting remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->