### PR TITLE
update codeowners: add urco and velas to sol and ci

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,10 +2,10 @@
 * @Asphodel-OS/Kamigotchi
 
 # By Language
-*.sol @jiracheron
+*.sol @jiracheron @kanyaveral @Cooops
 
 # By Domain
 pnpm-lock.yaml @Asphodel-OS/Kamigotchi
 
-.github/workflows/ @hubur @Cooops
-.github/scripts/ @hubur @Cooops
+.github/workflows/ @hubur @Cooops @kanyaveral
+.github/scripts/ @hubur @Cooops @kanyaveral


### PR DESCRIPTION
- *.sol: add @kanyaveral and @Cooops alongside @jiracheron so contract PRs are not bottlenecked on a single reviewer
- .github/workflows/ and .github/scripts/: add @kanyaveral
- global rule unchanged: every PR still requires a code owner approval, and @jiracheron stays auto-requested on solidity changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership coverage for Solidity files and selected repository automation paths.
  * Added additional reviewers responsible for workflow and scripting changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->