### PR TITLE
feat(musu): add countup animation to MusuRow using rAF easing

### DIFF
--- a/packages/client/src/app/components/modals/inventory/MusuRow.tsx
+++ b/packages/client/src/app/components/modals/inventory/MusuRow.tsx
@@ -29,43 +29,44 @@ export const MusuRow = ({
 
   const [displayMusu, setDisplayMusu] = useState<number>(musu);
   const animationRef = useRef<number | null>(null);
-  const startRef = useRef<number | null>(null);
-  const prevPropRef = useRef<number>(musu);
+  const stepTimeRef = useRef<number | null>(null);
+  const prevMusuRef = useRef<number>(musu);
 
+  // animate the musu balance, eased to the target value
   useEffect(() => {
     if (animationRef.current) cancelAnimationFrame(animationRef.current);
-    startRef.current = null;
-
-    const from = prevPropRef.current;
+    stepTimeRef.current = null;
+    const from = prevMusuRef.current;
     const to = musu;
-    const durationMs = 600;
+
+    // don't animate if the musu balance difference is low
+    if (Math.abs(to - from) < 10) {
+      prevMusuRef.current = musu;
+      setDisplayMusu(to);
+      return;
+    }
 
     // animation step
     const step = (t: number) => {
-      if (startRef.current == null) startRef.current = t;
-      const elapsed = t - startRef.current;
-      const progress = Math.min(1, elapsed / durationMs);
+      if (stepTimeRef.current == null) stepTimeRef.current = t;
+      const elapsed = t - stepTimeRef.current;
+      const progress = Math.min(1, elapsed / 750); // elapsed divided by tick duration
       const eased = 1 - Math.pow(1 - progress, 3);
       const value = Math.round(from + (to - from) * eased);
       setDisplayMusu(value);
       if (progress < 1) animationRef.current = requestAnimationFrame(step);
     };
 
-    if (Math.abs(to - from) < 1) {
-      setDisplayMusu(to);
-      return;
-    }
-
     animationRef.current = requestAnimationFrame(step);
+    prevMusuRef.current = musu;
 
     return () => {
       if (animationRef.current) cancelAnimationFrame(animationRef.current);
     };
   }, [musu]);
 
-  useEffect(() => {
-    prevPropRef.current = musu;
-  }, [musu]);
+  /////////////////
+  // INTERACTION
 
   // toggles views and activates the shuffle animation
   const triggerModalShuffle = () => {

--- a/packages/client/src/app/components/modals/inventory/MusuRow.tsx
+++ b/packages/client/src/app/components/modals/inventory/MusuRow.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 import { IconButton, TextTooltip } from 'app/components/library';
@@ -25,6 +26,46 @@ export const MusuRow = ({
   const { modals, setModals } = useVisibility();
   const { musu, obols } = data;
   const { mode, setMode, setShuffle } = state;
+
+  const [displayMusu, setDisplayMusu] = useState<number>(musu);
+  const animationRef = useRef<number | null>(null);
+  const startRef = useRef<number | null>(null);
+  const prevPropRef = useRef<number>(musu);
+
+  useEffect(() => {
+    if (animationRef.current) cancelAnimationFrame(animationRef.current);
+    startRef.current = null;
+
+    const from = prevPropRef.current;
+    const to = musu;
+    const durationMs = 600;
+
+    // animation step
+    const step = (t: number) => {
+      if (startRef.current == null) startRef.current = t;
+      const elapsed = t - startRef.current;
+      const progress = Math.min(1, elapsed / durationMs);
+      const eased = 1 - Math.pow(1 - progress, 3);
+      const value = Math.round(from + (to - from) * eased);
+      setDisplayMusu(value);
+      if (progress < 1) animationRef.current = requestAnimationFrame(step);
+    };
+
+    if (Math.abs(to - from) < 1) {
+      setDisplayMusu(to);
+      return;
+    }
+
+    animationRef.current = requestAnimationFrame(step);
+
+    return () => {
+      if (animationRef.current) cancelAnimationFrame(animationRef.current);
+    };
+  }, [musu]);
+
+  useEffect(() => {
+    prevPropRef.current = musu;
+  }, [musu]);
 
   // toggles views and activates the shuffle animation
   const triggerModalShuffle = () => {
@@ -74,7 +115,7 @@ export const MusuRow = ({
       <TextTooltip text={['MUSU']} direction='row' fullWidth>
         <MusuSection>
           <Icon src={ItemImages.musu} onClick={() => null} />
-          <Balance>{musu.toLocaleString()}</Balance>
+          <Balance>{displayMusu.toLocaleString()}</Balance>
         </MusuSection>
       </TextTooltip>
     </Container>


### PR DESCRIPTION
Musu Countup Animation on it's own isolated branch on main repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MUSU balance in the inventory modal now animates from the previous value to the new one with eased, time-based transitions for clearer change visibility; small changes update instantly to avoid unnecessary motion.

* **Style**
  * Refined micro-interactions: smooth, consistent transitions and better handling of rapid updates (animations cancel/restart as needed) while preserving existing UI interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->