### PR TITLE
Craft filtering fix

### DIFF
--- a/packages/client/src/app/components/modals/crafting/Crafting.tsx
+++ b/packages/client/src/app/components/modals/crafting/Crafting.tsx
@@ -4,8 +4,8 @@ import { useEffect, useState } from 'react';
 import { getAccount } from 'app/cache/account';
 import { getAllRecipes } from 'app/cache/recipes';
 import { ActionButton, EmptyText, ModalHeader, ModalWrapper } from 'app/components/library';
-import { UIComponent } from 'app/root/types';
 import { useLayers } from 'app/root/hooks';
+import { UIComponent } from 'app/root/types';
 import { useVisibility } from 'app/stores';
 import { CraftIcon } from 'assets/images/icons/actions';
 import { queryAccountFromEmbedded } from 'network/shapes/Account';
@@ -19,21 +19,11 @@ export const CraftingModal: UIComponent = {
   id: 'CraftingModal',
   Render: () => {
     const layers = useLayers();
-    
+
     const {
-      network: {
-        actions,
-        api,
-        components,
-        world,
-      },
+      network: { actions, api, components, world },
       data: { account },
-      utils: {
-        meetsRequirements,
-        displayRequirements,
-        getItemBalance,
-        hasIngredients
-      }
+      utils: { meetsRequirements, displayRequirements, getItemBalance, hasIngredients },
     } = (() => {
       const { network } = layers;
       const { world, components } = network;
@@ -76,7 +66,10 @@ export const CraftingModal: UIComponent = {
       const recipes = getAllRecipes(world, components);
       const currentTabRecipes = recipes.filter((recipe) => recipe.type === tab.toUpperCase());
       if (showAll) setRecipes(currentTabRecipes);
-      else setRecipes(currentTabRecipes.filter((recipe) => hasIngredients(recipe)));
+      else
+        setRecipes(
+          currentTabRecipes.filter((recipe) => meetsRequirements(recipe) && hasIngredients(recipe))
+        );
     }, [showAll, tab, craftingModalVisible]);
 
     /////////////////
@@ -124,7 +117,7 @@ export const CraftingModal: UIComponent = {
             data={{
               account,
               recipes,
-              tab
+              tab,
             }}
             actions={{
               craft,


### PR DESCRIPTION
fixes this

https://github.com/user-attachments/assets/624488f1-c4cf-4f8f-9cfd-f02b36e90c20



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Recipe list now hides items that don’t meet requirements, showing only those you both qualify for and have ingredients to craft.

- Refactor
  - Minor readability and formatting improvements to the crafting modal and related UI components with no impact on behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->