### PR TITLE
Remove temple blocks

### DIFF
--- a/packages/contracts/src/systems/HarvestCollectSystem.sol
+++ b/packages/contracts/src/systems/HarvestCollectSystem.sol
@@ -25,14 +25,6 @@ contract HarvestCollectSystem is System {
     uint256 accID = LibAccount.getByOperator(components, msg.sender);
     uint256 kamiID = LibHarvest.getKami(components, id);
 
-    // (ach) temporary blocker for temple of the wheel
-    if (LibKami.getRoom(components, kamiID) == 19) {
-      require(
-        LibAccount.getIndex(components, accID) == 833,
-        "you aren't even supposed to be here.."
-      );
-    }
-
     // standard checks (ownership, cooldown, state)
     LibHarvest.verifyIsHarvest(components, id);
     LibKami.verifyAccount(components, kamiID, accID);

--- a/packages/contracts/src/systems/HarvestStartSystem.sol
+++ b/packages/contracts/src/systems/HarvestStartSystem.sol
@@ -30,14 +30,6 @@ contract HarvestStartSystem is System {
     uint256 nodeID = LibNode.getByIndex(components, nodeIndex);
     if (nodeID == 0) revert("node does not exist");
 
-    // (ach) temporary blocker for temple of the wheel
-    if (nodeIndex == 19) {
-      require(
-        LibAccount.getIndex(components, accID) == 833,
-        "you aren't even supposed to be here.."
-      );
-    }
-
     // standard checks (ownership, cooldown, state)
     LibKami.verifyAccount(components, kamiID, accID);
     LibKami.verifyState(components, kamiID, "RESTING");

--- a/packages/contracts/src/systems/KamiUseItemSystem.sol
+++ b/packages/contracts/src/systems/KamiUseItemSystem.sol
@@ -20,13 +20,6 @@ contract KamiUseItemSystem is System {
     (uint256 kamiID, uint32 itemIndex) = abi.decode(arguments, (uint256, uint32));
     uint256 accID = LibAccount.getByOperator(components, msg.sender);
 
-    // (ach) temporary blocker for temple of the wheel
-    if (LibKami.getRoom(components, kamiID) == 19) {
-      require(
-        LibAccount.getIndex(components, accID) == 833,
-        "you aren't even supposed to be here.."
-      );
-    }
     LibItem.verifyEnabled(components, itemIndex);
 
     // pet checks


### PR DESCRIPTION
There were some blocks preventing harvesting in the Temple of the Wheel room until its release. These were cleared out when it was released, however, the change was kind of late and left out of the mega PR for the Temple of the Wheel, preventing it from reaching `main`.

Because of this, when these contracts got redeployed recently, those blocks _went back up_.

This PR simply ensures that these changes finally actually make it to `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed temporary access restrictions from harvest collection, harvest initiation, and item usage systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->