### PR TITLE
update token portal delay to 1 Day

### DIFF
--- a/packages/contracts/deployment/world/state/configs/configs.ts
+++ b/packages/contracts/deployment/world/state/configs/configs.ts
@@ -143,7 +143,7 @@ export async function initLiquidation(api: AdminAPI) {
 }
 
 export async function initPortal(api: AdminAPI) {
-  await api.config.set.number('PORTAL_TOKEN_EXPORT_DELAY', 1 * 24 * 3600); // measured in seconds (3 days)
+  await api.config.set.number('PORTAL_TOKEN_EXPORT_DELAY', 1 * 24 * 3600); // measured in seconds (1 day)
   await api.config.set.array('PORTAL_ITEM_EXPORT_TAX', [
     1, // flat tax (in resulting item)
     100, // % in basis points

--- a/packages/contracts/deployment/world/state/configs/configs.ts
+++ b/packages/contracts/deployment/world/state/configs/configs.ts
@@ -143,7 +143,7 @@ export async function initLiquidation(api: AdminAPI) {
 }
 
 export async function initPortal(api: AdminAPI) {
-  await api.config.set.number('PORTAL_TOKEN_EXPORT_DELAY', 3 * 24 * 3600); // measured in seconds (3 days)
+  await api.config.set.number('PORTAL_TOKEN_EXPORT_DELAY', 1 * 24 * 3600); // measured in seconds (3 days)
   await api.config.set.array('PORTAL_ITEM_EXPORT_TAX', [
     1, // flat tax (in resulting item)
     100, // % in basis points


### PR DESCRIPTION
doot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced the portal token export delay from 3 days to 1 day, so exported portal tokens become available much sooner. This shortens wait times for token access and accelerates workflows that depend on exported portal tokens without changing other behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->