### PR TITLE
fix: END_TYPE_PREFIX mismatch (ON_UNEQUIP_ -> UPON_UNEQUIP_)

### DIFF
--- a/packages/contracts/src/libraries/LibEquipment.sol
+++ b/packages/contracts/src/libraries/LibEquipment.sol
@@ -45,7 +45,7 @@ library LibEquipment {
   using LibString for string;
 
   string constant ENTITY_TYPE = "EQUIPMENT";
-  string constant END_TYPE_PREFIX = "ON_UNEQUIP_";
+  string constant END_TYPE_PREFIX = "UPON_UNEQUIP_";
 
   // Equipment capacity: base limit on total equipment an entity can have equipped
   uint256 constant DEFAULT_CAPACITY = 1;

--- a/packages/contracts/test/systems/Equipment.t.sol
+++ b/packages/contracts/test/systems/Equipment.t.sol
@@ -63,13 +63,13 @@ contract EquipmentTest is MintTemplate {
     );
     __ItemRegistrySystem.setSlot(PETPET_INDEX, SLOT_PETPET);
 
-    // Add bonus with ON_UNEQUIP end type (must match slot)
+    // Add bonus with UPON_UNEQUIP end type (must match slot)
     __ItemRegistrySystem.addAlloBonus(
       abi.encode(
         PETPET_INDEX,
         "EQUIP", // use case
         "STAT_POWER_SHIFT", // bonus type
-        "ON_UNEQUIP_Kami_Pet_Slot", // end type (slot-specific)
+        "UPON_UNEQUIP_Kami_Pet_Slot", // end type (slot-specific)
         uint256(0), // duration (0 for permanent until unequip)
         POWER_BONUS // value
       )
@@ -81,13 +81,13 @@ contract EquipmentTest is MintTemplate {
     );
     __ItemRegistrySystem.setSlot(HAT_INDEX, SLOT_HAT);
 
-    // Add bonus with ON_UNEQUIP end type (must match slot)
+    // Add bonus with UPON_UNEQUIP end type (must match slot)
     __ItemRegistrySystem.addAlloBonus(
       abi.encode(
         HAT_INDEX,
         "EQUIP",
         "STAT_HEALTH_SHIFT",
-        "ON_UNEQUIP_Kami_Hat_Slot",
+        "UPON_UNEQUIP_Kami_Hat_Slot",
         uint256(0),
         HEALTH_BONUS
       )
@@ -667,9 +667,9 @@ contract EquipmentTest is MintTemplate {
 
   function testGenEndType() public {
     string memory endType = LibEquipment.genEndType(SLOT_PETPET);
-    assertEq(endType, "ON_UNEQUIP_Kami_Pet_Slot", "End type should be ON_UNEQUIP_ + slot");
+    assertEq(endType, "UPON_UNEQUIP_Kami_Pet_Slot", "End type should be UPON_UNEQUIP_ + slot");
 
     string memory endType2 = LibEquipment.genEndType(SLOT_HAT);
-    assertEq(endType2, "ON_UNEQUIP_Kami_Hat_Slot", "End type should match slot");
+    assertEq(endType2, "UPON_UNEQUIP_Kami_Hat_Slot", "End type should match slot");
   }
 }

--- a/packages/contracts/test/systems/EquipmentTransfer.t.sol
+++ b/packages/contracts/test/systems/EquipmentTransfer.t.sol
@@ -122,7 +122,7 @@ contract EquipmentTransferTest is EquipmentTest {
       string.concat(context, ": item not returned to inventory")
     );
 
-    // (b) ON_UNEQUIP_{slot} bonus cleared
+    // (b) UPON_UNEQUIP_{slot} bonus cleared
     int256 powerBonus = LibBonus.getFor(components, "STAT_POWER_SHIFT", kamiID);
     assertEq(
       powerBonus, 0,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal identifier naming convention for equipment unequip operations to standardize bonus cleanup processes.
  * Updated corresponding test validations to reflect identifier naming changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->