### PR TITLE
Add me to the deployment folder as a codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,7 @@
 packages/client/ @jiracheron @chlwys @Xenofluxx @hubur @deeterbleater
 packages/client/src/app/ @ExistentialEnso
 packages/client/src/cache/ @ExistentialEnso
+packages/contracts/deployment/ @ExistentialEnso
 packages/contracts/ @chlwys @jiracheron
 
 


### PR DESCRIPTION
I'm now becoming the main person to handle the deployment of new game data into the world. This is going to require updating a lot of data files on a regular basis. Over the coming months, I also will be streamlining and improving our process for handling such tasks.

Therefore, I should be given ownership over the `contracts/deployment` folder to streamline my ability to merge in these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains no user-facing changes. An internal administrative update was made to code ownership configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->