### PR TITLE
Simplify accept offer contract

### DIFF
--- a/packages/contracts/src/systems/KamiMarketAcceptOfferSystem.sol
+++ b/packages/contracts/src/systems/KamiMarketAcceptOfferSystem.sol
@@ -15,6 +15,10 @@ import { KamiMarketVault } from "tokens/KamiMarketVault.sol";
 
 uint256 constant ID = uint256(keccak256("system.kamimarket.acceptoffer"));
 
+error KamiMarketAcceptKamiMismatch();
+error KamiMarketAcceptInvalidOrderType();
+error KamiMarketAcceptEmptyBatch();
+
 /// @notice Accept any offer — WETH pulled from buyer, kami reassigned via IDOwnsKami
 contract KamiMarketAcceptOfferSystem is System {
   constructor(IWorld _world, address _components) System(_world, _components) {}
@@ -69,10 +73,9 @@ contract KamiMarketAcceptOfferSystem is System {
 
     if (keccak256(bytes(orderType)) == keccak256(bytes("KAMI_OFFER"))) {
       // specific offer: verify the offer targets this kami
-      require(
-        LibKamiMarket.getKamiIndex(components, offerID) == kamiIndex,
-        "KamiMarketAccept: kami mismatch"
-      );
+      if (LibKamiMarket.getKamiIndex(components, offerID) != kamiIndex) {
+        revert KamiMarketAcceptKamiMismatch();
+      }
       (buyerAddress, price, ) = LibKamiMarket.fillOffer(world, components, offerID, sellerAccID);
     } else if (keccak256(bytes(orderType)) == keccak256(bytes("KAMI_COLLECTION_OFFER"))) {
       (buyerAddress, price) = LibKamiMarket.fillCollectionOffer(
@@ -83,7 +86,7 @@ contract KamiMarketAcceptOfferSystem is System {
         kamiIndex
       );
     } else {
-      revert("KamiMarketAccept: invalid order type");
+      revert KamiMarketAcceptInvalidOrderType();
     }
 
     // WETH transfers via vault
@@ -112,7 +115,7 @@ contract KamiMarketAcceptOfferSystem is System {
     uint256 offerID,
     uint32[] memory kamiIndices
   ) internal returns (bytes memory) {
-    require(kamiIndices.length > 0, "KamiMarketAccept: empty batch");
+    if (kamiIndices.length == 0) revert KamiMarketAcceptEmptyBatch();
 
     // --- shared checks (once) ---
     uint256 sellerAccID = LibAccount.verifyOperator(components);
@@ -150,13 +153,10 @@ contract KamiMarketAcceptOfferSystem is System {
     }
 
     // --- batched WETH transfers ---
-    uint256 totalPrice;
-    uint256 totalFee;
-    for (uint256 i; i < kamiIndices.length; i++) {
-      uint256 fee = LibKamiMarket.calcFee(components, pricePerKami);
-      totalFee += fee;
-      totalPrice += pricePerKami;
-    }
+    uint256 batchCount = kamiIndices.length;
+    uint256 feePerKami = LibKamiMarket.calcFee(components, pricePerKami);
+    uint256 totalPrice = pricePerKami * batchCount;
+    uint256 totalFee = feePerKami * batchCount;
     KamiMarketVault vault = LibKamiMarket.getVault(components);
     vault.transferWETH(buyerAddress, sellerAddress, totalPrice - totalFee);
     if (totalFee > 0) {


### PR DESCRIPTION
Two optimizations to reduce the byte size of `KamiMarketAcceptOfferSystem.sol`

1) Custom errors with `revert` use fewer bytes than returning error messages with `require`, since the error message has to be embedded into the compiled contract.

2) We were calculating the fee on multi-kami orders in an inefficient way. Since `pricePerKami` is always the same, we can just do some simple multiplication rather than iterating over the array of kami.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error reporting in market offer acceptance operations, providing clearer error messages for invalid transactions and mismatched orders.

* **Chores**
  * Optimized batch processing logic for WETH fee and price calculations, reducing computational overhead during multi-item market transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->