### PR TITLE
Fix font size on buttons 

### DIFF
--- a/packages/client/src/app/components/library/buttons/DropdownToggle.tsx
+++ b/packages/client/src/app/components/library/buttons/DropdownToggle.tsx
@@ -230,7 +230,7 @@ const MenuOption = styled.div<{
   justify-content: left;
   gap: 0.4vw;
   border-radius: 0.4vw;
-  font-size: 0.85vw;
+  font-size: 0.8vw;
   cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
   pointer-events: ${({ disabled }) => (disabled ? 'none' : 'auto')};
   background-color: ${({ disabled }) => (disabled ? '#bbb' : '#fff')};

--- a/packages/client/src/app/components/library/buttons/IconButton.tsx
+++ b/packages/client/src/app/components/library/buttons/IconButton.tsx
@@ -210,7 +210,7 @@ const Text = styled.div<{
   orientation: string;
   withIcon?: boolean;
 }>`
-  font-size: ${({ scale }) => scale * 0.4}${({ orientation }) => orientation};
+  font-size: ${({ scale }) => scale * 0.3}${({ orientation }) => orientation};
   padding: ${({ withIcon }) => (withIcon ? '0' : '0 0.6vw')};
 `;
 


### PR DESCRIPTION

<img width="623" height="272" alt="image" src="https://github.com/user-attachments/assets/ec3a1663-02bc-4352-9089-f761f2a92fb1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reduced font size in dropdown menu options for more compact typography.
  * Adjusted text scaling factor in icon buttons for refined visual proportions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->