### PR TITLE
add fee recipient to explicit kamiswap config

### DIFF
--- a/packages/contracts/deployment/world/state/configs/configs.ts
+++ b/packages/contracts/deployment/world/state/configs/configs.ts
@@ -81,6 +81,13 @@ async function initFriends(api: AdminAPI) {
   await api.config.set.number('FRIENDS_REQUEST_LIMIT', 10);
 }
 
+export async function initKamiSwap(api: AdminAPI) {
+  await api.config.set.address(
+    'KAMI_MARKET_FEE_RECIPIENT',
+    '0x6a2350be9eA194cB67df934Df24bFA939A1aAd40'
+  );
+}
+
 async function initLeveling(api: AdminAPI) {
   await api.config.set.number('KAMI_LVL_REQ_BASE', 40); // experience required for level 1->2
   await api.config.set.array('KAMI_LVL_REQ_MULT_BASE', [1259, 3]);

--- a/packages/contracts/deployment/world/state/configs/configs.ts
+++ b/packages/contracts/deployment/world/state/configs/configs.ts
@@ -84,7 +84,7 @@ async function initFriends(api: AdminAPI) {
 export async function initKamiSwap(api: AdminAPI) {
   await api.config.set.address(
     'KAMI_MARKET_FEE_RECIPIENT',
-    '0x6a2350be9eA194cB67df934Df24bFA939A1aAd40'
+    '0x3d7f111B3b69C657624b8633a997A56300212872'
   );
 }
 


### PR DESCRIPTION
probably need better ways of tracking/hosting config values

but in the meantime we need these to be explicit and accessible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new configuration initialization for KamiSwap market operations. The deployment system now supports automated setup of the designated market fee recipient address as part of the standard deployment workflow. This ensures proper fee configuration and enables correct fee routing for all KamiSwap market transactions going forward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->