### PR TITLE
Lower the top edge of center modals

### DIFF
--- a/packages/client/src/app/components/index.ts
+++ b/packages/client/src/app/components/index.ts
@@ -121,7 +121,7 @@ export const allComponents: UIComponentWithGrid[] = [
   },
   {
     uiComponent: CraftingModal,
-    gridConfig: { colStart: 33, colEnd: 67, rowStart: 3, rowEnd: 99 },
+    gridConfig: { colStart: 33, colEnd: 67, rowStart: 8, rowEnd: 99 },
   },
   {
     uiComponent: InventoryModal,
@@ -133,7 +133,7 @@ export const allComponents: UIComponentWithGrid[] = [
   },
   {
     uiComponent: NodeModal,
-    gridConfig: { colStart: 33, colEnd: 67, rowStart: 3, rowEnd: 99 },
+    gridConfig: { colStart: 33, colEnd: 67, rowStart: 8, rowEnd: 99 },
   },
   {
     uiComponent: PartyModal,
@@ -199,7 +199,7 @@ export const allComponents: UIComponentWithGrid[] = [
   },
   {
     uiComponent: KamiAdoptionAgency,
-    gridConfig: { colStart: 33, colEnd: 67, rowStart: 3, rowEnd: 99 },
+    gridConfig: { colStart: 33, colEnd: 67, rowStart: 8, rowEnd: 99 },
   },
   {
     uiComponent: RevealModal,


### PR DESCRIPTION
## Summary

Nudges three center-column modals down so their top edge aligns with the rest of the center-zone modals.

`CraftingModal`, `NodeModal`, and `KamiAdoptionAgency` were starting at `rowStart: 3`, while the other center modals start at `rowStart: 8`. This bumps all three to `rowStart: 8` for consistent vertical alignment.

## Changes

- `packages/client/src/app/components/index.ts` — `rowStart: 3 → 8` for `CraftingModal`, `NodeModal`, and `KamiAdoptionAgency` grid configs.

## Notes

- Placement-only change (modals are positioned on the shared 100×100 viewport grid); no logic touched.
- Worth a quick visual check that the three modals don't clip their headers at the new offset and still clear the top menu fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the vertical positioning of modal components for improved layout alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->