### PR TITLE
client-side port of new recoil formulas

### DIFF
--- a/packages/client/src/app/cache/config/kami.ts
+++ b/packages/client/src/app/cache/config/kami.ts
@@ -25,10 +25,8 @@ export const getConfig = (world: World, comps: Components): KamiConfigs => {
       salvage: getAST(world, comps, 'KAMI_LIQ_SALVAGE'),
       spoils: getAST(world, comps, 'KAMI_LIQ_SPOILS'),
       karma: getAST(world, comps, 'KAMI_LIQ_KARMA'),
-      karmaEfficacy: getEfficacy(world, comps, 'KAMI_LIQ_KARMA_EFFICACY'),
       recoil: getAST(world, comps, 'KAMI_LIQ_RECOIL'),
-      karmaTemp: getAST(world, comps, 'KAMI_LIQ_KARMA-temp'),
-      recoilTemp: getAST(world, comps, 'KAMI_LIQ_RECOIL-temp'),
+      karmaEfficacy: getEfficacy(world, comps, 'KAMI_LIQ_KARMA_EFFICACY'),
     },
     rest: {
       metabolism: getAST(world, comps, 'KAMI_REST_METABOLISM'),
@@ -61,10 +59,8 @@ export const processConfig = (world: World, comps: Components): KamiConfigs => {
       salvage: processAST(world, comps, 'KAMI_LIQ_SALVAGE'),
       spoils: processAST(world, comps, 'KAMI_LIQ_SPOILS'),
       karma: processAST(world, comps, 'KAMI_LIQ_KARMA'),
-      karmaEfficacy: processEfficacy(world, comps, 'KAMI_LIQ_KARMA_EFFICACY'),
       recoil: processAST(world, comps, 'KAMI_LIQ_RECOIL'),
-      karmaTemp: processAST(world, comps, 'KAMI_LIQ_KARMA-temp'),
-      recoilTemp: processAST(world, comps, 'KAMI_LIQ_RECOIL-temp'),
+      karmaEfficacy: processEfficacy(world, comps, 'KAMI_LIQ_KARMA_EFFICACY'),
     },
     rest: {
       metabolism: processAST(world, comps, 'KAMI_REST_METABOLISM'),
@@ -94,8 +90,6 @@ export const isFalsey = (configs: KamiConfigs) => {
     isFalseyAST(configs.liquidation.karma) ||
     isFalseyAST(configs.liquidation.recoil) ||
     isFalseyEfficacy(configs.liquidation.karmaEfficacy) ||
-    isFalseyAST(configs.liquidation.karmaTemp) ||
-    isFalseyAST(configs.liquidation.recoilTemp) ||
     isFalseyAST(configs.rest.metabolism) ||
     isFalseyAST(configs.rest.recovery)
   );

--- a/packages/client/src/app/cache/config/kami.ts
+++ b/packages/client/src/app/cache/config/kami.ts
@@ -25,7 +25,10 @@ export const getConfig = (world: World, comps: Components): KamiConfigs => {
       salvage: getAST(world, comps, 'KAMI_LIQ_SALVAGE'),
       spoils: getAST(world, comps, 'KAMI_LIQ_SPOILS'),
       karma: getAST(world, comps, 'KAMI_LIQ_KARMA'),
+      karmaEfficacy: getEfficacy(world, comps, 'KAMI_LIQ_KARMA_EFFICACY'),
       recoil: getAST(world, comps, 'KAMI_LIQ_RECOIL'),
+      karmaTemp: getAST(world, comps, 'KAMI_LIQ_KARMA-temp'),
+      recoilTemp: getAST(world, comps, 'KAMI_LIQ_RECOIL-temp'),
     },
     rest: {
       metabolism: getAST(world, comps, 'KAMI_REST_METABOLISM'),
@@ -58,7 +61,10 @@ export const processConfig = (world: World, comps: Components): KamiConfigs => {
       salvage: processAST(world, comps, 'KAMI_LIQ_SALVAGE'),
       spoils: processAST(world, comps, 'KAMI_LIQ_SPOILS'),
       karma: processAST(world, comps, 'KAMI_LIQ_KARMA'),
+      karmaEfficacy: processEfficacy(world, comps, 'KAMI_LIQ_KARMA_EFFICACY'),
       recoil: processAST(world, comps, 'KAMI_LIQ_RECOIL'),
+      karmaTemp: processAST(world, comps, 'KAMI_LIQ_KARMA-temp'),
+      recoilTemp: processAST(world, comps, 'KAMI_LIQ_RECOIL-temp'),
     },
     rest: {
       metabolism: processAST(world, comps, 'KAMI_REST_METABOLISM'),
@@ -87,6 +93,9 @@ export const isFalsey = (configs: KamiConfigs) => {
     isFalseyAST(configs.liquidation.spoils) ||
     isFalseyAST(configs.liquidation.karma) ||
     isFalseyAST(configs.liquidation.recoil) ||
+    isFalseyEfficacy(configs.liquidation.karmaEfficacy) ||
+    isFalseyAST(configs.liquidation.karmaTemp) ||
+    isFalseyAST(configs.liquidation.recoilTemp) ||
     isFalseyAST(configs.rest.metabolism) ||
     isFalseyAST(configs.rest.recovery)
   );

--- a/packages/client/src/app/cache/kami/calcs/index.ts
+++ b/packages/client/src/app/cache/kami/calcs/index.ts
@@ -27,6 +27,7 @@ export {
 export {
   calcKarma as calcLiqKarma,
   calcRecoil as calcLiqRecoil,
+  calcRecoilEfficacy as calcLiqRecoilEfficacy,
   calcSpoils as calcLiqSpoils,
   calcStrain as calcLiqStrain,
   calcThreshold as calcLiqThreshold,

--- a/packages/client/src/app/cache/kami/calcs/liquidation.ts
+++ b/packages/client/src/app/cache/kami/calcs/liquidation.ts
@@ -117,13 +117,12 @@ export const calcStrain = (attacker: Kami, defender: Kami): number => {
 // calculate Karma — Gaussian-based combat multiplier for recoil (PR #2384)
 // uses the same CDF curve as calcAnimosity but with defender's violence vs attacker's harmony.
 // old formula was linear (v2 - h1 + nudge); new formula is smooth (Gaussian CDF of log ratio).
-// result is a multiplier (~0 to karmaTemp.ratio.value), NOT raw HP damage.
+// result is a multiplier (~0 to karma.ratio.value), NOT raw HP damage.
 export const calcKarma = (attacker: Kami, defender: Kami): number => {
   const config = attacker.config ?? defender.config;
   if (!config) return 0;
 
-  // reads from KAMI_LIQ_KARMA-temp (new Gaussian-based karma)
-  const karmaConfig = config.liquidation.karmaTemp;
+  const karmaConfig = config.liquidation.karma;
   const defViolence = defender.stats?.violence.total ?? 1;
   const attHarmony = attacker.stats?.harmony.total ?? 1;
 
@@ -173,10 +172,9 @@ export const calcRecoilEfficacy = (attacker: Kami, defender: Kami, baseEfficacy:
 // ATK_RECOIL_BOOST (attacker, reduces recoil). higher boost = more recoil on the attacker.
 export const calcRecoil = (attacker: Kami, defender: Kami): number => {
   const baseConfig = attacker.config ?? defender.config;
-  if (!baseConfig || !baseConfig.liquidation.recoilTemp) return 0;
+  if (!baseConfig || !baseConfig.liquidation.recoil) return 0;
 
-  // reads from KAMI_LIQ_RECOIL-temp
-  const config = baseConfig.liquidation.recoilTemp;
+  const config = baseConfig.liquidation.recoil;
 
   const karma = calcKarma(attacker, defender);
   const baseEfficacy = config.nudge.value; // config[0]/10^config[1] — base efficacy value

--- a/packages/client/src/app/cache/kami/calcs/liquidation.ts
+++ b/packages/client/src/app/cache/kami/calcs/liquidation.ts
@@ -114,34 +114,82 @@ export const calcStrain = (attacker: Kami, defender: Kami): number => {
   return calcStrainFromBalance(attacker, spoils, true);
 };
 
-// calculate Karma, the liquidation hp recoil due to violence
-// NOTE: one of the few intermediary results that don't round up
+// calculate Karma — Gaussian-based combat multiplier for recoil (PR #2384)
+// uses the same CDF curve as calcAnimosity but with defender's violence vs attacker's harmony.
+// old formula was linear (v2 - h1 + nudge); new formula is smooth (Gaussian CDF of log ratio).
+// result is a multiplier (~0 to karmaTemp.ratio.value), NOT raw HP damage.
 export const calcKarma = (attacker: Kami, defender: Kami): number => {
   const config = attacker.config ?? defender.config;
   if (!config) return 0;
 
-  const karmaConfig = config.liquidation.karma;
-  const v2 = defender.stats?.violence.total ?? 0;
-  const h1 = attacker.stats?.harmony.total ?? 0;
-  const core = Math.max(0, v2 - h1 + karmaConfig.nudge.value);
-  const efficacy = calcEfficacy(defender, attacker);
-  const karma = core * efficacy * karmaConfig.boost.value;
-  return Math.floor(karma);
+  // reads from KAMI_LIQ_KARMA-temp (new Gaussian-based karma)
+  const karmaConfig = config.liquidation.karmaTemp;
+  const defViolence = defender.stats?.violence.total ?? 1;
+  const attHarmony = attacker.stats?.harmony.total ?? 1;
+
+  const base = cdf(Math.log(defViolence / attHarmony), 0, 1);
+  const ratio = karmaConfig.ratio.value; // karma range (e.g. 2.0 from config [0, 0, 2000, 3, ...])
+  return base * ratio;
 };
 
-// calculate total liquidation hp recoil
+// calculate the affinity-based efficacy nudge applied to recoil (PR #2384)
+// mirrors calcEfficacy but uses defender's HAND vs attacker's BODY (opposite direction),
+// and reads from KAMI_LIQ_KARMA_EFFICACY config instead of KAMI_LIQ_EFFICACY.
+// advantage = defender's hand beats attacker's body → more recoil on the attacker.
+export const calcRecoilEfficacy = (attacker: Kami, defender: Kami, baseEfficacy: number): number => {
+  const config = attacker.config ?? defender.config;
+  if (!config) return Math.max(0, baseEfficacy);
+
+  const effConfig = config.liquidation.karmaEfficacy;
+
+  let shift = effConfig.base; // neutral shift
+  if (defender.traits && attacker.traits) {
+    // NOTE: reversed direction from threshold efficacy — defender's hand vs attacker's body
+    const defAffinity = defender.traits.hand.affinity;
+    const atkAffinity = attacker.traits.body.affinity;
+
+    if (defAffinity === 'EERIE') {
+      if (atkAffinity === 'SCRAP') shift = effConfig.up;
+      else if (atkAffinity === 'INSECT') shift = effConfig.down;
+    } else if (defAffinity === 'SCRAP') {
+      if (atkAffinity === 'INSECT') shift = effConfig.up;
+      else if (atkAffinity === 'EERIE') shift = effConfig.down;
+    } else if (defAffinity === 'INSECT') {
+      if (atkAffinity === 'EERIE') shift = effConfig.up;
+      else if (atkAffinity === 'SCRAP') shift = effConfig.down;
+    } else if (defAffinity === 'NORMAL') {
+      if (atkAffinity === 'NORMAL') shift = effConfig.special;
+    }
+  }
+
+  // no bonuses applied here yet (hardcoded zeroes in contract), floor at 0
+  return Math.max(0, baseEfficacy + shift);
+};
+
+// calculate total liquidation hp recoil (PR #2384)
+// old formula: (strain * ratio + karma) * boost — additive karma, single boost
+// new formula: (karma + recoilEfficacy) * strain * boost — multiplicative, dual-sided boost
+// boost now includes both DEF_RECOIL_BOOST (defender, increases recoil) and
+// ATK_RECOIL_BOOST (attacker, reduces recoil). higher boost = more recoil on the attacker.
 export const calcRecoil = (attacker: Kami, defender: Kami): number => {
   const baseConfig = attacker.config ?? defender.config;
-  if (!baseConfig || !baseConfig.liquidation.recoil) return 0;
+  if (!baseConfig || !baseConfig.liquidation.recoilTemp) return 0;
 
-  const bonus = attacker.bonuses?.attack.recoil;
-  const config = baseConfig.liquidation.recoil;
+  // reads from KAMI_LIQ_RECOIL-temp
+  const config = baseConfig.liquidation.recoilTemp;
 
-  const ratio = config.ratio.value;
-  const boost = config.boost.value + (bonus?.boost ?? 0);
   const karma = calcKarma(attacker, defender);
+  const baseEfficacy = config.nudge.value; // config[0]/10^config[1] — base efficacy value
+  const nudge = calcRecoilEfficacy(attacker, defender, baseEfficacy);
   const strain = calcStrain(attacker, defender);
-  const recoil = (strain * ratio + karma) * boost;
+
+  // boost: config base + defender's DEF_RECOIL_BOOST - attacker's ATK_RECOIL_BOOST
+  const atkBoostBonus = attacker.bonuses?.attack.recoil?.boost ?? 0;
+  const defBoostBonus = defender.bonuses?.defense.recoil?.boost ?? 0;
+  const boostRaw = config.boost.value + defBoostBonus - atkBoostBonus;
+  const boost = Math.max(0, boostRaw); // clamp to 0 (can't have negative recoil)
+
+  const recoil = (karma + nudge) * strain * boost;
   return Math.floor(recoil);
 };
 

--- a/packages/client/src/app/cache/kami/index.ts
+++ b/packages/client/src/app/cache/kami/index.ts
@@ -17,6 +17,7 @@ export {
   calcHealthPercent,
   calcHealthRate,
   calcLiqKarma,
+  calcLiqRecoilEfficacy,
   calcLiqStrain,
   calcLiqThreshold,
   calcOutput,

--- a/packages/client/src/network/shapes/Kami/bonuses.ts
+++ b/packages/client/src/network/shapes/Kami/bonuses.ts
@@ -20,6 +20,7 @@ interface Attack {
 interface Defense {
   threshold: AsphoAST;
   salvage: AsphoAST;
+  recoil: AsphoAST;
 }
 
 interface Harvest {
@@ -90,6 +91,12 @@ export const getBonuses = (
         ratio: getBonus('DEF_SALVAGE_RATIO', 3),
         shift: 0,
         boost: 0,
+      },
+      recoil: {
+        nudge: 0,
+        ratio: 0,
+        shift: 0,
+        boost: getBonus('DEF_RECOIL_BOOST', 3),
       },
     },
     harvest: {

--- a/packages/client/src/network/shapes/Kami/configs.ts
+++ b/packages/client/src/network/shapes/Kami/configs.ts
@@ -28,7 +28,10 @@ interface LiquidationConfig {
   salvage: AsphoAST;
   spoils: AsphoAST;
   karma: AsphoAST;
+  karmaEfficacy: Efficacy;
   recoil: AsphoAST;
+  karmaTemp: AsphoAST;
+  recoilTemp: AsphoAST;
 }
 
 interface RestConfig {
@@ -83,7 +86,10 @@ export const getConfigs = (world: World, comps: Components): Configs => {
       salvage: getASTNode(world, comps, 'KAMI_LIQ_SALVAGE'),
       spoils: getASTNode(world, comps, 'KAMI_LIQ_SPOILS'),
       karma: getASTNode(world, comps, 'KAMI_LIQ_KARMA'),
+      karmaEfficacy: getEfficacyNode(world, comps, 'KAMI_LIQ_KARMA_EFFICACY'),
       recoil: getASTNode(world, comps, 'KAMI_LIQ_RECOIL'),
+      karmaTemp: getASTNode(world, comps, 'KAMI_LIQ_KARMA-temp'),
+      recoilTemp: getASTNode(world, comps, 'KAMI_LIQ_RECOIL-temp'),
     },
     rest: {
       metabolism: getASTNode(world, comps, 'KAMI_REST_METABOLISM'),

--- a/packages/client/src/network/shapes/Kami/configs.ts
+++ b/packages/client/src/network/shapes/Kami/configs.ts
@@ -28,10 +28,8 @@ interface LiquidationConfig {
   salvage: AsphoAST;
   spoils: AsphoAST;
   karma: AsphoAST;
-  karmaEfficacy: Efficacy;
   recoil: AsphoAST;
-  karmaTemp: AsphoAST;
-  recoilTemp: AsphoAST;
+  karmaEfficacy: Efficacy; // affinity shifts applied to recoil via karma (PR #2384)
 }
 
 interface RestConfig {
@@ -86,10 +84,8 @@ export const getConfigs = (world: World, comps: Components): Configs => {
       salvage: getASTNode(world, comps, 'KAMI_LIQ_SALVAGE'),
       spoils: getASTNode(world, comps, 'KAMI_LIQ_SPOILS'),
       karma: getASTNode(world, comps, 'KAMI_LIQ_KARMA'),
-      karmaEfficacy: getEfficacyNode(world, comps, 'KAMI_LIQ_KARMA_EFFICACY'),
       recoil: getASTNode(world, comps, 'KAMI_LIQ_RECOIL'),
-      karmaTemp: getASTNode(world, comps, 'KAMI_LIQ_KARMA-temp'),
-      recoilTemp: getASTNode(world, comps, 'KAMI_LIQ_RECOIL-temp'),
+      karmaEfficacy: getEfficacyNode(world, comps, 'KAMI_LIQ_KARMA_EFFICACY'),
     },
     rest: {
       metabolism: getASTNode(world, comps, 'KAMI_REST_METABOLISM'),


### PR DESCRIPTION
## Summary
- ports the new recoil/karma calculations from PR #2384 (solidity) to the client layer
- rewrites `calcKarma` to use Gaussian CDF curve (same as `calcAnimosity`) instead of linear stat difference
- adds new `calcRecoilEfficacy` function for affinity-based recoil modifier (defender hand vs attacker body)
- rewrites `calcRecoil` with multiplicative formula: `(karma + efficacy) * strain * boost`
- adds `DEF_RECOIL_BOOST` to defense bonuses for dual-sided boost
- loads 3 new config keys: `KAMI_LIQ_KARMA_EFFICACY`, `KAMI_LIQ_KARMA-temp`, `KAMI_LIQ_RECOIL-temp`

## Files changed
- `liquidation.ts` — core calc rewrites + new `calcRecoilEfficacy`
- `configs.ts` — `LiquidationConfig` interface updated with 3 new fields
- `bonuses.ts` — `Defense` interface + `DEF_RECOIL_BOOST` getter
- `config/kami.ts` — loading + processing + falsey check for new configs
- `calcs/index.ts` + `kami/index.ts` — barrel exports for `calcRecoilEfficacy`

## Notes
- uses `-temp` config keys to match the contract's staged rollout pattern
- old `karma`/`recoil` config fields kept intact for backwards compat with current deployed contracts
- `calcThreshold`, `calcSpoils`, `calcSalvage`, `calcStrain` are unchanged