### PR TITLE
sticky fallback

### DIFF
--- a/packages/client/src/app/components/library/modals/ModalWrapper.tsx
+++ b/packages/client/src/app/components/library/modals/ModalWrapper.tsx
@@ -83,7 +83,12 @@ export const ModalWrapper = ({
           </ButtonRow>
         )}
         {header && <Header noBorder={noInternalBorder}>{header}</Header>}
-        <Children scrollBarColor={scrollBarColor} noPadding={noPadding}>
+        <Children
+          scrollBarColor={scrollBarColor}
+          noPadding={noPadding}
+          data-scroll-container='true'
+          data-modal-id={id}
+        >
           {children}
         </Children>
         {footer && <Footer noBorder={noInternalBorder}>{footer}</Footer>}

--- a/packages/client/src/app/components/modals/party/Toolbar.tsx
+++ b/packages/client/src/app/components/modals/party/Toolbar.tsx
@@ -1,4 +1,5 @@
-import { Dispatch, useEffect, useMemo, useState } from 'react';
+import anime from 'animejs';
+import { Dispatch, useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 import { calcHealthPercent, canHarvest, isHarvesting, onCooldown } from 'app/cache/kami';
@@ -51,6 +52,8 @@ export const Toolbar = ({
   const { passesNodeReqs } = utils;
   const { displayedKamis, setDisplayedKamis, tick } = state;
   const partyModalVisible = useVisibility((s) => s.modals.party);
+  const toolbarRef = useRef<HTMLDivElement | null>(null);
+  const detachScroll = useRef<(() => void) | null>(null);
 
   const [addOptions, setAddOptions] = useState<DropdownOption[]>([]);
   const [collectOptions, setCollectOptions] = useState<DropdownOption[]>([]);
@@ -111,6 +114,31 @@ export const Toolbar = ({
     setDisplayedKamis(sorted);
   }, [partyModalVisible, kamis.length, sort, view]);
 
+  // JS-driven sticky fallback for Safari: translateY toolbar as parent scrolls
+  useEffect(() => {
+    if (!partyModalVisible) return;
+    const toolbarEl = toolbarRef.current;
+    if (!toolbarEl) return;
+
+    // Find the nearest modal scroll container
+    const container = toolbarEl.closest("[data-scroll-container='true']") as HTMLElement | null;
+    if (!container) return;
+
+    const onScroll = () => {
+      const y = container.scrollTop;
+      anime.set(toolbarEl, { translateY: y });
+    };
+
+    // initialize position and bind
+    onScroll();
+    container.addEventListener('scroll', onScroll, { passive: true });
+    detachScroll.current = () => container.removeEventListener('scroll', onScroll);
+    return () => {
+      if (detachScroll.current) detachScroll.current();
+      anime.set(toolbarEl, { translateY: 0 });
+    };
+  }, [partyModalVisible]);
+
   /////////////////
   // INTERACTION
 
@@ -133,7 +161,7 @@ export const Toolbar = ({
   );
 
   return (
-    <Container>
+    <Container ref={toolbarRef}>
       <Section>
         <TextTooltip text={[`${view}`]}>
           <IconButton img={ViewIcons[view]} onClick={() => toggleView()} radius={0.6} />
@@ -160,7 +188,8 @@ export const Toolbar = ({
 const Container = styled.div`
   padding: 0.6vw;
   z-index: 1;
-  position: sticky;
+  /* Avoid Safari white-screen bug when sticky is nested in overflow containers */
+  position: relative;
   top: 0;
   opacity: 0.9;
   width: 100%;

--- a/packages/client/src/app/components/modals/party/Toolbar.tsx
+++ b/packages/client/src/app/components/modals/party/Toolbar.tsx
@@ -114,28 +114,71 @@ export const Toolbar = ({
     setDisplayedKamis(sorted);
   }, [partyModalVisible, kamis.length, sort, view]);
 
-  // JS-driven sticky fallback for Safari: translateY toolbar as parent scrolls
+  // JS-driven sticky fallback across browsers: translateY toolbar as parent scrolls
   useEffect(() => {
     if (!partyModalVisible) return;
     const toolbarEl = toolbarRef.current;
     if (!toolbarEl) return;
 
-    // Find the nearest modal scroll container
-    const container = toolbarEl.closest("[data-scroll-container='true']") as HTMLElement | null;
+    // Helper: find the nearest scrollable ancestor if explicit container not found
+    const findScrollContainer = (start: HTMLElement): HTMLElement | null => {
+      let el: HTMLElement | null = start;
+      while (el) {
+        const style = window.getComputedStyle(el);
+        const overflowY = style.overflowY;
+        if ((overflowY === 'auto' || overflowY === 'scroll') && el.scrollHeight > el.clientHeight) {
+          return el;
+        }
+        el = el.parentElement;
+      }
+      return (document.scrollingElement as HTMLElement) || document.documentElement;
+    };
+
+    const explicit = toolbarEl.closest("[data-scroll-container='true']") as HTMLElement | null;
+    const container = explicit ?? findScrollContainer(toolbarEl);
     if (!container) return;
 
+    let rafId = 0;
+
+    const setY = (y: number) => {
+      try {
+        anime.set(toolbarEl, { translateY: y });
+      } catch {
+        // If Anime.js is unavailable for any reason, fallback to direct style
+        toolbarEl.style.transform = `translateY(${y}px)`;
+      }
+    };
+
+    const readScrollTop = () => {
+      if (container === document.scrollingElement || container === document.documentElement) {
+        return document.scrollingElement?.scrollTop ?? window.scrollY ?? 0;
+      }
+      return (container as HTMLElement).scrollTop;
+    };
+
     const onScroll = () => {
-      const y = container.scrollTop;
-      anime.set(toolbarEl, { translateY: y });
+      if (rafId) return;
+      rafId = requestAnimationFrame(() => {
+        const y = readScrollTop();
+        setY(y);
+        rafId = 0;
+      });
     };
 
     // initialize position and bind
     onScroll();
-    container.addEventListener('scroll', onScroll, { passive: true });
-    detachScroll.current = () => container.removeEventListener('scroll', onScroll);
+    container.addEventListener(
+      'scroll',
+      onScroll as EventListener,
+      { passive: true } as AddEventListenerOptions
+    );
+    detachScroll.current = () => {
+      container.removeEventListener('scroll', onScroll as EventListener);
+      if (rafId) cancelAnimationFrame(rafId);
+    };
     return () => {
       if (detachScroll.current) detachScroll.current();
-      anime.set(toolbarEl, { translateY: 0 });
+      setY(0);
     };
   }, [partyModalVisible]);
 
@@ -199,6 +242,7 @@ const Container = styled.div`
   align-items: center;
   user-select: none;
   background-color: rgb(238, 238, 238);
+  will-change: transform;
 `;
 
 const Section = styled.div`

--- a/packages/client/src/app/components/modals/party/Toolbar.tsx
+++ b/packages/client/src/app/components/modals/party/Toolbar.tsx
@@ -1,4 +1,3 @@
-import anime from 'animejs';
 import { Dispatch, useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 
@@ -141,12 +140,8 @@ export const Toolbar = ({
     let rafId = 0;
 
     const setY = (y: number) => {
-      try {
-        anime.set(toolbarEl, { translateY: y });
-      } catch {
-        // If Anime.js is unavailable for any reason, fallback to direct style
-        toolbarEl.style.transform = `translateY(${y}px)`;
-      }
+      // Use direct transform to avoid dependency issues and keep this hotfix minimal
+      toolbarEl.style.transform = `translateY(${y}px)`;
     };
 
     const readScrollTop = () => {
@@ -178,7 +173,7 @@ export const Toolbar = ({
     };
     return () => {
       if (detachScroll.current) detachScroll.current();
-      setY(0);
+      toolbarEl.style.transform = 'translateY(0px)';
     };
   }, [partyModalVisible]);
 


### PR DESCRIPTION
Fixes safari crash when opening the party modal by falling back to animejs sticky function instead of CSS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Toolbar in the Party modal now reliably remains visible (“sticky”) while scrolling inside modals across browsers (including Safari), fixing overflow-related stickiness issues.

* **User Experience**
  * Scrolling feels smoother and more consistent; toolbar movement is throttled and performs better, improving access to actions and sorting controls while interacting with modals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->