### PR TITLE
Send Zevana proceeds to marketplace fee wallet

### DIFF
--- a/packages/contracts/src/systems/NewbieVendorBuySystem.sol
+++ b/packages/contracts/src/systems/NewbieVendorBuySystem.sol
@@ -14,6 +14,7 @@ import { LibAccount } from "libraries/LibAccount.sol";
 import { LibConfig } from "libraries/LibConfig.sol";
 import { LibFlag } from "libraries/LibFlag.sol";
 import { LibKami } from "libraries/LibKami.sol";
+import { LibKamiMarket } from "libraries/LibKamiMarket.sol";
 import { LibSoulbound } from "libraries/LibSoulbound.sol";
 
 uint256 constant ID = uint256(keccak256("system.newbievendor.buy"));
@@ -116,6 +117,8 @@ contract NewbieVendorBuySystem is System {
   function _transferKami(uint32 kamiIndex, uint256 price, uint256 buyerAccID) internal {
     address vendorAddr = LibConfig.getAddress(components, "NEWBIE_VENDOR_ADDRESS");
     uint256 vendorAccID = uint256(uint160(vendorAddr));
+    address feeRecipient = LibKamiMarket.getFeeRecipient(components);
+    if (feeRecipient == address(0)) feeRecipient = vendorAddr;
 
     uint256 kamiID = LibKami.getByIndex(components, kamiIndex);
     require(kamiID != 0, "NewbieVendor: kami not found");
@@ -125,8 +128,8 @@ contract NewbieVendorBuySystem is System {
     // reassign ownership via IDOwnsKami
     LibKami.setOwner(components, kamiID, buyerAccID);
 
-    // send ETH to vendor address
-    _transferETH(vendorAddr, price);
+    // route newbie-vendor proceeds to marketplace fee recipient when configured
+    _transferETH(feeRecipient, price);
 
     // refund excess
     uint256 excess = msg.value - price;

--- a/packages/contracts/test/systems/NewbieVendorTWAP.t.sol
+++ b/packages/contracts/test/systems/NewbieVendorTWAP.t.sol
@@ -362,6 +362,27 @@ contract NewbieVendorTWAPTest is SetupTemplate {
     assertTrue(LibFlag.has(components, charlie.id, "NEWBIE_VENDOR_PURCHASED"));
   }
 
+  function testVendorBuyRoutesProceedsToMarketFeeRecipient() public {
+    uint256 kamiID = _mintKami(alice);
+    uint32 kamiIndex = LibKami.getIndex(components, kamiID);
+
+    uint256[] memory pool = new uint256[](1);
+    pool[0] = uint256(kamiIndex);
+    vm.prank(deployer);
+    __NewbieVendorRegistrySystem.setPool(pool);
+
+    uint256 price = _NewbieVendorBuySystem.calcPrice();
+    uint256 treasuryBalanceBefore = treasury.balance;
+    uint256 vendorBalanceBefore = alice.owner.balance;
+
+    vm.deal(charlie.owner, price);
+    vm.prank(charlie.owner);
+    _NewbieVendorBuySystem.executeTyped{value: price}(kamiIndex);
+
+    assertEq(treasury.balance - treasuryBalanceBefore, price);
+    assertEq(alice.owner.balance - vendorBalanceBefore, 0);
+  }
+
   function testRefundReentrancyCannotBypassOneTimePurchase() public {
     ReentrantNewbieVendorBuyer attacker = new ReentrantNewbieVendorBuyer(address(_NewbieVendorBuySystem));
 


### PR DESCRIPTION
Currently, when someone buys a kami from Zevana, the funds are routed into the same wallet that stores the pool of kami she sells.

Ideally, this should just be sent to the same wallet that collects marketplace fees.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Updated vendor purchase payment routing to direct proceeds to the marketplace fee recipient.
  * Added fallback mechanism to ensure proper fund handling when the fee recipient is not configured.

* **Tests**
  * Added test coverage verifying marketplace fee recipient receives vendor purchase proceeds as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->