### PR TITLE
Add check on production contract deployments that branch is main

### DIFF
--- a/packages/contracts/deployment/commands/deploy.ts
+++ b/packages/contracts/deployment/commands/deploy.ts
@@ -7,11 +7,13 @@ dotenv.config({ path: `.env.${process.env.NODE_ENV}` });
 import { clearInitWorld } from '../scripts/codegen';
 import { generateAndDeploy } from '../scripts/deployer';
 import { genInitScript } from '../scripts/worldIniter';
-import { setAutoMine, setTimestamp } from '../utils';
+import { assertProductionBranch, setAutoMine, setTimestamp } from '../utils';
 
 const argv = yargs(hideBin(process.argv)).argv;
 
 const run = async () => {
+  await assertProductionBranch();
+
   const partialDeployment =
     argv.partial ??
     (argv.components != undefined || argv.systems != undefined || argv.emitter != undefined);

--- a/packages/contracts/deployment/utils/index.ts
+++ b/packages/contracts/deployment/utils/index.ts
@@ -12,3 +12,4 @@ export {
 export { findLog } from './findLog';
 export { ignoreSolcErrors } from './forge';
 export { extractIdFromFile, getAllCompIDs, getAllSystemIDs, keccak256 } from './ids';
+export { assertProductionBranch } from './prodGuard';

--- a/packages/contracts/deployment/utils/prodGuard.ts
+++ b/packages/contracts/deployment/utils/prodGuard.ts
@@ -1,0 +1,29 @@
+import { execSync } from 'child_process';
+import * as readline from 'readline';
+
+export async function assertProductionBranch(): Promise<void> {
+  if (process.env.NODE_ENV !== 'production') return;
+
+  const branch = execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf-8' }).trim();
+
+  if (branch !== 'main') {
+    console.warn('\n⚠️  WARNING: You are deploying to PRODUCTION from branch "%s" (not main)\n', branch);
+
+    const confirmed = await promptConfirm('Are you sure you want to continue? (y/N): ');
+    if (!confirmed) {
+      console.log('Deployment aborted.');
+      process.exit(1);
+    }
+    console.log();
+  }
+}
+
+function promptConfirm(question: string): Promise<boolean> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.trim().toLowerCase() === 'y');
+    });
+  });
+}


### PR DESCRIPTION
When trying to deploy new/updated smart contracts to production, we should warn the user and require confirmation if their local repository is not currently checked out to `main` to avoid accidentally deploying the wrong code.

This is ignored on test deployments, since it is important to be able to test contract changes before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a production environment safeguard that verifies the deployment branch and requests user confirmation when deploying from non-main branches, preventing unintended production deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->