### PR TITLE
Fix rarity deploy for consumables

### DIFF
--- a/packages/contracts/deployment/world/state/items/items.ts
+++ b/packages/contracts/deployment/world/state/items/items.ts
@@ -149,7 +149,7 @@ async function createConsumable(api: AdminAPI, entry: any) {
   const name = entry['Name'].trim();
   const description = entry['Description'];
   const rarityKey = entry['Rarity'];
-  const rarity = 5 - Rarities.indexOf(rarityKey);
+  const rarity = Rarities.indexOf(rarityKey) + 1;
 
   const image = getItemImage(name);
   const for_ = (entry['For'] ?? 'KAMI').toUpperCase();


### PR DESCRIPTION
Consumables do not currently have rarities deployed correctly due to the math for them being inverted (e.g. common = 5 instead of common = 1). This fixes that issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rarity calculation for consumable items to align with the standardized indexing system used by other item types, ensuring consistent rarity assignment across all consumables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->