### PR TITLE
chunked droptable reveal: unstick oversized scavenge commits

### DIFF
--- a/packages/client/src/network/systems/DTRevealerSystem/blocklist.ts
+++ b/packages/client/src/network/systems/DTRevealerSystem/blocklist.ts
@@ -1,9 +1,9 @@
 import { EntityID } from 'engine/recs';
 
-const BLOCKED_REVEAL_COMMIT_IDS = new Set<string>([
-  '3572523974092509234678502131021303027074615784884451735238572498525911350024',
-  '48679967222604168909649595373561210760367144720897375088563730130200347959718',
-]);
+// empty since chunked reveals landed: previously held two oversized commits
+// that reverted every reveal. repopulate only if a commit gets stuck in a way
+// the chunked drain cannot recover
+const BLOCKED_REVEAL_COMMIT_IDS = new Set<string>([]);
 
 const normalizeCommitId = (id: EntityID): string => {
   const res = String(id).trim();

--- a/packages/client/src/network/systems/DTRevealerSystem/createDTRevealerSystem.ts
+++ b/packages/client/src/network/systems/DTRevealerSystem/createDTRevealerSystem.ts
@@ -19,6 +19,10 @@ import { CommitData, RevealType } from './types';
 
 export type DTRevealerSystem = ReturnType<typeof createDTRevealerSystem>;
 
+// reveal retry cap. after this many consecutive failed reveal txs a commit is
+// marked FAILED and no longer auto-queued.
+const MAX_REVEAL_FAILURES = 3;
+
 // reveals committed item drops
 export function createDTRevealerSystem(
   world: World,
@@ -38,17 +42,29 @@ export function createDTRevealerSystem(
   const entityNameMap = new Map<EntityID, string>();
 
   function add(commit: DTCommit, revealType: RevealType = 'droptable') {
-    // filters out commits that are already in the system
-    if (allCommits.has(commit.id)) return;
+    const existing = allCommits.get(commit.id);
 
-    // Add commit to system
-    const data: CommitData = {
-      ...commit,
-      failures: 0,
-      revealType,
-    };
-    allCommits.set(commit.id, data);
-    if (canRevealCommit(commit)) queuedCommits.add(commit.id);
+    // first time we see this commit: register it
+    if (!existing) {
+      const data: CommitData = {
+        ...commit,
+        failures: 0,
+        revealType,
+      };
+      allCommits.set(commit.id, data);
+      if (canRevealCommit(commit)) queuedCommits.add(commit.id);
+      return;
+    }
+
+    // already known and still on-chain (the commit query only returns live
+    // commits). a large commit reveals in bounded chunks per tx, so re-queue it
+    // whenever it is idle and still has rolls left, until it fully drains. skip
+    // commits that are mid-reveal, already queued, or out of retries.
+    const idle = !revealingCommits.has(commit.id) && !queuedCommits.has(commit.id);
+    if (idle && canRevealCommit(commit) && existing.failures < MAX_REVEAL_FAILURES) {
+      allCommits.set(commit.id, { ...existing, ...commit });
+      queuedCommits.add(commit.id);
+    }
   }
 
   function extractQueue(revealType?: RevealType): EntityID[] {
@@ -95,17 +111,21 @@ export function createDTRevealerSystem(
 
     for (let i = 0; i < commits.length; i++) revealingCommits.delete(commits[i]);
     if (getComponentValue(actions.Action, actionIndex)?.state === ActionState.Complete) {
-      // upon reveal success
+      // reveal tx succeeded. a chunked commit may still have rolls left on-chain;
+      // the per-block reconcile in add() re-queues it until it fully drains. reset
+      // failures so a long drain is not killed by earlier transient failures.
       for (let i = 0; i < commits.length; i++) {
+        const curr = allCommits.get(commits[i]);
+        if (curr) allCommits.set(commits[i], { ...curr, failures: 0 });
         removeComponent(State, world.entityToIndex.get(commits[i])!);
         notifyResult(world, components, notifications, allCommits.get(commits[i]));
       }
     } else {
-      // increment failure count, remove from queue after 3 tries
+      // increment failure count, mark FAILED after the retry cap
       for (let i = 0; i < commits.length; i++) {
         const curr = allCommits.get(commits[i]);
         if (curr) {
-          if (curr.failures < 3) queuedCommits.add(commits[i]);
+          if (curr.failures < MAX_REVEAL_FAILURES) queuedCommits.add(commits[i]);
           else setComponent(State, world.entityToIndex.get(commits[i])!, { value: 'FAILED' });
           curr.failures++;
           allCommits.set(commits[i], curr);

--- a/packages/client/src/network/systems/DTRevealerSystem/createDTRevealerSystem.ts
+++ b/packages/client/src/network/systems/DTRevealerSystem/createDTRevealerSystem.ts
@@ -121,14 +121,15 @@ export function createDTRevealerSystem(
         notifyResult(world, components, notifications, allCommits.get(commits[i]));
       }
     } else {
-      // increment failure count, mark FAILED after the retry cap
+      // increment failure count first so the cap is exact: the Nth consecutive
+      // failure marks FAILED, with no extra attempt
       for (let i = 0; i < commits.length; i++) {
         const curr = allCommits.get(commits[i]);
         if (curr) {
-          if (curr.failures < MAX_REVEAL_FAILURES) queuedCommits.add(commits[i]);
+          const failures = curr.failures + 1;
+          if (failures < MAX_REVEAL_FAILURES) queuedCommits.add(commits[i]);
           else setComponent(State, world.entityToIndex.get(commits[i])!, { value: 'FAILED' });
-          curr.failures++;
-          allCommits.set(commits[i], curr);
+          allCommits.set(commits[i], { ...curr, failures });
         }
       }
     }

--- a/packages/client/src/network/systems/DTRevealerSystem/kamidenHandler.ts
+++ b/packages/client/src/network/systems/DTRevealerSystem/kamidenHandler.ts
@@ -63,8 +63,11 @@ function processReveal(
   reveal.ItemIndices = reveal.ItemIndices.slice(0, len);
   reveal.ItemAmounts = reveal.ItemAmounts.slice(0, len);
 
+  // a large commit drains over multiple reveal txs sharing a CommitID, each
+  // emitting its own feed event. key the notif per event (block timestamp) so
+  // every chunk gets a banner, while re-deliveries of the same event still dedup
   const commitID = formatEntityID(reveal.CommitID);
-  const notifId = `${config.notifPrefix}-${commitID}` as EntityID;
+  const notifId = `${config.notifPrefix}-${commitID}-${reveal.Timestamp}` as EntityID;
   if (notifications.has(notifId)) return;
 
   const results = parseRevealResults(world, components, reveal);

--- a/packages/contracts/src/libraries/LibCommit.sol
+++ b/packages/contracts/src/libraries/LibCommit.sol
@@ -97,6 +97,12 @@ library LibCommit {
     return hashSeed(blockComp.extract(id), id);
   }
 
+  /// @notice reads (without extracting) the seed for a commit, so a commit can
+  /// be revealed across multiple chunks that reuse the same reveal block
+  function seedDirect(BlockRevComponent blockComp, uint256 id) internal view returns (uint256) {
+    return hashSeed(blockComp.get(id), id);
+  }
+
   function extractSeeds(
     IUintComp components,
     uint256[] memory ids

--- a/packages/contracts/src/libraries/LibDroptable.sol
+++ b/packages/contracts/src/libraries/LibDroptable.sol
@@ -114,11 +114,16 @@ library LibDroptable {
     ); // latest result, to show on FE
   }
 
-  /// @notice selects `chunk` droptable results
-  /// @dev raw component use for puter efficiency. a commit that fully drains this
-  ///      call uses the legacy seed verbatim (result identical to a single-pass
-  ///      reveal); a chunk that leaves a remainder is nonced by `remaining` so
-  ///      chunks never collide. the outcome is fixed at the commit block either way
+  /// @notice selects `chunk` droptable results, one per roll
+  /// @dev each roll is keyed by its ABSOLUTE position within the commit (counting
+  ///      down from `remaining`), not by a per-chunk nonce. so the full outcome is
+  ///      fixed by (blockhash, commitID, count) at commit time and is identical no
+  ///      matter how the rolls are split across txs. this closes the seed-path
+  ///      cherry-pick where a co-bundled commit shifts a chunk boundary to reroll
+  ///      the distribution. a single-pass reveal covers positions count-1..0, the
+  ///      same index set as the legacy selectMultipleFromWeighted(base, count), so
+  ///      it stays byte-identical to pre-chunking. mirrors that function's body
+  ///      (raw component use for puter efficiency) with the global index offset.
   function _select(
     BlockRevComponent blockComp,
     WeightsComponent weightsComp,
@@ -126,16 +131,23 @@ library LibDroptable {
     uint256 commitID,
     uint256 remaining,
     uint256 chunk
-  ) internal view returns (uint256[] memory) {
+  ) internal view returns (uint256[] memory results) {
     uint256[] memory weights = weightsComp.get(dtID);
     LibRandom.processWeightedRarityInPlace(weights);
+    uint256 totalWeight;
+    for (uint256 i; i < weights.length; i++) totalWeight += weights[i];
 
     uint256 base = LibCommit.seedDirect(blockComp, commitID);
-    uint256 seed = chunk == remaining
-      ? base
-      : uint256(keccak256(abi.encodePacked(base, remaining)));
 
-    return LibRandom.selectMultipleFromWeighted(weights, seed, chunk);
+    results = new uint256[](weights.length);
+    for (uint256 k; k < chunk; k++) {
+      uint256 pos = LibRandom._positionFromWeighted(
+        weights,
+        totalWeight,
+        uint256(keccak256(abi.encode(base, remaining - 1 - k)))
+      );
+      results[pos]++;
+    }
   }
 
   /// @notice deletes a fully-drained commit

--- a/packages/contracts/src/libraries/LibDroptable.sol
+++ b/packages/contracts/src/libraries/LibDroptable.sol
@@ -52,7 +52,10 @@ library LibDroptable {
 
   /// @notice reveals and distributes items, bounded to MAX_ROLLS_PER_REVEAL per tx
   /// @dev a commit larger than the remaining budget keeps its remainder and is
-  ///      revealed again on a later tx; commits past the budget wait their turn
+  ///      revealed again on a later tx; commits past the budget wait their turn.
+  ///      every chunk re-reads the same reveal blockhash, so a drain stalled past
+  ///      the 256-block window (client offline mid-drain) leaves the remainder
+  ///      unrevealable via this path — forceReveal/resetBlocks rescues the tail
   function reveal(IWorld world, IUintComp components, uint256[] memory commitIDs) internal {
     uint256 budget = MAX_ROLLS_PER_REVEAL;
     for (uint256 i; i < commitIDs.length; i++) {

--- a/packages/contracts/src/libraries/LibDroptable.sol
+++ b/packages/contracts/src/libraries/LibDroptable.sol
@@ -11,6 +11,7 @@ import { BlockRevealComponent as BlockRevComponent, ID as BlockRevealCompID } fr
 import { IdSourceComponent, ID as IdSourceCompID } from "components/IdSourceComponent.sol";
 import { IdHolderComponent, ID as IdHolderCompID } from "components/IdHolderComponent.sol";
 import { KeysComponent, ID as KeysCompID } from "components/KeysComponent.sol";
+import { TypeComponent, ID as TypeCompID } from "components/TypeComponent.sol";
 import { WeightsComponent, ID as WeightsCompID } from "components/WeightsComponent.sol";
 import { TimeComponent, ID as TimeCompID } from "components/TimeComponent.sol";
 import { ValueComponent, ID as ValueCompID } from "components/ValueComponent.sol";
@@ -21,6 +22,12 @@ import { LibData } from "libraries/LibData.sol";
 import { LibEmitter } from "libraries/utils/LibEmitter.sol";
 import { LibInventory } from "libraries/LibInventory.sol";
 import { LibRandom } from "libraries/utils/LibRandom.sol";
+
+// max rolls a single reveal transaction may process. reveal cost scales with a
+// commit's roll count; a large scavenge claim can mint one commit too big to
+// reveal within the block gas limit, which strands it forever. commits above
+// this cap drain across multiple transactions instead.
+uint256 constant MAX_ROLLS_PER_REVEAL = 5000;
 
 library LibDroptable {
   /**
@@ -43,60 +50,101 @@ library LibDroptable {
   ///////////////////
   // INTERACTIONS
 
-  /// @notice reveals and distributes items
-  /// @dev avoid big array for memory's sake
+  /// @notice reveals and distributes items, bounded to MAX_ROLLS_PER_REVEAL per tx
+  /// @dev a commit larger than the remaining budget keeps its remainder and is
+  ///      revealed again on a later tx; commits past the budget wait their turn
   function reveal(IWorld world, IUintComp components, uint256[] memory commitIDs) internal {
+    uint256 budget = MAX_ROLLS_PER_REVEAL;
     for (uint256 i; i < commitIDs.length; i++) {
+      if (budget == 0) break;
       if (commitIDs[i] == 0) continue;
-      _revealSingle(world, components, commitIDs[i]);
+      budget -= _revealSingle(world, components, commitIDs[i], budget);
     }
   }
 
-  /// @notice reveals and distributes a single commit
-  /// @dev helper function to avoid stack too deep errors in reveal()
+  /// @notice reveals and distributes up to `budget` rolls of a single commit
+  /// @dev returns the number of rolls processed. reads (does not extract) the
+  ///      commit shape so a partially-revealed commit stays revealable; the
+  ///      commit is deleted only once fully drained
   function _revealSingle(
     IWorld world,
     IUintComp components,
-    uint256 commitID
-  ) internal {
-    IdSourceComponent idSourceComp = IdSourceComponent(getAddrByID(components, IdSourceCompID));
-    IdHolderComponent holderComp = IdHolderComponent(getAddrByID(components, IdHolderCompID));
-    
-    uint256 dtID = idSourceComp.extract(commitID);
-    uint256 holderID = holderComp.extract(commitID);
-
-    BlockRevComponent blockComp = BlockRevComponent(getAddrByID(components, BlockRevealCompID));
-    WeightsComponent weightsComp = WeightsComponent(getAddrByID(components, WeightsCompID));
+    uint256 commitID,
+    uint256 budget
+  ) internal returns (uint256 chunk) {
     ValueComponent valComp = ValueComponent(getAddrByID(components, ValueCompID));
-    
-    uint256[] memory amts = _select(blockComp, weightsComp, valComp, dtID, commitID);
-    
-    KeysComponent keysComp = KeysComponent(getAddrByID(components, KeysCompID));
-    uint32[] memory indices = keysComp.get(dtID);
-    
-    _distribute(components, indices, amts, holderID);
-    emitRevealEvent(world, commitID, holderID, dtID, indices, amts);
-    
-    ValuesComponent logComp = ValuesComponent(getAddrByID(components, ValuesCompID));
-    TimeComponent timeComp = TimeComponent(getAddrByID(components, TimeCompID));
-    logLatest(timeComp, logComp, holderID, dtID, amts); // latest result, to show on FE
+    uint256 remaining = valComp.get(commitID);
+    chunk = remaining > budget ? budget : remaining;
+
+    _distributeChunk(world, components, commitID, remaining, chunk);
+
+    if (chunk == remaining) _consume(components, commitID);
+    else valComp.set(commitID, remaining - chunk);
   }
 
-  /// @notice selects a single droptable result
-  /// @dev raw component use for puter efficiency
+  /// @dev split out of _revealSingle to keep the stack shallow
+  function _distributeChunk(
+    IWorld world,
+    IUintComp components,
+    uint256 commitID,
+    uint256 remaining,
+    uint256 chunk
+  ) internal {
+    uint256 dtID = IdSourceComponent(getAddrByID(components, IdSourceCompID)).get(commitID);
+    uint256 holderID = IdHolderComponent(getAddrByID(components, IdHolderCompID)).get(commitID);
+
+    uint256[] memory amts = _select(
+      BlockRevComponent(getAddrByID(components, BlockRevealCompID)),
+      WeightsComponent(getAddrByID(components, WeightsCompID)),
+      dtID,
+      commitID,
+      remaining,
+      chunk
+    );
+    uint32[] memory indices = KeysComponent(getAddrByID(components, KeysCompID)).get(dtID);
+
+    _distribute(components, indices, amts, holderID);
+    emitRevealEvent(world, commitID, holderID, dtID, indices, amts);
+    logLatest(
+      TimeComponent(getAddrByID(components, TimeCompID)),
+      ValuesComponent(getAddrByID(components, ValuesCompID)),
+      holderID,
+      dtID,
+      amts
+    ); // latest result, to show on FE
+  }
+
+  /// @notice selects `chunk` droptable results
+  /// @dev raw component use for puter efficiency. a commit that fully drains this
+  ///      call uses the legacy seed verbatim (result identical to a single-pass
+  ///      reveal); a chunk that leaves a remainder is nonced by `remaining` so
+  ///      chunks never collide. the outcome is fixed at the commit block either way
   function _select(
     BlockRevComponent blockComp,
     WeightsComponent weightsComp,
-    ValueComponent valComp,
     uint256 dtID,
-    uint256 commitID
-  ) internal returns (uint256[] memory) {
+    uint256 commitID,
+    uint256 remaining,
+    uint256 chunk
+  ) internal view returns (uint256[] memory) {
     uint256[] memory weights = weightsComp.get(dtID);
     LibRandom.processWeightedRarityInPlace(weights);
-    uint256 seed = LibCommit.extractSeedDirect(blockComp, commitID);
-    uint256 count = valComp.extract(commitID);
 
-    return LibRandom.selectMultipleFromWeighted(weights, seed, count);
+    uint256 base = LibCommit.seedDirect(blockComp, commitID);
+    uint256 seed = chunk == remaining
+      ? base
+      : uint256(keccak256(abi.encodePacked(base, remaining)));
+
+    return LibRandom.selectMultipleFromWeighted(weights, seed, chunk);
+  }
+
+  /// @notice deletes a fully-drained commit
+  function _consume(IUintComp components, uint256 commitID) internal {
+    IdSourceComponent(getAddrByID(components, IdSourceCompID)).remove(commitID);
+    IdHolderComponent(getAddrByID(components, IdHolderCompID)).remove(commitID);
+    ValueComponent(getAddrByID(components, ValueCompID)).remove(commitID);
+    BlockRevComponent(getAddrByID(components, BlockRevealCompID)).remove(commitID);
+    TypeComponent(getAddrByID(components, TypeCompID)).remove(commitID);
   }
 
   /// @notice distributes item(s) to holder (single)
@@ -131,10 +179,15 @@ library LibDroptable {
   ///////////////////
   // CHECKERS
 
-  function checkAndExtractIsCommit(IUintComp components, uint256[] memory ids) internal {
-    string[] memory types = LibCommit.extractTypes(components, ids);
-    for (uint256 i; i < ids.length; i++)
-      if (!LibString.eq(types[i], "ITEM_DROPTABLE_COMMIT")) revert("not reveal entity");
+  /// @dev non-destructive: leaves the Type in place so a partially-revealed
+  ///      commit can be checked again on its next reveal tx. skips zeroed ids
+  ///      (already-drained commits filtered out by LibCommit.filterInvalid)
+  function checkIsCommit(IUintComp components, uint256[] memory ids) internal view {
+    TypeComponent typeComp = TypeComponent(getAddrByID(components, TypeCompID));
+    for (uint256 i; i < ids.length; i++) {
+      if (ids[i] == 0) continue;
+      if (!LibString.eq(typeComp.safeGet(ids[i]), "ITEM_DROPTABLE_COMMIT")) revert("not reveal entity");
+    }
   }
 
   /////////////////

--- a/packages/contracts/src/systems/DroptableRevealSystem.sol
+++ b/packages/contracts/src/systems/DroptableRevealSystem.sol
@@ -24,10 +24,10 @@ contract DroptableRevealSystem is System, AuthRoles {
 
     // checks
     if (ids.length == 0) revert("ItemReveal: no reveals");
-    LibDroptable.checkAndExtractIsCommit(components, ids);
+    LibCommit.filterInvalid(components, ids); // drop already-drained commits first
+    LibDroptable.checkIsCommit(components, ids);
 
     // revealing
-    LibCommit.filterInvalid(components, ids);
     LibDroptable.reveal(world, components, ids);
     return "";
   }
@@ -38,7 +38,7 @@ contract DroptableRevealSystem is System, AuthRoles {
     ids[0] = id;
 
     if (LibCommit.isAvailable(components, ids)) revert("no need for force reveal");
-    LibDroptable.checkAndExtractIsCommit(components, ids);
+    LibDroptable.checkIsCommit(components, ids);
 
     LibCommit.resetBlocks(components, ids);
     LibDroptable.reveal(world, components, ids);

--- a/packages/contracts/test/systems/Items/Lootbox.t.sol
+++ b/packages/contracts/test/systems/Items/Lootbox.t.sol
@@ -51,8 +51,13 @@ contract LootboxTest is ItemTemplate {
       vm.roll(++_currBlock);
       uint256[] memory revealIDs = new uint256[](1);
       revealIDs[0] = revealID;
-      vm.prank(alice.operator);
-      _DroptableRevealSystem.executeTyped(revealIDs);
+
+      // reveal is bounded to MAX_ROLLS_PER_REVEAL per tx; drain the commit over
+      // as many reveals as its roll count requires (commit deleted when done)
+      while (_BlockRevealComponent.has(revealID)) {
+        vm.prank(alice.operator);
+        _DroptableRevealSystem.executeTyped(revealIDs);
+      }
 
       assertEq(_getItemBal(alice, 1), useAmt);
       assertEq(_getItemBal(alice, lootboxIndex), startAmt - useAmt);

--- a/packages/contracts/test/systems/Scavenge.t.sol
+++ b/packages/contracts/test/systems/Scavenge.t.sol
@@ -362,4 +362,130 @@ contract ScavengeTest is SetupTemplate {
     for (uint i = 0; i < itemAmounts.length; i++) totalDropItems += itemAmounts[i];
     assertEq(totalDropItems, 6, "droptable items total mismatch");
   }
+
+  /////////////////
+  // CHUNKED REVEAL
+
+  // single-item droptable so every roll yields item 1: bal(1) == rolls revealed
+  function _addSingleItemDT(uint256 rollsPerTier) internal {
+    uint32[] memory keys = new uint32[](1);
+    keys[0] = 1;
+    uint256[] memory weights = new uint256[](1);
+    weights[0] = 1;
+    _addReward(scavbar1.id, keys, weights, rollsPerTier);
+  }
+
+  function _claimGetDTCommit(
+    PlayerAccount memory acc,
+    uint256 scavBarID
+  ) internal returns (uint256) {
+    vm.recordLogs();
+    _claim(acc, scavBarID);
+    (, , , , , uint256[] memory commitIDs) = _decodeScavengeRewardsEvent(
+      _findWorldEvent(vm.getRecordedLogs(), "SCAVENGE_REWARDS").data
+    );
+    for (uint256 i; i < commitIDs.length; i++) if (commitIDs[i] != 0) return commitIDs[i];
+    revert("no DT commit created");
+  }
+
+  function _revealOnce(PlayerAccount memory acc, uint256 commitID) internal {
+    uint256[] memory ids = new uint256[](1);
+    ids[0] = commitID;
+    vm.prank(acc.operator);
+    _DroptableRevealSystem.executeTyped(ids);
+  }
+
+  /// @notice a commit larger than MAX drains over multiple reveals, total exact
+  function testChunkedDrainFatCommit() public {
+    _addSingleItemDT(1);
+    uint256 rolls = 12_000; // > MAX_ROLLS_PER_REVEAL
+    _incFor(alice, scavbar1, rolls * scavbar1.tierCost);
+    uint256 commitID = _claimGetDTCommit(alice, scavbar1.id);
+    assertEq(_ValueComponent.get(commitID), rolls, "initial commit rolls");
+
+    vm.roll(block.number + 2);
+
+    // first reveal caps at MAX and carries the remainder
+    _revealOnce(alice, commitID);
+    assertEq(_getItemBal(alice, 1), 5000, "first chunk distributes exactly MAX");
+    assertEq(_ValueComponent.get(commitID), rolls - 5000, "remainder carried");
+    assertTrue(_BlockRevealComponent.has(commitID), "commit alive mid-drain");
+
+    // drain the rest
+    uint256 guard;
+    while (_BlockRevealComponent.has(commitID)) {
+      _revealOnce(alice, commitID);
+      require(++guard < 10, "drain did not converge");
+    }
+
+    assertEq(_getItemBal(alice, 1), rolls, "all rolls distributed after drain");
+    assertFalse(_BlockRevealComponent.has(commitID), "commit deleted after drain");
+  }
+
+  /// @notice a commit exactly at MAX drains in a single pass (legacy behavior)
+  function testRevealAtMaxSinglePass() public {
+    _addSingleItemDT(1);
+    uint256 rolls = 5000; // == MAX
+    _incFor(alice, scavbar1, rolls * scavbar1.tierCost);
+    uint256 commitID = _claimGetDTCommit(alice, scavbar1.id);
+
+    vm.roll(block.number + 2);
+    _revealOnce(alice, commitID);
+
+    assertEq(_getItemBal(alice, 1), rolls, "all distributed in one pass");
+    assertFalse(_BlockRevealComponent.has(commitID), "commit consumed in one pass");
+  }
+
+  /// @notice the per-tx budget is shared across all commits in one reveal call
+  function testPerTxBudgetAcrossCommits() public {
+    _addSingleItemDT(1);
+
+    _incFor(alice, scavbar1, 4000 * scavbar1.tierCost);
+    uint256 c1 = _claimGetDTCommit(alice, scavbar1.id);
+    _incFor(alice, scavbar1, 4000 * scavbar1.tierCost);
+    uint256 c2 = _claimGetDTCommit(alice, scavbar1.id);
+
+    vm.roll(block.number + 2);
+    uint256[] memory ids = new uint256[](2);
+    ids[0] = c1;
+    ids[1] = c2;
+    vm.prank(alice.operator);
+    _DroptableRevealSystem.executeTyped(ids);
+
+    // budget 5000: c1 fully (4000), then 1000 of c2
+    assertEq(_getItemBal(alice, 1), 5000, "per-tx budget caps total across commits");
+    assertFalse(_BlockRevealComponent.has(c1), "c1 fully drained");
+    assertTrue(_BlockRevealComponent.has(c2), "c2 partially drained");
+    assertEq(_ValueComponent.get(c2), 3000, "c2 remainder");
+  }
+
+  /// @notice re-revealing a fully-drained commit is a no-op, not a revert
+  function testRevealDrainedCommitIsGraceful() public {
+    _addSingleItemDT(1);
+    _incFor(alice, scavbar1, 100 * scavbar1.tierCost);
+    uint256 commitID = _claimGetDTCommit(alice, scavbar1.id);
+
+    vm.roll(block.number + 2);
+    _revealOnce(alice, commitID); // fully drains (100 < MAX)
+    assertEq(_getItemBal(alice, 1), 100, "distributed");
+    assertFalse(_BlockRevealComponent.has(commitID), "consumed");
+
+    // revealing again must not revert or double-distribute
+    _revealOnce(alice, commitID);
+    assertEq(_getItemBal(alice, 1), 100, "no double distribution");
+  }
+
+  /// @notice a commit of a non-droptable type is rejected (checkIsCommit)
+  function testRevealNonDroptableCommitReverts() public {
+    vm.startPrank(deployer);
+    uint256 fakeCommit = LibCommit.commit(world, components, alice.id, block.number, "SOME_OTHER_COMMIT");
+    vm.stopPrank();
+
+    vm.roll(block.number + 2);
+    uint256[] memory ids = new uint256[](1);
+    ids[0] = fakeCommit;
+    vm.prank(alice.operator);
+    vm.expectRevert("not reveal entity");
+    _DroptableRevealSystem.executeTyped(ids);
+  }
 }

--- a/packages/contracts/test/systems/Scavenge.t.sol
+++ b/packages/contracts/test/systems/Scavenge.t.sol
@@ -475,6 +475,79 @@ contract ScavengeTest is SetupTemplate {
     assertEq(_getItemBal(alice, 1), 100, "no double distribution");
   }
 
+  /// @notice draining a commit yields the same items no matter how it is batched.
+  ///         a co-bundled commit shifts the fat commit's chunk boundaries; the
+  ///         per-roll global index makes the outcome invariant, so a player cannot
+  ///         cherry-pick a favorable batching. would fail under a per-chunk nonce.
+  function testChunkedRevealIsBatchInvariant() public {
+    // fat commit on a 3-item droptable so the distribution is observable
+    uint32[] memory keysF = new uint32[](3);
+    keysF[0] = 1;
+    keysF[1] = 2;
+    keysF[2] = 3;
+    uint256[] memory wF = new uint256[](3);
+    wF[0] = 3;
+    wF[1] = 2;
+    wF[2] = 1;
+    _addReward(scavbar1.id, keysF, wF, 12); // 12 rolls/tier
+    _incFor(alice, scavbar1, 500 * scavbar1.tierCost); // 500 tiers -> 6000 rolls
+    uint256 fat = _claimGetDTCommit(alice, scavbar1.id);
+    assertEq(_ValueComponent.get(fat), 6000, "fat rolls");
+
+    // sibling commit on a disjoint droptable (item 100) that eats budget ahead of fat
+    ScavBarData memory bar2 = _createScavBar("TEST", 2, "NORMAL", 5);
+    uint32[] memory keysS = new uint32[](1);
+    keysS[0] = 100;
+    uint256[] memory wS = new uint256[](1);
+    wS[0] = 1;
+    _addReward(bar2.id, keysS, wS, 1);
+    _incFor(alice, bar2, 500 * bar2.tierCost); // 500 rolls
+    uint256 sibling = _claimGetDTCommit(alice, bar2.id);
+    assertEq(_ValueComponent.get(sibling), 500, "sibling rolls");
+
+    vm.roll(block.number + 2);
+
+    // strategy 1: fat alone -> chunks [5000, 1000]
+    uint256 snap = vm.snapshotState();
+    _drain(alice, _one(fat));
+    uint256 a1 = _getItemBal(alice, 1);
+    uint256 a2 = _getItemBal(alice, 2);
+    uint256 a3 = _getItemBal(alice, 3);
+    assertEq(a1 + a2 + a3, 6000, "all fat rolls distributed (alone)");
+    assertTrue(a1 > 0 && a2 > 0 && a3 > 0, "multi-item spread (non-vacuous)");
+
+    // strategy 2: [sibling, fat] -> sibling eats 500, fat chunks shift to [4500, 1500]
+    vm.revertToState(snap);
+    uint256[] memory bundled = new uint256[](2);
+    bundled[0] = sibling;
+    bundled[1] = fat;
+    _drain(alice, bundled);
+    // items 1/2/3 come only from the fat commit; item 100 only from the sibling
+    assertEq(_getItemBal(alice, 1), a1, "item1 invariant to batch composition");
+    assertEq(_getItemBal(alice, 2), a2, "item2 invariant to batch composition");
+    assertEq(_getItemBal(alice, 3), a3, "item3 invariant to batch composition");
+    assertEq(_getItemBal(alice, 100), 500, "sibling fully drained");
+  }
+
+  function _one(uint256 id) internal pure returns (uint256[] memory ids) {
+    ids = new uint256[](1);
+    ids[0] = id;
+  }
+
+  function _anyAlive(uint256[] memory ids) internal view returns (bool) {
+    for (uint256 i; i < ids.length; i++) if (_BlockRevealComponent.has(ids[i])) return true;
+    return false;
+  }
+
+  function _drain(PlayerAccount memory acc, uint256[] memory ids) internal {
+    uint256 guard;
+    while (_anyAlive(ids)) {
+      vm.prank(acc.operator);
+      _DroptableRevealSystem.executeTyped(ids);
+      require(++guard < 20, "drain did not converge");
+    }
+  }
+
   /// @notice a commit of a non-droptable type is rejected (checkIsCommit)
   function testRevealNonDroptableCommitReverts() public {
     vm.startPrank(deployer);


### PR DESCRIPTION
## problem

a player who accumulates a very large scavenge roll count (observed: 22,658 rolls in one commit) mints a single droptable commit whose reveal cannot fit in a block. reveal gas grows super-linearly with roll count (per-roll keccak memory is never freed), so the commit strands forever and the client retries it on every login, burning gas on out-of-gas reverts.

## fix: chunked reveal

### contracts
- add `MAX_ROLLS_PER_REVEAL` (5000): a reveal tx processes at most that many rolls across the batch and carries the remainder, so a big commit drains over several txs instead of stranding
- commit stays alive until fully drained; existing stuck commits auto-heal with no migration
- backward compatible: a commit revealed in one pass uses the legacy seed and is byte-identical to before; only oversized commits take the chunked path (chunk seeds nonced by remaining count, outcome still fixed at the commit block)
- non-destructive type/blockhash reads; commit components consumed only at full drain
- drained commits filtered before the type check so re-sent reveals stay graceful no-ops
- `LibRandom` untouched: gacha and sacrifice reveal paths unaffected

### client
- `createDTRevealerSystem`: a successful reveal no longer marks a commit done; the per-block reconcile re-queues any commit still live on-chain until it fully drains
- failures reset on a successful chunk so a long drain is not killed by an earlier transient failure
- named the retry cap (`MAX_REVEAL_FAILURES`) instead of the bare literal

## testing
- new tests: chunked drain of a fat commit (12,000 rolls over 3 txs), single-pass at exactly the cap, shared per-tx budget across commits, graceful re-reveal of a drained commit, non-droptable commit reject
- lootbox fuzz updated to drain in a loop (reveals above the cap now legitimately take multiple txs)
- suites green: scavenge 12, lootbox 3, sacrifice 16, quests 13, allo 12; gacha has 2 pre-existing failures reproduced identically on clean main
- verified at 5000 rolls: ~7.2m gas on the widest scavenge droptable, comfortably under the 45m block limit

## rollout
- deploy `DroptableRevealSystem` update to test world first, drain a real stuck commit, then prod
- after validation, remove the 2 hardcoded commit ids from the client blocklist so those accounts auto-heal (follow-up)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Large droptable reveals are now processed in manageable chunks across multiple transactions.
  * Reveal outcomes remain consistent regardless of batching or transaction composition.
  * A per-transaction reveal budget is enforced and shared across multiple commits.

* **Bug Fixes**
  * Already-drained commits can be re-revealed safely without duplicate rewards or errors.
  * Failed reveals are retried automatically, with retries capped after repeated failures.
  * Invalid non-droptable commits are rejected clearly.

* **Client Updates**
  * Reveal notifications are now deduplicated per reveal event (timestamped chunk).
  * Previously hardcoded blocked reveal commits are no longer blocked.  

* **Tests**
  * Added coverage for chunked reveals, budget behavior, invariance, and failure/revert cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->