### PR TITLE
auto-close bridge modal after completion

### DIFF
--- a/packages/client/src/app/components/modals/bridge/Bridge.tsx
+++ b/packages/client/src/app/components/modals/bridge/Bridge.tsx
@@ -30,6 +30,7 @@ import {
   BridgePhase,
   BridgeUpdateEntry,
   BridgeUpdateTone,
+  COMPLETION_AUTO_CLOSE_MS,
   DEGRADED_POLL_INTERVAL_MS,
   DISABLED_SOURCE_CHAIN_IDS,
   MIN_BRIDGE_AMOUNT,
@@ -55,6 +56,7 @@ export const BridgeModal: UIComponent = {
     // PREPARATION
 
     const isOpen = useVisibility((s) => s.modals.bridge);
+    const setModals = useVisibility((s) => s.setModals);
     const setBridgeProcessActive = useVisibility((s) => s.setBridgeProcessActive);
     const selectedAddress = useNetwork((s) => s.selectedAddress);
     const { wallets } = useWallets();
@@ -400,6 +402,11 @@ export const BridgeModal: UIComponent = {
           appendUpdate('success', `**Yominet** Tx: ${receivedOnYominet}`, `${DefaultChain.blockExplorers?.default.url}/tx/${receivedOnYominet}`);
           appendUpdate('celebrate', 'Bridge Complete Congratulations');
           persistCompletion();
+          // auto-advance: close the modal after the celebration so onboarding
+          // (registration screen) resumes without a manual X
+          setTimeout(() => {
+            if (!signal.aborted) setModals({ bridge: false });
+          }, COMPLETION_AUTO_CLOSE_MS);
           return;
         }
       }

--- a/packages/client/src/app/components/modals/bridge/helpers/constants.ts
+++ b/packages/client/src/app/components/modals/bridge/helpers/constants.ts
@@ -81,4 +81,6 @@ export const POLL_INTERVAL_MS = 15_000;
 export const DEGRADED_POLL_INTERVAL_MS = 45_000;
 export const POLL_MAX_ATTEMPTS = 40;
 export const STATUS_RECHECK_EVERY_ATTEMPTS = 4;
+// how long the completion celebration stays up before the modal auto-closes
+export const COMPLETION_AUTO_CLOSE_MS = 2_500;
 


### PR DESCRIPTION
## what

on bridge success, the modal auto-closes 2.5s after the 'Bridge Complete Congratulations' celebration (`COMPLETION_AUTO_CLOSE_MS`). closing clears `bridgeFlowActive`, so the account registrar re-evaluates and the username screen appears — same thing the manual X did, automated. covers both the live polling path and the localStorage resume path (shared success branch in `waitForBridgeCompletion`). skipped when the run's abort signal fired.

## why

onboarding fix-list: the bridge completed into silence — users had to X out to discover registration continues. observed live in the 2026-07-15 playtest.

## notes

- `setModals({ bridge: false })` is safe here: `resolveConflicts` only guards bridge against being closed by *other modals opening*; an explicit false is the same terminal path as the exit button, and by completion the phase has settled to idle so no close-guard (wallet prompt / abort) is bypassed.
- error/timeout completion paths do NOT auto-close — only the confirmed-received branch.

## tested

tsc --noEmit: no new errors vs main (278 pre-existing baseline). not runtime-tested end-to-end (needs a real bridge run); logic reuses the existing manual-close path.