### PR TITLE
fix dead sudoswap link in party modal → adoption agency / kamiswap

### DIFF
--- a/packages/client/src/app/components/library/text/EmptyText.tsx
+++ b/packages/client/src/app/components/library/text/EmptyText.tsx
@@ -2,13 +2,11 @@ import styled from 'styled-components';
 
 // before and after are used to write plain text in the same line as the link
 // href opens an external page; onClick handles in-app actions (e.g. opening a modal)
-interface Link {
+type Link = {
   before?: string;
   linkText: string;
-  href?: string;
-  onClick?: () => void;
   after?: string;
-}
+} & ({ href: string; onClick?: never } | { href?: never; onClick: () => void });
 
 type TextPart = string | Link;
 
@@ -43,6 +41,7 @@ export const EmptyText = ({
               <Text key={index} size={size} color={textColor} gapScale={gapScale}>
                 {part.before}
                 <Link
+                  as={part.href ? 'a' : 'button'}
                   href={part.href}
                   target={part.href ? '_blank' : undefined}
                   rel={part.href ? 'noopener noreferrer' : undefined}
@@ -83,7 +82,12 @@ const Text = styled.div<{ size: number; gapScale: number; color: string }>`
   pointer-events: auto;
 `;
 
+// button resets keep the onClick variant visually identical to the anchor
 const Link = styled.a<{ size: number; gapScale: number; color: string }>`
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: inherit;
   color: ${({ color }) => color};
   font-size: ${({ size }) => size}vw;
   line-height: ${({ size, gapScale }) => gapScale * size}vw;

--- a/packages/client/src/app/components/library/text/EmptyText.tsx
+++ b/packages/client/src/app/components/library/text/EmptyText.tsx
@@ -1,10 +1,12 @@
 import styled from 'styled-components';
 
 // before and after are used to write plain text in the same line as the link
+// href opens an external page; onClick handles in-app actions (e.g. opening a modal)
 interface Link {
   before?: string;
   linkText: string;
-  href: string;
+  href?: string;
+  onClick?: () => void;
   after?: string;
 }
 
@@ -42,8 +44,9 @@ export const EmptyText = ({
                 {part.before}
                 <Link
                   href={part.href}
-                  target='_blank'
-                  rel='noopener noreferrer'
+                  target={part.href ? '_blank' : undefined}
+                  rel={part.href ? 'noopener noreferrer' : undefined}
+                  onClick={part.onClick}
                   size={size}
                   color={linkColor}
                   gapScale={gapScale}
@@ -85,6 +88,7 @@ const Link = styled.a<{ size: number; gapScale: number; color: string }>`
   font-size: ${({ size }) => size}vw;
   line-height: ${({ size, gapScale }) => gapScale * size}vw;
   text-decoration: underline;
+  cursor: pointer;
   &:hover {
     text-decoration: none;
   }

--- a/packages/client/src/app/components/modals/party/kamis/KamiList.tsx
+++ b/packages/client/src/app/components/modals/party/kamis/KamiList.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { EmptyText } from 'app/components/library';
 import { useVisibility } from 'app/stores';
 import { triggerKamiAdoptionAgencyModal } from 'app/triggers';
+import { playClick } from 'utils/sounds';
 import { objectBellShapedDevice } from 'assets/images/rooms/12_junkyard-machine';
 import { Account } from 'network/shapes/Account';
 import { Bonus } from 'network/shapes/Bonus';
@@ -48,6 +49,12 @@ export const KamiList = ({
   };
 }) => {
   const partyModalVisible = useVisibility((s) => s.modals.party);
+  const setModals = useVisibility((s) => s.setModals);
+
+  const openMarketplace = () => {
+    playClick();
+    setModals({ marketplace: true });
+  };
 
   const listedKamis = useMemo(
     () => data.kamis.filter((kami) => kami.state === 'LISTED'),
@@ -67,10 +74,16 @@ export const KamiList = ({
               'You are Kamiless.',
               '\n',
               {
-                before: 'Go to the ',
+                before: 'New? Get your first Kami at the ',
                 linkText: 'Adoption Agency',
                 onClick: () => triggerKamiAdoptionAgencyModal(),
-                after: ' to get a Kami! ',
+                after: '!',
+              },
+              {
+                before: 'Or find one on ',
+                linkText: 'KamiSwap',
+                onClick: openMarketplace,
+                after: '.',
               },
             ]}
           />

--- a/packages/client/src/app/components/modals/party/kamis/KamiList.tsx
+++ b/packages/client/src/app/components/modals/party/kamis/KamiList.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 import { EmptyText } from 'app/components/library';
 import { useVisibility } from 'app/stores';
+import { triggerKamiAdoptionAgencyModal } from 'app/triggers';
 import { objectBellShapedDevice } from 'assets/images/rooms/12_junkyard-machine';
 import { Account } from 'network/shapes/Account';
 import { Bonus } from 'network/shapes/Bonus';
@@ -66,9 +67,9 @@ export const KamiList = ({
               'You are Kamiless.',
               '\n',
               {
-                before: 'Go to ',
-                linkText: 'Sudoswap',
-                href: 'https://sudoswap.xyz/#/browse/yominet/buy/0x5d4376b62fa8ac16dfabe6a9861e11c33a48c677',
+                before: 'Go to the ',
+                linkText: 'Adoption Agency',
+                onClick: () => triggerKamiAdoptionAgencyModal(),
                 after: ' to get a Kami! ',
               },
             ]}


### PR DESCRIPTION
## what

the party modal's kamiless empty-state (`KamiList.tsx`) linked to an expired external sudoswap pool. it now offers two in-app paths:

- **Adoption Agency** — opens via the existing `triggerKamiAdoptionAgencyModal()` (same trigger Zevana's dialogue uses). new-player path.
- **KamiSwap** — opens the marketplace modal via `setModals`; zone resolution closes the party modal, identical to the menu KamiSwap button.

`EmptyText` link parts take `href` (external) or `onClick` (in-app) — an either/or union, so a part with neither doesn't compile. onClick links render as `<button>` with anchor-matching resets, so they're keyboard-reachable.

## why

new-player dead end: kamiless players were sent to a dead external pool. the adoption agency alone isn't enough — it only serves accounts <24h old that haven't adopted, so older kamiless players would hit 'you don't qualify' (another dead end). offering both lets the player self-select.

## rejected

single smart link that picks agency vs marketplace by account age — duplicates the modal's qualification logic in KamiList for marginal gain; two labeled links are self-explanatory.

## tested

tsc --noEmit: no new errors vs main (repo has 278 pre-existing, incl. one pre-existing unrelated error in KamiList.tsx — verified via stash/unstash). not runtime-tested: both targets reuse existing open mechanisms (dialogue trigger / menu button path).