### PR TITLE
Transfer History fix 

### DIFF
--- a/packages/client/src/app/components/modals/inventory/transfer/Transfer.tsx
+++ b/packages/client/src/app/components/modals/inventory/transfer/Transfer.tsx
@@ -1,22 +1,15 @@
 import { EntityID, EntityIndex } from '@mud-classic/recs';
-import { BigNumber } from 'ethers';
 import { ChangeEvent, useEffect, useMemo, useState } from 'react';
 import styled from 'styled-components';
 
 import { Inventory } from 'app/cache/inventory';
-import {
-  EmptyText,
-  IconButton,
-  IconListButton,
-  IconListButtonOption,
-} from 'app/components/library';
+import { IconButton, IconListButton, IconListButtonOption } from 'app/components/library';
 import { useVisibility } from 'app/stores';
 import { ArrowIcons } from 'assets/images/icons/arrows';
 import { MenuIcons } from 'assets/images/icons/menu';
 import { getKamidenClient } from 'clients/kamiden';
 import { ItemTransfer, ItemTransferRequest } from 'clients/kamiden/proto';
 import { STONE_INDEX } from 'constants/items';
-import { formatEntityID } from 'engine/utils';
 import { Account } from 'network/shapes/Account';
 import { Item, NullItem } from 'network/shapes/Item';
 import { Mode } from '../types';
@@ -124,7 +117,7 @@ export const Transfer = ({
         //  Timestamp: '0',
       };
       const response = await KamidenClient?.getItemTransfers(request);
-      setHistory(response?.Transfers || []);
+      setHistory(response?.Transfers.reverse() || []);
     } catch (error) {
       console.error('Error getting send history :', error);
       throw error;
@@ -151,40 +144,6 @@ export const Transfer = ({
 
   /////////////////
   // DISPLAY
-
-  // get the history of items sent
-  // TODO: consider moving this to its own component
-  const TransferHistory = useMemo(() => {
-    const transfers: JSX.Element[] = [];
-    history.forEach((send, index) => {
-      const senderID = formatEntityID(BigNumber.from(send.SenderAccountID));
-      const receiverID = formatEntityID(BigNumber.from(send.RecvAccountID));
-      const sender = getAccount(getEntityIndex(senderID));
-      const receiver = getAccount(getEntityIndex(receiverID));
-      const item = getItem(send.ItemIndex as EntityIndex);
-
-      if (receiver.id === account.id) {
-        transfers.push(
-          <div key={`receiver-${index}`}>
-            * You <span style={{ color: 'green' }}>received</span> {send?.Amount} {item?.name} from{' '}
-            {sender?.name}
-          </div>
-        );
-      } else if (sender.id === account.id) {
-        transfers.push(
-          <div key={`sender-${index}`}>
-            * You <span style={{ color: 'red' }}>sent</span> {send?.Amount} {item?.name} to{' '}
-            {receiver?.name}
-          </div>
-        );
-      }
-    });
-    if (transfers.length === 0) {
-      return <EmptyText text={['No transfers to show.']} />;
-    } else {
-      return transfers.reverse();
-    }
-  }, [history, account.id, getAccount, getEntityIndex, getItem]);
 
   // gets filtered item options
   const ItemOptions = useMemo(() => {

--- a/packages/client/src/app/components/modals/inventory/transfer/Transfer.tsx
+++ b/packages/client/src/app/components/modals/inventory/transfer/Transfer.tsx
@@ -79,6 +79,11 @@ export const Transfer = ({
     if (item === NullItem) setItem(stone());
   }, [inventories, item]);
 
+  // updates transfer history
+  useEffect(() => {
+    setTransferEvents(account.id);
+  }, [accountEntity, resetSend, mode]);
+
   // reset form values when a reset update is triggered
   useEffect(() => {
     if (resetSend) {
@@ -105,7 +110,6 @@ export const Transfer = ({
       const accountsSorted = newAccounts.sort((a, b) => a.name.localeCompare(b.name));
       setAccounts(accountsSorted);
     }
-    setTransferEvents(account.id);
   }, [inventoryModalOpen, tick, accountEntity]);
 
   /////////////////

--- a/packages/client/src/app/components/modals/inventory/transfer/Transfer.tsx
+++ b/packages/client/src/app/components/modals/inventory/transfer/Transfer.tsx
@@ -117,7 +117,7 @@ export const Transfer = ({
         //  Timestamp: '0',
       };
       const response = await KamidenClient?.getItemTransfers(request);
-      setHistory(response?.Transfers.reverse() || []);
+      setHistory((response?.Transfers ?? []).slice().reverse());
     } catch (error) {
       console.error('Error getting send history :', error);
       throw error;


### PR DESCRIPTION
Fixes kamiden constant calls and  history transfer order, newers transfers are ordered from new to old

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transfer history now reliably refreshes when changing accounts, resetting send state, or switching modes.
  * Display order updated to show most recent transfers first.

* **Refactor**
  * Transfer history rendering delegated to the dedicated History component for clearer UI responsibilities.
  * Simplified internal handling and refresh triggers for transfer events, reducing redundant update paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->