### PR TITLE
fix CastItem stamina sync

### DIFF
--- a/packages/contracts/src/systems/KamiCastItemSystem.sol
+++ b/packages/contracts/src/systems/KamiCastItemSystem.sol
@@ -28,6 +28,7 @@ contract KamiCastItemSystem is System {
     LibItem.verifyRequirements(components, itemIndex, "USE", kamiID);
 
     // use stamina from caster
+    LibAccount.sync(components, accID);
     LibAccount.depleteStamina(components, accID, 10); // implicit stamina check
 
     // use item


### PR DESCRIPTION
did not call `LibAccount.syncStamina()` prior in `KamiCastItemSystem`. this fixes it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improves reliability when casting items by ensuring the account state is synchronized before stamina is deducted.
  - Reduces rare mismatches in stamina tracking that could lead to unexpected failures during item use.
  - No changes to visible UI or controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->