### PR TITLE
fix: robust world-state arg parsing + single-line verify names

### DIFF
--- a/packages/contracts/deployment/commands/verify-world.ts
+++ b/packages/contracts/deployment/commands/verify-world.ts
@@ -338,7 +338,9 @@ async function run() {
       console.log(`\n  ${entityType.label} (${rows.length} entries) - Index component not registered!`);
       for (const row of rows) {
         const idx = Number(row[entityType.indexCol]);
-        const name = row[entityType.nameCol] || `#${idx}`;
+        // collapse whitespace so multi-line CSV names (quoted values with embedded
+        // newlines) stay on one output line and don't break line-based parsing
+        const name = (row[entityType.nameCol] || `#${idx}`).replace(/\s+/g, ' ').trim();
         stateResults.push({ category: entityType.label, name: `${name} (#${idx})`, status: row['Status'] || '', onChain: false, state: 'ERROR', detail: 'Index component not registered' });
       }
       continue;
@@ -352,7 +354,9 @@ async function run() {
       const idx = Number(row[entityType.indexCol]);
       if (isNaN(idx) || idx === 0) continue;
 
-      const name = row[entityType.nameCol] || `#${idx}`;
+      // collapse whitespace so multi-line CSV names (quoted values with embedded
+      // newlines) stay on one output line and don't break line-based parsing
+      const name = (row[entityType.nameCol] || `#${idx}`).replace(/\s+/g, ' ').trim();
       const csvStatus = hasStatus ? row['Status'] : 'In Game';
       const entityID = generateRegID(entityType.regField, idx);
 

--- a/packages/contracts/deployment/commands/verify-world.ts
+++ b/packages/contracts/deployment/commands/verify-world.ts
@@ -339,8 +339,10 @@ async function run() {
       for (const row of rows) {
         const idx = Number(row[entityType.indexCol]);
         // collapse whitespace so multi-line CSV names (quoted values with embedded
-        // newlines) stay on one output line and don't break line-based parsing
-        const name = (row[entityType.nameCol] || `#${idx}`).replace(/\s+/g, ' ').trim();
+        // newlines) stay on one output line and don't break line-based parsing;
+        // collapse BEFORE the fallback so a whitespace-only cell still yields #idx
+        const rawName = (row[entityType.nameCol] ?? '').replace(/\s+/g, ' ').trim();
+        const name = rawName || `#${idx}`;
         stateResults.push({ category: entityType.label, name: `${name} (#${idx})`, status: row['Status'] || '', onChain: false, state: 'ERROR', detail: 'Index component not registered' });
       }
       continue;
@@ -355,8 +357,10 @@ async function run() {
       if (isNaN(idx) || idx === 0) continue;
 
       // collapse whitespace so multi-line CSV names (quoted values with embedded
-      // newlines) stay on one output line and don't break line-based parsing
-      const name = (row[entityType.nameCol] || `#${idx}`).replace(/\s+/g, ' ').trim();
+      // newlines) stay on one output line and don't break line-based parsing;
+      // collapse BEFORE the fallback so a whitespace-only cell still yields #idx
+      const rawName = (row[entityType.nameCol] ?? '').replace(/\s+/g, ' ').trim();
+      const name = rawName || `#${idx}`;
       const csvStatus = hasStatus ? row['Status'] : 'In Game';
       const entityID = generateRegID(entityType.regField, idx);
 

--- a/packages/contracts/deployment/commands/worldState.ts
+++ b/packages/contracts/deployment/commands/worldState.ts
@@ -12,6 +12,10 @@ import { SubFunc, WorldAPI } from '../world/world';
 const argv = yargs(hideBin(process.argv))
   .usage('Usage: $0 -world <address> -categories <string> -action <string>  -args <number[]>')
   .alias('category', 'c')
+  // collect list args so space-separated indices (`--args 4 5 6`) aren't dropped
+  // into positionals; comma-separated (`--args 4,5,6`) still parses identically
+  .array('args')
+  .array('npc')
   .parse();
 
 const run = async () => {

--- a/packages/contracts/deployment/commands/worldState.ts
+++ b/packages/contracts/deployment/commands/worldState.ts
@@ -23,13 +23,15 @@ const run = async () => {
   const world = argv.world ? argv.world : process.env.WORLD;
   const category: keyof WorldAPI = argv.category ?? 'init';
   const action = argv.action ? (argv.action as keyof SubFunc) : 'init';
-  const args = argv.args
+  // .length guard: a bare `--args` yields [] (truthy), which would flow through
+  // toString/split/Number into [0] and silently target entity index 0
+  const args = argv.args?.length
     ? argv.args
         .toString()
         .split(',') // ensure array
         .map((a: string) => Number(a)) // cast to number
     : undefined;
-  const npcArgs = argv.npc
+  const npcArgs = argv.npc?.length
     ? argv.npc
         .toString()
         .split(',')


### PR DESCRIPTION
two small, self-contained deploy-tooling fixes surfaced while syncing a stale test world from CSVs. both target the same failure mode: a run that looks successful while doing almost nothing.

## worldState.ts: collect list args as arrays
- `--args`/`--npc` are now declared `.array()` in the yargs config
- before: `--args 4 5 6` (space-separated) made yargs keep only `4` as `args` and drop `5 6` into positionals, so a multi-index init silently deployed just the first entity while still logging `Creating ...` / `Transactions saved` and exiting 0
- after: space-separated and comma-separated forms both yield the full array; the existing `.toString().split(',')` handles either. verified `--args 4 5 6`, `--args 4,5,6`, `--args 55`, and no-args all parse correctly with no positional leakage

## verify-world.ts: single-line entity names
- entity names are whitespace-collapsed before printing
- some CSV titles are quoted values with embedded newlines (e.g. quests 59/60); those printed `[MISSING]` on a separate line from `<label> #<idx>`, which hid them from line-based extraction of the missing set
- now every entry prints on one line

no behavior change for existing comma-separated callers; no chain writes involved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved world-state verification output by normalizing whitespace in entity names and providing a clear fallback for blank names.
  * Fixed world-state command-line handling for space-separated `--args` and `--npc` values.
  * Prevented empty `--args` or `--npc` options from generating unintended default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->