### PR TITLE
Fix: ATK_RECOIL_BOOST sign inversion in new recoil formula

### DIFF
--- a/packages/client/src/app/cache/kami/calcs/liquidation.ts
+++ b/packages/client/src/app/cache/kami/calcs/liquidation.ts
@@ -181,10 +181,10 @@ export const calcRecoil = (attacker: Kami, defender: Kami): number => {
   const nudge = calcRecoilEfficacy(attacker, defender, baseEfficacy);
   const strain = calcStrain(attacker, defender);
 
-  // boost: config base + defender's DEF_RECOIL_BOOST - attacker's ATK_RECOIL_BOOST
+  // boost: config base + defender's DEF_RECOIL_BOOST + attacker's ATK_RECOIL_BOOST
   const atkBoostBonus = attacker.bonuses?.attack.recoil?.boost ?? 0;
   const defBoostBonus = defender.bonuses?.defense.recoil?.boost ?? 0;
-  const boostRaw = config.boost.value + defBoostBonus - atkBoostBonus;
+  const boostRaw = config.boost.value + defBoostBonus + atkBoostBonus;
   const boost = Math.max(0, boostRaw); // clamp to 0 (can't have negative recoil)
 
   const recoil = (karma + nudge) * strain * boost;

--- a/packages/contracts/src/libraries/LibKill.sol
+++ b/packages/contracts/src/libraries/LibKill.sol
@@ -212,7 +212,7 @@ library LibKill {
     // determine recoil boost based on bonuses
     int256 boostAtkBonus = LibBonus.getFor(comps, "ATK_RECOIL_BOOST", targetID);
     int256 boostDefBonus = LibBonus.getFor(comps, "DEF_RECOIL_BOOST", sourceID);
-    int256 boostRaw = config[6].toInt256() + boostDefBonus - boostAtkBonus;
+    int256 boostRaw = config[6].toInt256() + boostDefBonus + boostAtkBonus;
     uint256 boost = boostRaw > 0 ? uint256(boostRaw) : 0;
 
     uint256 precision = 10 ** uint256(config[1] + config[3] + config[7]);


### PR DESCRIPTION
## Summary
- The new `calcRecoil` formula (from #2384) subtracted `ATK_RECOIL_BOOST` assuming it would be a positive value, but the Apology Letter stores it as **-250** (negative = reduce by 25%)
- Subtracting a negative caused a double negation: `1000 - (-250) = 1250` → **25% increase** instead of the intended 25% reduction
- Fixes both `LibKill.sol` (on-chain) and `liquidation.ts` (client display) by changing `- atkBoostBonus` to `+ atkBoostBonus`, restoring the convention where the bonus value encodes its own direction

## Test plan
- [ ] Verify Apology Letter reduces recoil by 25% (not increases)
- [ ] Verify recoil without any bonus items is unchanged
- [ ] Verify DEF_RECOIL_BOOST (currently unused) would correctly increase recoil when positive

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected recoil damage calculations to properly account for attacker boost bonuses throughout all game interactions. Attacker bonuses now correctly increase recoil damage output instead of reducing it, providing more accurate and balanced combat mechanics. This adjustment improves consistency and ensures reliable damage calculations across all gameplay systems and layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->