### PR TITLE
Add UPON_COOLDOWN_SET bonus end type for Energy Drink

### DIFF
--- a/packages/client/src/app/cache/bonus/getters.ts
+++ b/packages/client/src/app/cache/bonus/getters.ts
@@ -26,6 +26,7 @@ export const getTemp = (
 
   return [
     ...getForEndType(world, components, 'UPON_HARVEST_ACTION', holder, update),
+    ...getForEndType(world, components, 'UPON_COOLDOWN_SET', holder, update),
     ...getForEndType(world, components, 'UPON_LIQUIDATION', holder, update),
     ...getForEndType(world, components, 'UPON_DEATH', holder, update),
     ...getForEndType(world, components, 'UPON_KILL_OR_KILLED', holder, update),

--- a/packages/client/src/network/shapes/Bonus/interpretation.ts
+++ b/packages/client/src/network/shapes/Bonus/interpretation.ts
@@ -45,6 +45,7 @@ export const parseTooltipText = (bonus: Bonus): string[] => {
 const parseEndtype = (bonus: Bonus): string => {
   if (bonus.endType === 'TIMED') return 'for ' + bonus.duration + 's';
   else if (bonus.endType === 'UPON_HARVEST_ACTION') return 'til next action';
+  else if (bonus.endType === 'UPON_COOLDOWN_SET') return 'til next cooldown';
   else if (bonus.endType === 'UPON_DEATH') return 'til death';
   else if (bonus.endType === 'UPON_LIQUIDATION') return 'til kami liquidates';
   else if (bonus.endType === 'UPON_KILL_OR_KILLED') return 'til kami kills or is killed';

--- a/packages/contracts/src/libraries/LibBonus.sol
+++ b/packages/contracts/src/libraries/LibBonus.sol
@@ -316,6 +316,11 @@ library LibBonus {
     unassignBy(components, "UPON_HARVEST_STOP", holderID);
   }
 
+  /// @notice resets cooldown-related bonuses (e.g. Energy Drink) after cooldown is set
+  function resetUponCooldownSet(IUintComp components, uint256 holderID) public {
+    unassignBy(components, "UPON_COOLDOWN_SET", holderID);
+  }
+
   /// @notice resets upon kami death
   function resetUponDeath(IUintComp components, uint256 holderID) public {
     unassignBy(components, "UPON_DEATH", holderID);
@@ -338,6 +343,7 @@ library LibBonus {
     // no need to call resetUponHarvestAction since it's included in resetUponHarvestStop
 
     resetUponHarvestStop(components, holderID);
+    resetUponCooldownSet(components, holderID);
     resetUponDeath(components, holderID);
     resetUponLiquidation(components, holderID);
     resetTimed(components, holderID);

--- a/packages/contracts/src/systems/HarvestCollectSystem.sol
+++ b/packages/contracts/src/systems/HarvestCollectSystem.sol
@@ -94,6 +94,7 @@ contract HarvestCollectSystem is System {
     uint256 output = LibHarvest.claim(components, id, accID);
     LibExperience.inc(components, kamiID, output);
     LibKami.resetCooldown(components, kamiID);
+    LibBonus.resetUponCooldownSet(components, kamiID);
 
     // scavenge
     uint256 nodeID = LibHarvest.getNode(components, id);

--- a/packages/contracts/src/systems/HarvestLiquidateSystem.sol
+++ b/packages/contracts/src/systems/HarvestLiquidateSystem.sol
@@ -76,6 +76,7 @@ contract HarvestLiquidateSystem is System {
     LibKill.rewardKiller(components, accID); // killer gets reward
     LibBonus.resetUponLiquidation(components, killerID); // resets killer's liquidation bonus
     LibKami.resetCooldown(components, killerID); // resets killer's cooldown
+    LibBonus.resetUponCooldownSet(components, killerID); // consumes cooldown bonuses (e.g. Energy Drink)
 
     // victim post-death actions
     LibKami.kill(components, victimID); // kills victim

--- a/packages/contracts/src/systems/HarvestStartSystem.sol
+++ b/packages/contracts/src/systems/HarvestStartSystem.sol
@@ -59,6 +59,7 @@ contract HarvestStartSystem is System {
     uint256 id = LibHarvest.startFor(components, nodeID, kamiID, taxerID, taxAmt);
     LibKami.setState(components, kamiID, "HARVESTING");
     LibKami.resetCooldown(components, kamiID);
+    LibBonus.resetUponCooldownSet(components, kamiID);
 
     // standard logging and tracking
     LibAccount.updateLastTs(components, accID);

--- a/packages/contracts/src/systems/HarvestStopSystem.sol
+++ b/packages/contracts/src/systems/HarvestStopSystem.sol
@@ -96,6 +96,7 @@ contract HarvestStopSystem is System {
     LibKami.setState(components, kamiID, "RESTING");
     LibExperience.inc(components, kamiID, output);
     LibKami.resetCooldown(components, kamiID);
+    LibBonus.resetUponCooldownSet(components, kamiID);
 
     // scavenge
     uint256 nodeID = LibHarvest.getNode(components, harvestID);


### PR DESCRIPTION
## Summary

- Introduces `UPON_COOLDOWN_SET` end type so cooldown bonuses (Energy Drink) live on a separate path from harvest bonuses
- `LibBonus.resetUponCooldownSet()` is called after every `resetCooldown()` in: HarvestStart, HarvestCollect, HarvestStop, HarvestLiquidate
- Client updated to query and display the new end type (`"til next cooldown"`)
- `clearAll()` updated to include the new type

## Bugs Fixed

1. **Feeding wasted Energy Drink** — regular food called `resetUponHarvestAction` which wiped the drink's bonus, even though feeding never sets cooldown
2. **Liquidation exploit** — killer's cooldown bonus was never consumed, giving permanent -30s cooldown across repeated kills

## Notion Data Change Required

In the **allos** table, update the `COOLDOWN-30s` row's **Terminator** column:

```
UPON_HARVEST_ACTION  →  UPON_COOLDOWN_SET
```

Without this data change, the Energy Drink will still register under the old end type and the code fix won't take effect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new bonus expiration type that triggers when cooldowns reset. Bonuses of this type will automatically expire during all harvest-related operations, including collecting items, liquidating resources, starting new harvests, and stopping ongoing harvests. This mechanic enables time-sensitive strategic gameplay elements tied to cooldown cycles and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->