### PR TITLE
link twitter to account via privy

### DIFF
--- a/packages/client/src/app/components/library/buttons/IconButton.tsx
+++ b/packages/client/src/app/components/library/buttons/IconButton.tsx
@@ -32,6 +32,8 @@ export const IconButton = forwardRef(function IconButton(
     scale = 2.5,
     scaleOrientation = 'vw',
     icon,
+    filter,
+    noBorder,
   }: {
     img?: string | SvgIconComponent;
     onClick: Function;
@@ -56,12 +58,14 @@ export const IconButton = forwardRef(function IconButton(
     scaleOrientation?: 'vw' | 'vh';
     shadow?: boolean;
     flatten?: `left` | `right`; // flattens a side, for use with dropdowns
+    noBorder?: boolean;
     icon?: {
       size?: number;
       inset?: { px?: number; x?: number; y?: number };
       color?: string;
       position?: 'left' | 'right';
     };
+    filter?: string;
   },
   ref: ForwardedRef<HTMLButtonElement>
 ) {
@@ -109,6 +113,8 @@ export const IconButton = forwardRef(function IconButton(
       shadow={shadow}
       ref={ref}
       flatten={flatten}
+      noBorder={noBorder}
+      filter={filter}
     >
       {MyImage()}
       {text && (
@@ -134,9 +140,11 @@ const Container = styled.button<{
   pulse?: boolean;
   flatten?: `left` | `right`;
   shadow?: boolean;
+  noBorder?: boolean;
+  filter?: string;
 }>`
   position: relative;
-  border: solid black 0.15vw;
+  border: ${({ noBorder }) => (noBorder ? 'none' : 'solid black 0.15vw')};
   border-radius: ${({ radius, orientation }) => `${radius}${orientation}`};
 
   height: ${({ scale, orientation }) => `${scale}${orientation}`};
@@ -173,6 +181,7 @@ const Container = styled.button<{
   }
 
   ${({ pulse }) => pulse && `animation: ${pulseFx} 2.5s ease-in-out infinite;`}
+  ${({ filter }) => filter && `filter: ${filter};`}
 `;
 
 const Image = styled.img<{

--- a/packages/client/src/app/components/modals/account/header/Header.tsx
+++ b/packages/client/src/app/components/modals/account/header/Header.tsx
@@ -15,6 +15,7 @@ import { playClick } from 'utils/sounds';
 import { Bio } from './Bio';
 import { FriendActions } from './FriendActions';
 import { Pfp } from './Pfp';
+import { TwitterPrivyAccountLink } from './TwitterPrivyAccountLink';
 
 export const Header = ({
   account,
@@ -91,7 +92,10 @@ export const Header = ({
       )}
       <Info>
         <TitleSection>
-          <Text size={1.2}>{account.name}</Text>
+          <TitleHeader>
+            <Text size={1.2}>{account.name}</Text>
+            {isSelf && <TwitterPrivyAccountLink />}
+          </TitleHeader>
           <TextTooltip title='Owner Address' text={[account.ownerAddress, '\n', '(click to copy)']}>
             <Subtitle onClick={() => copyText(account.ownerAddress)}>
               {abbreviateAddress(account.ownerAddress)}
@@ -140,6 +144,14 @@ const TitleSection = styled.div`
   flex-flow: column nowrap;
   gap: 0.3vw;
   margin-bottom: 0.6vw;
+`;
+
+const TitleHeader = styled.div`
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+  height: 2vw;
+  gap: 0.3vw;
 `;
 
 const Subtitle = styled.div`

--- a/packages/client/src/app/components/modals/account/header/TwitterPrivyAccountLink.tsx
+++ b/packages/client/src/app/components/modals/account/header/TwitterPrivyAccountLink.tsx
@@ -52,7 +52,7 @@ export const TwitterPrivyAccountLink = () => {
           >
             <IconButton
               img={SocialIcon}
-              onClick={async () => await handleTwitterUnlink()}
+              onClick={handleTwitterUnlink}
               disabled={!(ready && authenticated)}
               color='transparent'
               noBorder

--- a/packages/client/src/app/components/modals/account/header/TwitterPrivyAccountLink.tsx
+++ b/packages/client/src/app/components/modals/account/header/TwitterPrivyAccountLink.tsx
@@ -1,0 +1,73 @@
+import XIcon from '@mui/icons-material/X';
+import { useLinkAccount, usePrivy } from '@privy-io/react-auth';
+import moment from 'moment';
+import styled from 'styled-components';
+
+import { IconButton } from 'app/components/library/buttons/IconButton';
+import { TextTooltip } from 'app/components/library/poppers/TextTooltip';
+import SocialIcon from 'assets/images/icons/menu/social.png';
+
+export const TwitterPrivyAccountLink = () => {
+  const { ready, authenticated, user, unlinkTwitter } = usePrivy();
+  const { linkTwitter } = useLinkAccount();
+
+  const twitterAccount = user?.linkedAccounts.find((acc) => acc.type === 'twitter_oauth');
+
+  const handleTwitterUnlink = async () => {
+    if (!twitterAccount?.subject) return;
+    await unlinkTwitter(twitterAccount?.subject);
+  };
+
+  return (
+    <Container>
+      {!twitterAccount ? (
+        <>
+          <TextTooltip
+            text={[
+              <>
+                Link <XIcon style={{ fontSize: '1.2vw', verticalAlign: 'middle' }} /> Account
+              </>,
+            ]}
+          >
+            <IconButton
+              img={SocialIcon}
+              onClick={linkTwitter}
+              disabled={!(ready && authenticated)}
+              color='transparent'
+              noBorder
+              filter="opacity(0.5)"
+            />
+          </TextTooltip>
+        </>
+      ) : (
+        <>
+          <TextTooltip
+            text={[
+              <XIcon style={{ fontSize: '1.2vw', marginBottom: '0.7vw' }} />,
+              `${user?.twitter?.username}`,
+              `Linked ${moment(twitterAccount?.firstVerifiedAt).fromNow()}`,
+              `\n`,
+              `(Click to unlink)`,
+            ]}
+          >
+            <IconButton
+              img={SocialIcon}
+              onClick={async () => await handleTwitterUnlink()}
+              disabled={!(ready && authenticated)}
+              color='transparent'
+              noBorder
+              filter="drop-shadow(0 0 3px #2E7D32)"
+            />
+          </TextTooltip>
+        </>
+      )}
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+  gap: 0.3vw;
+`;

--- a/packages/client/src/app/components/modals/account/header/TwitterPrivyAccountLink.tsx
+++ b/packages/client/src/app/components/modals/account/header/TwitterPrivyAccountLink.tsx
@@ -24,9 +24,9 @@ export const TwitterPrivyAccountLink = () => {
         <>
           <TextTooltip
             text={[
-              <>
+              <span key="unlinked-text">
                 Link <XIcon style={{ fontSize: '1.2vw', verticalAlign: 'middle' }} /> Account
-              </>,
+              </span>
             ]}
           >
             <IconButton
@@ -43,7 +43,7 @@ export const TwitterPrivyAccountLink = () => {
         <>
           <TextTooltip
             text={[
-              <XIcon style={{ fontSize: '1.2vw', marginBottom: '0.7vw' }} />,
+              <XIcon key="x-icon" style={{ fontSize: '1.2vw', marginBottom: '0.7vw' }} />,
               `${user?.twitter?.username}`,
               `Linked ${moment(twitterAccount?.firstVerifiedAt).fromNow()}`,
               `\n`,


### PR DESCRIPTION
- keeps initial user login as is ([just wallet](https://github.com/Asphodel-OS/kamigotchi/pull/2072))
- allows optional twitter [link/unlink](https://docs.privy.io/user-management/users/linking-accounts) via privy through account modal header 
- linked twitter accounts can be accesses from `linkdAccounts` or `twitter` via `const { user } = usePrivy();`
- cant link the same twitter account to numerous wallets (within same privy app) 
- data only stored on privy side

unlinked twitter: 
<img width="428" height="225" alt="Screenshot 2025-09-10 at 22 49 58" src="https://github.com/user-attachments/assets/d98b6008-3548-4936-82f1-97ba7cf8588d" />

linked twitter:
<img width="428" height="225"  alt="Screenshot 2025-09-10 at 19 44 47" src="https://github.com/user-attachments/assets/616669c9-9320-4c8a-809f-8e937bbfea91" />

twitter auth redirect:
<img width="352" height="725" alt="Screenshot 2025-09-10 at 19 39 58" src="https://github.com/user-attachments/assets/ffcec791-9123-46b1-83ba-7c42b66bd42c" />

- optional: set up kami app in twitter dev console to set custom logo / description to show during twitter auth redirect
<img width="770" height="252" alt="Untitled" src="https://github.com/user-attachments/assets/bfbfff28-b9b0-4279-9619-8ba1047fd935" />


successful twitter link:
<img width="1216" height="647" alt="Screenshot 2025-09-10 at 22 56 33" src="https://github.com/user-attachments/assets/8f2f4131-3b52-44cc-ac46-2fb351bcd3ab" />


failed twitter link:
<img width="1213" height="801" alt="Screenshot 2025-09-10 at 19 41 54" src="https://github.com/user-attachments/assets/09ad1175-4416-4860-be1f-ecc9705f773d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Link or unlink your Twitter account directly from your profile header when viewing your own profile; shows connection status, username, and time-since-linked.
* UI Improvements
  * Profile header shows a Twitter connection control next to your name when applicable.
  * Icon buttons can be rendered borderless and accept visual filter effects for refined appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->