### PR TITLE
starve cutoff — cap harvest bounty by HP via inverse strain formula

### DIFF
--- a/packages/client/src/app/cache/harvest/calcs.ts
+++ b/packages/client/src/app/cache/harvest/calcs.ts
@@ -42,6 +42,21 @@ export const calcNetBounty = (harvest: Harvest): number => {
   return Math.floor(duration * rate);
 };
 
+// Calculate the bounty since last sync from first principles.
+// Does not read from the rate cache, so it is safe to call even when
+// rates have been zeroed for display (starve cutoff).
+export const calcRawNetBounty = (harvest: Harvest, kami: Kami): number => {
+  if (harvest.state !== 'ACTIVE' || !kami.config) return 0;
+  const config = kami.config.harvest.bounty;
+  const boostBonus = kami.bonuses?.harvest.bounty.boost ?? 0;
+  const boost = config.boost.value + boostBonus;
+  const fertility = calcFertility(harvest, kami);
+  const intensity = calcIntensity(harvest, kami);
+  const rate = boost * (fertility + intensity.average);
+  const duration = calcIdleTime(harvest);
+  return Math.floor(duration * rate);
+};
+
 /////////////////
 // RATE CALCS
 

--- a/packages/client/src/app/cache/harvest/calcs.ts
+++ b/packages/client/src/app/cache/harvest/calcs.ts
@@ -45,6 +45,9 @@ export const calcNetBounty = (harvest: Harvest): number => {
 // Calculate the bounty since last sync from first principles.
 // Does not read from the rate cache, so it is safe to call even when
 // rates have been zeroed for display (starve cutoff).
+// Used by calcHealth and calcOutput, which need the real bounty to compute
+// cap and strain correctly. See updateHarvestRate in kami/calcs/harvest.ts
+// for why the rate cache gets zeroed and why these callers can't use it.
 export const calcRawNetBounty = (harvest: Harvest, kami: Kami): number => {
   if (harvest.state !== 'ACTIVE' || !kami.config) return 0;
   const config = kami.config.harvest.bounty;

--- a/packages/client/src/app/cache/harvest/index.ts
+++ b/packages/client/src/app/cache/harvest/index.ts
@@ -5,6 +5,7 @@ export {
   calcIdleTime as calcHarvestIdleTime,
   calcLifeTime as calcHarvestLifeTime,
   calcNetBounty as calcHarvestNetBounty,
+  calcRawNetBounty as calcHarvestRawNetBounty,
   updateRates as updateHarvestRates,
 } from './calcs';
 export { getItem as getHarvestItem } from './functions';

--- a/packages/client/src/app/cache/kami/calcs/base.ts
+++ b/packages/client/src/app/cache/kami/calcs/base.ts
@@ -1,4 +1,4 @@
-import { calcHarvestIdleTime, calcHarvestNetBounty } from 'app/cache/harvest';
+import { calcHarvestIdleTime, calcHarvestRawNetBounty } from 'app/cache/harvest';
 import { Kami } from 'network/shapes/Kami/types';
 import { calcHarvestingHealthRate, calcMaxMusu, calcStrainFromBalance } from './harvest';
 
@@ -106,7 +106,7 @@ export const calcHealth = (kami: Kami): number => {
   let health = kami.stats?.health.sync ?? 0;
 
   if (isHarvesting(kami) && kami.harvest) {
-    const netBounty = calcHarvestNetBounty(kami.harvest);
+    const netBounty = calcHarvestRawNetBounty(kami.harvest, kami);
     const maxMusu = calcMaxMusu(kami);
     const capped = netBounty < maxMusu ? netBounty : maxMusu;
     const strain = calcStrainFromBalance(kami, capped, true);

--- a/packages/client/src/app/cache/kami/calcs/base.ts
+++ b/packages/client/src/app/cache/kami/calcs/base.ts
@@ -1,6 +1,6 @@
 import { calcHarvestIdleTime, calcHarvestNetBounty } from 'app/cache/harvest';
 import { Kami } from 'network/shapes/Kami/types';
-import { calcHarvestingHealthRate, calcStrainFromBalance } from './harvest';
+import { calcHarvestingHealthRate, calcMaxMusu, calcStrainFromBalance } from './harvest';
 
 ////////////////
 // STATE CHECKS
@@ -107,7 +107,9 @@ export const calcHealth = (kami: Kami): number => {
 
   if (isHarvesting(kami) && kami.harvest) {
     const netBounty = calcHarvestNetBounty(kami.harvest);
-    const strain = calcStrainFromBalance(kami, netBounty, true);
+    const maxMusu = calcMaxMusu(kami);
+    const capped = netBounty < maxMusu ? netBounty : maxMusu;
+    const strain = calcStrainFromBalance(kami, capped, true);
     health -= strain;
   } else if (isResting(kami)) {
     const duration = calcIdleTime(kami);

--- a/packages/client/src/app/cache/kami/calcs/base.ts
+++ b/packages/client/src/app/cache/kami/calcs/base.ts
@@ -99,8 +99,11 @@ export const calcCooldownRequirement = (kami: Kami): number => {
 ////////////////
 // HEALTH CALCS
 
-// calculate health based on the drain against last confirmed health
-// assumes that kami health rate has been updated
+// calculate health based on the drain against last confirmed health.
+// assumes that kami health rate has been updated.
+// uses calcRawNetBounty (not calcNetBounty) because the rate cache may
+// be zeroed by updateHarvestRate for display; we need the real bounty
+// to compute how much strain the kami has actually taken.
 export const calcHealth = (kami: Kami): number => {
   const totalHealth = kami.stats?.health.total ?? 0;
   let health = kami.stats?.health.sync ?? 0;

--- a/packages/client/src/app/cache/kami/calcs/harvest.ts
+++ b/packages/client/src/app/cache/kami/calcs/harvest.ts
@@ -34,7 +34,10 @@ export const calcHarvestingHealthRate = (kami: Kami): number => {
 // calculate the expected output from a pet harvest based on start time
 export const calcOutput = (kami: Kami): number => {
   if (!isHarvesting(kami) || !kami.harvest) return 0;
-  return kami.harvest.balance + calcHarvestNetBounty(kami.harvest);
+  const netBounty = calcHarvestNetBounty(kami.harvest);
+  const maxMusu = calcMaxMusu(kami);
+  const capped = netBounty < maxMusu ? netBounty : maxMusu;
+  return kami.harvest.balance + capped;
 };
 
 ////////////////////
@@ -53,3 +56,24 @@ export const calcStrainFromBalance = (kami: Kami, balance: number, roundUp = tru
   const strain = (balance * ratio * boost) / (harmony + baseHarmony);
   return roundUp ? Math.ceil(strain) : strain;
 };
+
+// Max MUSU a kami can earn given its current HP. Inverse of calcStrainFromBalance.
+// strain = amt * ratio * boost / (harmony + base) => max_amt = hp * (harmony + base) / (ratio * boost)
+export const calcMaxMusu = (kami: Kami): number => {
+  const hp = kami.stats?.health.sync ?? 0;
+  if (hp <= 0) return 0;
+
+  const config = kami.config?.harvest.strain;
+  if (!config) return Infinity;
+
+  const ratio = config.ratio.value;
+  const harmony = kami.stats?.harmony.total ?? 0;
+  const baseHarmony = config.nudge.value;
+  const boostBonus = kami.bonuses?.harvest.strain.boost ?? 0;
+  const boost = config.boost.value + boostBonus;
+  const denom = ratio * boost;
+  if (denom === 0) return Infinity;
+
+  return Math.floor((hp * (harmony + baseHarmony)) / denom);
+};
+

--- a/packages/client/src/app/cache/kami/calcs/harvest.ts
+++ b/packages/client/src/app/cache/kami/calcs/harvest.ts
@@ -1,4 +1,4 @@
-import { calcHarvestIdleTime, calcHarvestNetBounty, updateHarvestRates } from 'app/cache/harvest';
+import { calcHarvestIdleTime, calcHarvestNetBounty, calcHarvestRawNetBounty, updateHarvestRates } from 'app/cache/harvest';
 import { Kami } from 'network/shapes/Kami/types';
 import { isHarvesting } from './base';
 
@@ -43,7 +43,7 @@ export const calcHarvestingHealthRate = (kami: Kami): number => {
 // calculate the expected output from a pet harvest based on start time
 export const calcOutput = (kami: Kami): number => {
   if (!isHarvesting(kami) || !kami.harvest) return 0;
-  const netBounty = calcHarvestNetBounty(kami.harvest);
+  const netBounty = calcHarvestRawNetBounty(kami.harvest, kami);
   const maxMusu = calcMaxMusu(kami);
   const capped = netBounty < maxMusu ? netBounty : maxMusu;
   return kami.harvest.balance + capped;

--- a/packages/client/src/app/cache/kami/calcs/harvest.ts
+++ b/packages/client/src/app/cache/kami/calcs/harvest.ts
@@ -15,9 +15,18 @@ export const calcHarvestTime = (kami: Kami): number => {
 // RATES
 
 // update the harvest rate on the kami's harvest. do nothing if no harvest
+// zeroes displayed rates if HP budget is exhausted (starve cutoff)
 export const updateHarvestRate = (kami: Kami): number => {
   if (!kami.harvest || kami.harvest.state !== 'ACTIVE') return 0;
-  return updateHarvestRates(kami.harvest, kami);
+  updateHarvestRates(kami.harvest, kami);
+
+  const maxMusu = calcMaxMusu(kami);
+  if (maxMusu <= 0 || calcHarvestNetBounty(kami.harvest) >= maxMusu) {
+    kami.harvest.rates.total = { average: 0, spot: 0 };
+    return 0;
+  }
+
+  return kami.harvest.rates.total.average;
 };
 
 // calculate the rate of health drain while harvesting

--- a/packages/client/src/app/cache/kami/calcs/harvest.ts
+++ b/packages/client/src/app/cache/kami/calcs/harvest.ts
@@ -14,8 +14,13 @@ export const calcHarvestTime = (kami: Kami): number => {
 ////////////////
 // RATES
 
-// update the harvest rate on the kami's harvest. do nothing if no harvest
-// zeroes displayed rates if HP budget is exhausted (starve cutoff)
+// update the harvest rate on the kami's harvest. do nothing if no harvest.
+// zeroes the cached rates when HP budget is exhausted (starve cutoff).
+// this zeroing is intentional: it keeps all downstream rate consumers correct,
+// including calcHarvestingHealthRate (which would otherwise show a drain rate
+// on a kami whose health is already capped at 0) and all display components.
+// calcHealth and calcOutput must NOT read from the zeroed cache: they use
+// calcRawNetBounty instead to get the real bounty for cap/strain math.
 export const updateHarvestRate = (kami: Kami): number => {
   if (!kami.harvest || kami.harvest.state !== 'ACTIVE') return 0;
   updateHarvestRates(kami.harvest, kami);
@@ -40,7 +45,9 @@ export const calcHarvestingHealthRate = (kami: Kami): number => {
 ////////////////
 // OUTPUT
 
-// calculate the expected output from a pet harvest based on start time
+// calculate the expected output from a pet harvest based on start time.
+// uses calcRawNetBounty (not calcNetBounty) because the rate cache may
+// be zeroed by updateHarvestRate for display; we need the real bounty here.
 export const calcOutput = (kami: Kami): number => {
   if (!isHarvesting(kami) || !kami.harvest) return 0;
   const netBounty = calcHarvestRawNetBounty(kami.harvest, kami);

--- a/packages/contracts/src/libraries/LibHarvest.sol
+++ b/packages/contracts/src/libraries/LibHarvest.sol
@@ -167,7 +167,31 @@ library LibHarvest {
 
     // precision is only divided this time as applied > final (1e0)
     uint256 precision = 10 ** (RATE_PREC + config[3] + config[7]);
-    return (rate * ratio * boost) / precision;
+    uint256 rawBounty = (rate * ratio * boost) / precision;
+
+    // cap bounty at max MUSU sustainable by current HP (inverse strain)
+    uint256 maxMusu = calcMaxMusu(components, kamiID);
+    return rawBounty < maxMusu ? rawBounty : maxMusu;
+  }
+
+  /// @notice Max MUSU a kami can earn given its current HP. Inverse of LibKami.calcStrain.
+  /// strain = ceil(amt * core * boost / divisor) => max_amt = floor(hp * divisor / (core * boost))
+  function calcMaxMusu(IUintComp components, uint256 kamiID) internal view returns (uint256) {
+    int32 hp = LibStat.getCurrent(components, "HEALTH", kamiID);
+    if (hp <= 0) return 0;
+
+    uint32[8] memory config = LibConfig.getArray(components, "KAMI_HARV_STRAIN");
+    int256 bonusBoost = LibBonus.getFor(components, "STND_STRAIN_BOOST", kamiID);
+    uint256 core = config[2];
+    uint256 boost = (config[6].toInt256() + bonusBoost).toUint256();
+    uint256 denom = core * boost;
+    if (denom == 0) return type(uint256).max; // no strain = no cap
+
+    uint256 harmony = LibStat.getTotal(components, "HARMONY", kamiID).toUint256();
+    uint256 precision = 10 ** uint(config[3] + config[7]);
+    uint256 divisor = precision * (harmony + config[0]);
+
+    return (hp.toUint256() * divisor) / denom;
   }
 
   // Calculate the efficacy of a kami's core harvesting calc (min 0).

--- a/packages/contracts/test/systems/Harvest/StarveCutoff.t.sol
+++ b/packages/contracts/test/systems/Harvest/StarveCutoff.t.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity >=0.8.28;
+
+import "tests/utils/SetupTemplate.t.sol";
+
+contract StarveCutoffTest is SetupTemplate {
+  uint256 aKamiID;
+  uint256 prodID;
+
+  function setUp() public override {
+    super.setUp();
+    aKamiID = _mintKami(alice);
+    prodID = _startHarvest(aKamiID, 1);
+    _fastForward(_idleRequirement + 50);
+  }
+
+  // healthy kami should earn bounty normally
+  function testBountyNormalWhenHealthy() public {
+    assertTrue(LibKami.isHealthy(components, aKamiID), "should be healthy");
+    uint256 bounty = LibHarvest.calcBounty(components, prodID);
+    assertTrue(bounty > 0, "healthy kami should earn bounty");
+  }
+
+  // bounty should never exceed max MUSU sustainable by current HP
+  function testBountyCappedByHP() public {
+    uint256 maxMusu = LibHarvest.calcMaxMusu(components, aKamiID);
+    assertTrue(maxMusu > 0, "should have max musu budget");
+
+    // fast forward far enough that raw bounty would greatly exceed maxMusu
+    _fastForward(200 hours);
+    uint256 bounty = LibHarvest.calcBounty(components, prodID);
+
+    assertLe(bounty, maxMusu, "bounty should be capped by HP budget");
+    assertEq(bounty, maxMusu, "bounty should hit the cap exactly");
+  }
+
+  // after HP is drained to 0, bounty should be 0
+  function testBountyZeroAfterDrained() public {
+    // fast forward and sync to drain HP
+    _fastForward(200 hours);
+    ExternalCaller.kamiSync(aKamiID);
+
+    assertFalse(LibKami.isHealthy(components, aKamiID), "should be at 0 HP");
+
+    // further time passes — bounty should stay at 0
+    _fastForward(1 hours);
+    uint256 bounty = LibHarvest.calcBounty(components, prodID);
+    assertEq(bounty, 0, "drained kami should earn nothing");
+  }
+
+  // after healing back above 0 HP, bounty should return
+  function testBountyReturnsAfterHealing() public {
+    // drain to 0
+    _fastForward(200 hours);
+    ExternalCaller.kamiSync(aKamiID);
+    assertFalse(LibKami.isHealthy(components, aKamiID), "should be drained");
+
+    // heal back up
+    _healKami(aKamiID, 25);
+    assertTrue(LibKami.isHealthy(components, aKamiID), "should be healed");
+
+    // bounty should work again
+    _fastForward(10 minutes);
+    uint256 bounty = LibHarvest.calcBounty(components, prodID);
+    assertTrue(bounty > 0, "healed kami should earn bounty");
+  }
+
+  // accumulated balance should be preserved (only new bounty stops)
+  function testAccumulatedBalancePreserved() public {
+    // earn some bounty and sync it into balance
+    _fastForward(5 minutes);
+    ExternalCaller.kamiSync(aKamiID);
+    uint256 balanceBeforeDrain = LibHarvest.getBalance(components, prodID);
+    assertTrue(balanceBeforeDrain > 0, "should have earned something");
+
+    // drain HP to 0
+    _fastForward(200 hours);
+    ExternalCaller.kamiSync(aKamiID);
+
+    // balance should still include what was earned before
+    uint256 balanceAfterDrain = LibHarvest.getBalance(components, prodID);
+    assertGe(balanceAfterDrain, balanceBeforeDrain, "accumulated balance should be preserved");
+  }
+}


### PR DESCRIPTION
## summary
- caps harvest bounty at the maximum MUSU sustainable by current HP, using the inverse of the strain formula — `maxMusu = floor(hp * divisor / (core * boost))`
- when a kami's HP is drained to 0, bounty immediately stops accruing instead of continuing at full rate until the next sync
- client-side rates display 0 when HP budget is exhausted, keeping UI consistent with actual earnings

## files changed
- `LibHarvest.sol` — added `calcMaxMusu()`, capped `calcBounty()` return value
- `kami/calcs/harvest.ts` — client mirror of `calcMaxMusu`, capped `calcOutput()`, zeroed rates in `updateHarvestRate()`
- `kami/calcs/base.ts` — `calcHealth()` caps net bounty before computing strain
- `StarveCutoff.t.sol` — 5 new tests (healthy bounty, HP cap, zero after drain, heals back, balance preserved)

## do not merge yet
- needs test world confirmation still

## test plan
- [ ] all 11 harvest tests pass (5 new + 6 existing)
- [ ] verify client displays 0 rate when kami HP is drained
- [ ] verify bounty resumes after healing
- [ ] improve UI when in starving state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Harvest output is now capped by a health-derived maximum, preventing excessive earnings.
  * Harvest production halts when health is depleted and reliably resumes after recovery.
  * Health drain during harvesting now respects the same cap, reducing unexpected over-drain.

* **New Features**
  * Added an uncached raw bounty calculation and improved harvest-rate handling with a starve cutoff.

* **Tests**
  * Added tests covering bounty capping, starvation behavior, recovery, and preservation of accumulated harvest balance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->