### PR TITLE
Show external kami in account too

### DIFF
--- a/packages/client/src/app/components/modals/account/Account.tsx
+++ b/packages/client/src/app/components/modals/account/Account.tsx
@@ -3,9 +3,6 @@ import { uuid } from '@mud-classic/utils';
 import { BigNumberish } from 'ethers';
 import { useEffect, useState } from 'react';
 
-import { getKami as _getKami } from 'app/cache/kami';
-import { queryKamiByIndex as _queryKamiByIndex } from 'network/shapes/Kami';
-
 import {
   getAccount as _getAccount,
   getAccountKamis as _getAccountKamis,
@@ -14,7 +11,7 @@ import {
 } from 'app/cache/account';
 import { getFriends as _getFriends } from 'app/cache/account/getters';
 import { getConfigAddress } from 'app/cache/config';
-import { Kami } from 'app/cache/kami';
+import { getKami as _getKami, Kami } from 'app/cache/kami';
 import { ModalHeader, ModalWrapper } from 'app/components/library';
 import { useLayers } from 'app/root/hooks';
 import { UIComponent } from 'app/root/types';
@@ -22,6 +19,7 @@ import { useAccount, useNetwork, useSelected, useVisibility } from 'app/stores';
 import { OperatorIcon } from 'assets/images/icons/menu';
 import { BaseAccount, NullAccount, queryAccountByIndex } from 'network/shapes/Account';
 import { Friendship } from 'network/shapes/Friendship';
+import { queryKamiByIndex as _queryKamiByIndex } from 'network/shapes/Kami';
 import { getTotalScoreByFilter, getVIPEpoch } from 'network/shapes/Score';
 import { getCompAddr } from 'network/shapes/utils';
 import { waitForActionCompletion } from 'network/utils';

--- a/packages/client/src/app/components/modals/account/Account.tsx
+++ b/packages/client/src/app/components/modals/account/Account.tsx
@@ -3,17 +3,27 @@ import { uuid } from '@mud-classic/utils';
 import { BigNumberish } from 'ethers';
 import { useEffect, useState } from 'react';
 
-import { Account, getAccount as _getAccount, getAccountKamis as _getAccountKamis, getAllAccounts } from 'app/cache/account';
+import { getKami as _getKami } from 'app/cache/kami';
+import { queryKamiByIndex as _queryKamiByIndex } from 'network/shapes/Kami';
+
+import {
+  getAccount as _getAccount,
+  getAccountKamis as _getAccountKamis,
+  Account,
+  getAllAccounts,
+} from 'app/cache/account';
 import { getFriends as _getFriends } from 'app/cache/account/getters';
+import { getConfigAddress } from 'app/cache/config';
 import { Kami } from 'app/cache/kami';
 import { ModalHeader, ModalWrapper } from 'app/components/library';
-import { UIComponent } from 'app/root/types';
 import { useLayers } from 'app/root/hooks';
+import { UIComponent } from 'app/root/types';
 import { useAccount, useNetwork, useSelected, useVisibility } from 'app/stores';
 import { OperatorIcon } from 'assets/images/icons/menu';
 import { BaseAccount, NullAccount, queryAccountByIndex } from 'network/shapes/Account';
 import { Friendship } from 'network/shapes/Friendship';
 import { getTotalScoreByFilter, getVIPEpoch } from 'network/shapes/Score';
+import { getCompAddr } from 'network/shapes/utils';
 import { waitForActionCompletion } from 'network/utils';
 import { Bottom } from './bottom/Bottom';
 import { Header } from './header/Header';
@@ -23,11 +33,11 @@ export const AccountModal: UIComponent = {
   id: 'AccountModal',
   Render: () => {
     const layers = useLayers();
-    
+
     const {
       network,
-      data: { vip },
-      utils: { getAccount, getAccountKamis, getFriends }
+      data: { vip, kamiNFTAddress, spender },
+      utils: { getAccount, getAccountKamis, getFriends, getKami, queryKamiByIndex },
     } = (() => {
       const { network } = layers;
       const { world, components } = network;
@@ -41,10 +51,24 @@ export const AccountModal: UIComponent = {
 
       const vipEpoch = getVIPEpoch(world, components);
       const vipFilter = { epoch: vipEpoch, index: 0, type: 'VIP_SCORE' };
+      const kamiRefreshOptions = {
+        live: 0,
+        bonuses: 5, // set this to 3600 once we get explicit triggers for updates
+        harvest: 5, // set this to 60 once we get explicit triggers for updates
+        progress: 5,
+        skills: 5, // set this to 3600 once we get explicit triggers for updates
+        flags: 10, // set this to 3600 once we get explicit triggers for updates
+        config: 3600,
+        stats: 3600,
+        traits: 3600,
+        state: 5,
+      };
 
       return {
         network,
         data: {
+          kamiNFTAddress: getConfigAddress(world, components, 'KAMI721_ADDRESS'),
+          spender: getCompAddr(world, components, 'component.token.allowance'),
           vip: {
             epoch: vipEpoch,
             total: getTotalScoreByFilter(world, components, vipFilter),
@@ -56,6 +80,8 @@ export const AccountModal: UIComponent = {
           getAccountKamis: (accEntity: EntityIndex) =>
             _getAccountKamis(world, components, accEntity),
           getFriends: (accEntity: EntityIndex) => _getFriends(world, components, accEntity),
+          queryKamiByIndex: (index: number) => _queryKamiByIndex(world, components, index),
+          getKami: (entity: EntityIndex) => _getKami(world, components, entity, kamiRefreshOptions),
         },
       };
     })();
@@ -72,6 +98,10 @@ export const AccountModal: UIComponent = {
     const [isSelf, setIsSelf] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
     const [accounts, setAccounts] = useState<Account[]>([]);
+
+    /////////////////
+    // SUBSCRIPTIONS
+
     useEffect(() => {
       setAccounts(getAllAccounts(world, components));
     }, []);
@@ -198,7 +228,7 @@ export const AccountModal: UIComponent = {
         header={<ModalHeader key='header' title='Account' icon={OperatorIcon} />}
         canExit
         truncate
-        >
+      >
         <Header
           key='header'
           account={account} // account selected for viewing
@@ -226,10 +256,13 @@ export const AccountModal: UIComponent = {
             vip,
             player,
             isSelf,
+            kamiNFTAddress,
           }}
           utils={{
             getAccountKamis,
             getFriends,
+            queryKamiByIndex,
+            getKami,
           }}
           view={{
             isSelf,

--- a/packages/client/src/app/components/modals/account/bottom/Bottom.tsx
+++ b/packages/client/src/app/components/modals/account/bottom/Bottom.tsx
@@ -6,6 +6,7 @@ import { Account, BaseAccount } from 'network/shapes/Account';
 import { Friends } from 'network/shapes/Account/friends';
 import { Friendship } from 'network/shapes/Friendship';
 import { Kami } from 'network/shapes/Kami';
+import { Address } from 'viem';
 import { PartyBottom } from './PartyBottom';
 import { SocialBottom } from './SocialBottom/SocialBottom';
 import { SubTabs } from './SocialBottom/SubTabs';
@@ -27,7 +28,7 @@ export const Bottom = ({
     account: Account;
     accounts: Account[];
     isSelf: boolean;
-    kamiNFTAddress: `0x${string}`;
+    kamiNFTAddress: Address;
     player: PlayerAccount;
     vip: {
       epoch: number; // current VIP epoch

--- a/packages/client/src/app/components/modals/account/bottom/Bottom.tsx
+++ b/packages/client/src/app/components/modals/account/bottom/Bottom.tsx
@@ -15,12 +15,7 @@ export const Bottom = ({
   actions,
   data,
   utils,
-  view: {
-    tab,
-    subTab,
-    setSubTab,
-    isSelf,
-  },
+  view: { tab, subTab, setSubTab, isSelf },
 }: {
   actions: {
     acceptFren: (friendship: Friendship) => void;
@@ -32,6 +27,7 @@ export const Bottom = ({
     account: Account;
     accounts: Account[];
     isSelf: boolean;
+    kamiNFTAddress: `0x${string}`;
     player: PlayerAccount;
     vip: {
       epoch: number; // current VIP epoch
@@ -41,6 +37,8 @@ export const Bottom = ({
   utils: {
     getAccountKamis: (accEntity: EntityIndex) => Kami[];
     getFriends: (accEntity: EntityIndex) => Friends;
+    queryKamiByIndex: (index: number) => EntityIndex | undefined;
+    getKami: (entity: EntityIndex) => Kami;
   };
   view: {
     isSelf: boolean;
@@ -71,7 +69,7 @@ export const Bottom = ({
         <StatsBottom key='statsbottom' data={data} />
       </Tab>
       <Tab isVisible={tab === 'party'}>
-        <PartyBottom key='partybottom' data={{ account }} utils={utils} />
+        <PartyBottom key='partybottom' data={data} utils={utils} />
       </Tab>
     </>
   );

--- a/packages/client/src/app/components/modals/account/bottom/PartyBottom.tsx
+++ b/packages/client/src/app/components/modals/account/bottom/PartyBottom.tsx
@@ -3,13 +3,14 @@ import styled from 'styled-components';
 
 import { Account } from 'network/shapes/Account';
 import { Kami } from 'network/shapes/Kami';
+import { Address } from 'viem';
 import { Kamis } from '../party/Kamis';
 
 export const PartyBottom = ({
   data,
   utils,
 }: {
-  data: { account: Account; kamiNFTAddress: `0x${string}` };
+  data: { account: Account; kamiNFTAddress: Address };
   utils: {
     getAccountKamis: (accEntity: EntityIndex) => Kami[];
     queryKamiByIndex: (index: number) => EntityIndex | undefined;

--- a/packages/client/src/app/components/modals/account/bottom/PartyBottom.tsx
+++ b/packages/client/src/app/components/modals/account/bottom/PartyBottom.tsx
@@ -1,7 +1,7 @@
-import type { ComponentProps } from 'react';
 import { EntityIndex } from '@mud-classic/recs';
 import styled from 'styled-components';
 
+import { Account } from 'network/shapes/Account';
 import { Kami } from 'network/shapes/Kami';
 import { Kamis } from '../party/Kamis';
 
@@ -9,9 +9,11 @@ export const PartyBottom = ({
   data,
   utils,
 }: {
-  data: ComponentProps<typeof Kamis>['data'];
+  data: { account: Account; kamiNFTAddress: `0x${string}` };
   utils: {
     getAccountKamis: (accEntity: EntityIndex) => Kami[];
+    queryKamiByIndex: (index: number) => EntityIndex | undefined;
+    getKami: (entity: EntityIndex) => Kami;
   };
 }) => {
   /////////////////

--- a/packages/client/src/app/components/modals/account/party/Kamis.tsx
+++ b/packages/client/src/app/components/modals/account/party/Kamis.tsx
@@ -93,18 +93,14 @@ export const Kamis = ({
   if (kamis.length === 0 && wildKamis.length === 0) return <EmptyText>no kamis. ngmi</EmptyText>;
   return (
     <Container key='grid'>
-      {kamis.map((kami) => (
-        <TextTooltip key={kami.index} text={[kami.name, 'in the wild']}>
+      {[...kamis, ...wildKamis].map((kami, idx) => (
+        <TextTooltip
+          key={`${kami.index}-${kami.id}-${idx}`}
+          text={[kami.name, kami.state === '721_EXTERNAL' ? 'in the wild' : '']}
+        >
           <CellContainer id={`grid-${kami.id}`}>
             <Image onClick={() => kamiOnClick(kami)} src={kami.image} />
-          </CellContainer>
-        </TextTooltip>
-      ))}
-      {wildKamis.map((kami) => (
-        <TextTooltip key={kami.index} text={[kami.name, 'in the wild']}>
-          <CellContainer id={`grid-${kami.id}`}>
-            <Image onClick={() => kamiOnClick(kami)} src={kami.image} />
-            <ExtIcon src={ExternalIcon} />
+            {kami.state === '721_EXTERNAL' && <ExtIcon src={ExternalIcon} />}
           </CellContainer>
         </TextTooltip>
       ))}

--- a/packages/client/src/app/components/modals/account/party/Kamis.tsx
+++ b/packages/client/src/app/components/modals/account/party/Kamis.tsx
@@ -1,5 +1,6 @@
 import { EntityIndex } from '@mud-classic/recs';
 import styled from 'styled-components';
+import { useReadContracts, useWatchBlockNumber } from 'wagmi';
 
 import { TextTooltip } from 'app/components/library';
 import { useSelected, useVisibility } from 'app/stores';
@@ -9,7 +10,6 @@ import { Account } from 'network/shapes/Account';
 import { Kami } from 'network/shapes/Kami';
 import { useEffect, useState } from 'react';
 import { playClick } from 'utils/sounds';
-import { useReadContracts, useWatchBlockNumber } from 'wagmi';
 
 const REFRESH_INTERVAL = 1000;
 
@@ -90,7 +90,7 @@ export const Kamis = ({
     playClick();
   };
 
-  if (kamis.length && wildKamis.length === 0) return <EmptyText>no kamis. ngmi</EmptyText>;
+  if (kamis.length === 0 && wildKamis.length === 0) return <EmptyText>no kamis. ngmi</EmptyText>;
   return (
     <Container key='grid'>
       {kamis.map((kami) => (

--- a/packages/client/src/app/components/modals/account/party/Kamis.tsx
+++ b/packages/client/src/app/components/modals/account/party/Kamis.tsx
@@ -83,16 +83,22 @@ export const Kamis = ({
   };
 
   if (kamis.length === 0 && wildKamis.length === 0) return <EmptyText>no kamis. ngmi</EmptyText>;
+
   return (
     <Container key='grid'>
-      {[...kamis, ...wildKamis].map((kami, idx) => (
-        <TextTooltip
-          key={`${kami.index}-${kami.id}-${idx}`}
-          text={[kami.name, kami.state === '721_EXTERNAL' ? 'in the wild' : '']}
-        >
+      {kamis.map((kami, idx) => (
+        <TextTooltip key={`internal-${kami.index}-${kami.id}-${idx}`} text={[kami.name, '']}>
           <CellContainer id={`grid-${kami.id}`}>
             <Image onClick={() => kamiOnClick(kami)} src={kami.image} />
-            {kami.state === '721_EXTERNAL' && <ExtIcon src={ExternalIcon} />}
+          </CellContainer>
+        </TextTooltip>
+      ))}
+
+      {wildKamis.map((kami, idx) => (
+        <TextTooltip key={`wild-${kami.index}-${kami.id}-${idx}`} text={[kami.name, 'in the wild']}>
+          <CellContainer id={`grid-${kami.id}`}>
+            <Image onClick={() => kamiOnClick(kami)} src={kami.image} />
+            <ExtIcon src={ExternalIcon} />
           </CellContainer>
         </TextTooltip>
       ))}

--- a/packages/client/src/app/components/modals/account/party/Kamis.tsx
+++ b/packages/client/src/app/components/modals/account/party/Kamis.tsx
@@ -3,33 +3,84 @@ import styled from 'styled-components';
 
 import { TextTooltip } from 'app/components/library';
 import { useSelected, useVisibility } from 'app/stores';
+import { ExternalIcon } from 'assets/images/icons/menu';
+import { erc721ABI } from 'network/chain/ERC721';
+import { Account } from 'network/shapes/Account';
 import { Kami } from 'network/shapes/Kami';
 import { useEffect, useState } from 'react';
 import { playClick } from 'utils/sounds';
-import type { ComponentProps } from 'react';
+import { useReadContracts, useWatchBlockNumber } from 'wagmi';
+
+const REFRESH_INTERVAL = 1000;
 
 export const Kamis = ({
   data,
   utils,
 }: {
-  data: ComponentProps<typeof Kamis>['data'];
+  data: { account: Account; kamiNFTAddress: `0x${string}` };
   utils: {
     getAccountKamis: (accEntity: EntityIndex) => Kami[];
+    queryKamiByIndex: (index: number) => EntityIndex | undefined;
+    getKami: (entity: EntityIndex) => Kami;
   };
 }) => {
-  const { account } = data;
-  const { getAccountKamis } = utils;
+  const { account, kamiNFTAddress } = data;
+  const { getAccountKamis, queryKamiByIndex, getKami } = utils;
 
   const kamiModalOpen = useVisibility((s) => s.modals.kami);
   const setModals = useVisibility((s) => s.setModals);
   const kamiIndex = useSelected((s) => s.kamiIndex);
   const setKami = useSelected((s) => s.setKami);
   const [kamis, setKamis] = useState<Kami[]>([]);
+  const [wildKamis, setWildKamis] = useState<Kami[]>([]);
+  const [tick, setTick] = useState(Date.now());
+
+  /////////////////
+  // BLOCK WATCHERS
+
+  useWatchBlockNumber({
+    onBlockNumber: () => refetchNFTs(),
+  });
+
+  const { refetch: refetchNFTs, data: nftData } = useReadContracts({
+    contracts: [
+      {
+        address: kamiNFTAddress,
+        abi: erc721ABI,
+        functionName: 'getAllTokens',
+        args: [account.ownerAddress],
+      },
+    ],
+  });
+
+  /////////////////
+  // SUBSCRIPTIONS
+  kamis.map((kami) => console.log(`WORLD`, kami.name));
+  wildKamis.map((kami) => console.log(`WILD`, kami.name));
+  // mounting
+  useEffect(() => {
+    // set ticking
+    const refreshClock = () => setTick(Date.now());
+    const timerId = setInterval(refreshClock, REFRESH_INTERVAL);
+    return () => clearInterval(timerId);
+  }, []);
 
   useEffect(() => {
-    const kamis = getAccountKamis(account?.entity);
-    setKamis(kamis);
-  }, [account?.entity]);
+    const accountKamis = getAccountKamis(account?.entity);
+    setKamis(accountKamis);
+  }, [account?.entity, tick]);
+
+  // update list of wild kamis whenever that changes
+  // TOTO: properly typecast the result of the abi call
+  useEffect(() => {
+    const result = (nftData?.[0]?.result ?? []) as number[];
+    if (result.length != wildKamis.length) {
+      const entities = result.map((index: number) => queryKamiByIndex(index));
+      const filtered = entities.filter((entity) => !!entity) as EntityIndex[];
+      const externalKamis = filtered.map((entity: EntityIndex) => getKami(entity));
+      setWildKamis(externalKamis);
+    }
+  }, [nftData, account?.entity]);
 
   const kamiOnClick = (kami: Kami) => {
     const sameKami = kamiIndex === kami.index;
@@ -40,13 +91,21 @@ export const Kamis = ({
     playClick();
   };
 
-  if (kamis.length === 0) return <EmptyText>no kamis. ngmi</EmptyText>;
+  if (kamis.length && wildKamis.length === 0) return <EmptyText>no kamis. ngmi</EmptyText>;
   return (
     <Container key='grid'>
       {kamis.map((kami) => (
-        <TextTooltip key={kami.index} text={[kami.name]}>
+        <TextTooltip key={kami.index} text={[kami.name, 'in the wild']}>
           <CellContainer id={`grid-${kami.id}`}>
             <Image onClick={() => kamiOnClick(kami)} src={kami.image} />
+          </CellContainer>
+        </TextTooltip>
+      ))}
+      {wildKamis.map((kami) => (
+        <TextTooltip key={kami.index} text={[kami.name, 'in the wild']}>
+          <CellContainer id={`grid-${kami.id}`}>
+            <Image onClick={() => kamiOnClick(kami)} src={kami.image} />
+            <ExtIcon src={ExternalIcon} />
           </CellContainer>
         </TextTooltip>
       ))}
@@ -73,10 +132,16 @@ const Image = styled.img`
   border-radius: 0.1vw;
   height: 8vw;
   cursor: pointer;
-
   &:hover {
     opacity: 0.75;
   }
+`;
+
+const ExtIcon = styled.img`
+  position: absolute;
+  width: 2.5vw;
+  right: 0vw;
+  bottom: 0vw;
 `;
 
 const EmptyText = styled.div`

--- a/packages/client/src/app/components/modals/account/party/Kamis.tsx
+++ b/packages/client/src/app/components/modals/account/party/Kamis.tsx
@@ -10,14 +10,15 @@ import { Account } from 'network/shapes/Account';
 import { Kami } from 'network/shapes/Kami';
 import { useEffect, useState } from 'react';
 import { playClick } from 'utils/sounds';
+import { Address } from 'viem';
 
-const REFRESH_INTERVAL = 1000;
+const REFRESH_INTERVAL = 3000;
 
 export const Kamis = ({
   data,
   utils,
 }: {
-  data: { account: Account; kamiNFTAddress: `0x${string}` };
+  data: { account: Account; kamiNFTAddress: Address };
   utils: {
     getAccountKamis: (accEntity: EntityIndex) => Kami[];
     queryKamiByIndex: (index: number) => EntityIndex | undefined;

--- a/packages/client/src/app/components/modals/account/party/Kamis.tsx
+++ b/packages/client/src/app/components/modals/account/party/Kamis.tsx
@@ -1,11 +1,11 @@
 import { EntityIndex } from '@mud-classic/recs';
 import styled from 'styled-components';
-import { useReadContracts, useWatchBlockNumber } from 'wagmi';
+import { useWatchBlockNumber } from 'wagmi';
 
 import { TextTooltip } from 'app/components/library';
 import { useSelected, useVisibility } from 'app/stores';
 import { ExternalIcon } from 'assets/images/icons/menu';
-import { erc721ABI } from 'network/chain/ERC721';
+import { useBalance } from 'network/chain/ERC721';
 import { Account } from 'network/shapes/Account';
 import { Kami } from 'network/shapes/Kami';
 import { useEffect, useState } from 'react';
@@ -42,16 +42,7 @@ export const Kamis = ({
     onBlockNumber: () => refetchNFTs(),
   });
 
-  const { refetch: refetchNFTs, data: nftData } = useReadContracts({
-    contracts: [
-      {
-        address: kamiNFTAddress,
-        abi: erc721ABI,
-        functionName: 'getAllTokens',
-        args: [account.ownerAddress],
-      },
-    ],
-  });
+  const { refetch: refetchNFTs, data: nftData } = useBalance(account.ownerAddress, kamiNFTAddress);
 
   /////////////////
   // SUBSCRIPTIONS

--- a/packages/client/src/app/components/modals/account/party/Kamis.tsx
+++ b/packages/client/src/app/components/modals/account/party/Kamis.tsx
@@ -55,8 +55,7 @@ export const Kamis = ({
 
   /////////////////
   // SUBSCRIPTIONS
-  kamis.map((kami) => console.log(`WORLD`, kami.name));
-  wildKamis.map((kami) => console.log(`WILD`, kami.name));
+
   // mounting
   useEffect(() => {
     // set ticking

--- a/packages/client/src/app/components/modals/account/party/Kamis.tsx
+++ b/packages/client/src/app/components/modals/account/party/Kamis.tsx
@@ -12,7 +12,7 @@ import { useEffect, useState } from 'react';
 import { playClick } from 'utils/sounds';
 import { Address } from 'viem';
 
-const REFRESH_INTERVAL = 3000;
+const REFRESH_INTERVAL = 5000;
 
 export const Kamis = ({
   data,

--- a/packages/client/src/network/chain/ERC721.ts
+++ b/packages/client/src/network/chain/ERC721.ts
@@ -12,7 +12,10 @@ export function useBalance(owner: Address, token: Address) {
   });
   return {
     ...results,
-    tokenIndices: results.data?.[0].result?.map((i: any) => Number(i)),
+    tokenIndices:
+      results.data && Array.isArray(results.data[0].result)
+        ? results.data[0].result.map((i) => Number(i))
+        : [],
   };
 }
 


### PR DESCRIPTION
<img width="627" height="896" alt="image" src="https://github.com/user-attachments/assets/c927fc11-d7f9-4a60-a63b-2618852ba027" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account modal now shows owned and external (“wild”) Kami NFTs together, marked with an external icon and “in the wild” label.
  * On-demand Kami lookup and index-based browsing added; Kami data and lookup tools are shared across modal sections for consistent browsing.
  * Kami list auto-refreshes (block- and interval-driven) for up-to-date results.

* **Bug Fixes**
  * NFT balance handling made more robust to missing or irregular data shapes, reducing runtime errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->