### PR TITLE
disable settings/help during registration overlay

### DIFF
--- a/packages/client/src/app/components/fixtures/menu/buttons/More.tsx
+++ b/packages/client/src/app/components/fixtures/menu/buttons/More.tsx
@@ -13,6 +13,9 @@ export const MoreMenuButton = () => {
   const setModals = useVisibility((s) => s.setModals);
   const settingsVisible = useVisibility((s) => s.modals.settings);
   const helpVisible = useVisibility((s) => s.modals.help);
+  // settings/help modals render beneath the registration overlay (z 3 vs 20),
+  // so disable those entries while the registrar is up
+  const registrarVisible = useVisibility((s) => s.validators.accountRegistrar);
   const [disabled, setDisabled] = useState(true);
 
   useEffect(() => {
@@ -106,8 +109,13 @@ export const MoreMenuButton = () => {
       img={MoreIcon}
       options={[
         { text: 'Bridge', image: MenuIcons.kami, onClick: () => triggerBridgeModal() },
-        { text: 'Settings', disabled, image: SettingsIcon, onClick: toggleSettings },
-        { text: 'Help', image: HelpIcon, onClick: toggleHelp },
+        {
+          text: 'Settings',
+          disabled: disabled || registrarVisible,
+          image: SettingsIcon,
+          onClick: toggleSettings,
+        },
+        { text: 'Help', disabled: registrarVisible, image: HelpIcon, onClick: toggleHelp },
         { text: 'Logout', disabled, image: LogoutIcon, onClick: handleLogout },
         { text: 'Reset State', image: ResetIcon, onClick: handleResetState },
       ]}


### PR DESCRIPTION
## what

the More dropdown's Settings and Help entries are disabled while the account-registration overlay is up (`validators.accountRegistrar`). Settings reuses its existing auth-disabled pattern; Help gains the same flag. Bridge, Logout, and Reset State stay enabled.

## why

onboarding fix-list item: settings was reachable during registration and 'overlapped' it. root cause is layering, not reachability — `ValidatorWrapper` sits at z-index 20, `ModalWrapper` at 3, so settings/help open *underneath* the registration overlay and peek out around its edges looking broken.

settings itself stays pre-account (volume, address copy, operator key export are all legitimately needed before an account exists) — it's only disabled for the registration screen, which carries its own address-copy and docs link.

## rejected

- hiding the settings entry pre-account entirely — settings carries needed pre-account functions.
- raising modal z-index above validators — inverts the deliberate 'validators trump modals' layering and would let any modal cover required onboarding steps.

## tested

tsc --noEmit: no new errors vs main (278 pre-existing baseline). not runtime-tested: single boolean gate on an existing per-option disabled prop.