### PR TITLE
update account card to handle bios with long text

### DIFF
--- a/packages/client/src/app/components/library/cards/AccountCard/AccountCard.tsx
+++ b/packages/client/src/app/components/library/cards/AccountCard/AccountCard.tsx
@@ -56,17 +56,17 @@ export const AccountCard = ({
         </TextTooltip>
       </TitleBar>
       <Content>
-        <ContentColumn key='col-1'>
+        <BioColumn key='col-1'>
           {description.map((text, i) => (
             <TextMedium key={`desc-${i}`}>{text}</TextMedium>
           ))}
-        </ContentColumn>
-        <ContentColumn key='col-2'>
+        </BioColumn>
+        <ActionsColumn key='col-2'>
           <ContentSubtext key='subtext' onClick={subtextOnClick}>
             {subtext}
           </ContentSubtext>
           <ContentActions key='actions'>{actions}</ContentActions>
-        </ContentColumn>
+        </ActionsColumn>
       </Content>
     </Card>
   );
@@ -94,14 +94,37 @@ const TitleText = styled.div`
 
 const Content = styled.div`
   padding: 0.2vw;
+  min-height: 4vw;
 
-  display: flex;
-  flex-flow: row nowrap;
+  display: grid;
+  grid-template-columns: 9fr 1fr; 
   align-items: stretch;
 `;
 
-const ContentColumn = styled.div`
-  flex-grow: 1;
+const BioColumn = styled.div`
+  display: flex;
+  flex-flow: column nowrap;
+  max-height: 3.5vw;
+  overflow-y: auto;
+  overflow-wrap: break-word; 
+  
+  /* Hide scrollbar by default and show on hover */
+  &::-webkit-scrollbar {
+    width: 1vw;
+  }
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 8px;
+  }
+  &:hover::-webkit-scrollbar-thumb {
+    background-color: #ccc;
+  }
+`;
+
+const ActionsColumn = styled.div`
   display: flex;
   flex-flow: column nowrap;
 `;

--- a/packages/client/src/app/components/library/cards/AccountCard/AccountCard.tsx
+++ b/packages/client/src/app/components/library/cards/AccountCard/AccountCard.tsx
@@ -56,7 +56,7 @@ export const AccountCard = ({
         </TextTooltip>
       </TitleBar>
       <Content>
-        <BioColumn key='col-1'>
+        <BioColumn key='col-1' tabIndex={0} role="region" aria-label="Account bio">
           {description.map((text, i) => (
             <TextMedium key={`desc-${i}`}>{text}</TextMedium>
           ))}


### PR DESCRIPTION
handle cases where a user has a long bio set (~140 characters) and wrap text within account card

before:

<img width="340" height="292" alt="Screenshot 2025-09-09 at 13 28 29" src="https://github.com/user-attachments/assets/0369123d-fe26-4fa1-83a4-2abe17831bce" />

after: 

<img width="323" height="263" alt="Screenshot 2025-09-09 at 13 28 41" src="https://github.com/user-attachments/assets/16c1b4eb-b4c6-4e06-8aea-409fcb92abb1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked Account Card to a two-column layout with a dedicated actions area for clearer separation of details and actions.
  * Preserved existing interaction behavior (no changes to clicks or modals).

* **Style**
  * Improved bio readability with word wrapping and a scrollable content area.
  * Subtle scrollbars appear on hover for long bios.
  * Adjusted spacing and minimum height for a more consistent, balanced presentation.

* **Accessibility**
  * Enhanced navigability and screen-reader labeling for the bio region.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->