### PR TITLE
client: maintenance gate behind VITE_MAINTENANCE

### DIFF
--- a/packages/client/src/app/components/boot/MaintenanceScreen.tsx
+++ b/packages/client/src/app/components/boot/MaintenanceScreen.tsx
@@ -1,0 +1,94 @@
+import styled from 'styled-components';
+
+// font.css must be imported here: this screen renders from a bare createRoot
+// before app/boot.tsx (the usual importer of the Pixel @font-face) ever runs.
+import 'app/styles/font.css';
+import { loadingScreens } from 'assets/images/loading';
+
+// Full-client maintenance wall, shown when VITE_MAINTENANCE === 'true'.
+// Rendered from boot() IN PLACE OF the app: the network layer (RPC, kamigaze,
+// wallet) never initializes, so users cannot transact against a world that is
+// mid-ceremony. Self-contained by design — no stores, providers or network
+// hooks, since none of that exists when it mounts. Banner pick mirrors
+// BootScreen's rotation but seeds locally (no useNetwork store).
+const bannerKeys = Object.keys(loadingScreens);
+const bannerIndex = Math.floor(Math.random() * bannerKeys.length);
+
+export const MaintenanceScreen = () => {
+  return (
+    <Container>
+      <Image src={Object.values(loadingScreens)[bannerIndex]} />
+      <Dimmer />
+      <StatusContainer>
+        <Title>KAMIGOTCHI UNDER MAINTENANCE</Title>
+        <Subline>back soon! check the Discord for updates</Subline>
+      </StatusContainer>
+      <TagContainer>
+        <Tag>banner by: </Tag>
+        <Tag>{bannerKeys[bannerIndex]}</Tag>
+      </TagContainer>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  position: fixed;
+  inset: 0;
+  background-color: #000;
+  overflow: hidden;
+  user-select: none;
+  z-index: 2;
+`;
+
+const Image = styled.img`
+  height: 100%;
+  width: 100%;
+  user-drag: none;
+`;
+
+const Dimmer = styled.div`
+  position: absolute;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+`;
+
+const StatusContainer = styled.div`
+  position: absolute;
+  bottom: 25vh;
+  gap: 3vh;
+
+  width: 100%;
+  display: flex;
+  flex-flow: column nowrap;
+  justify-content: center;
+  align-items: center;
+  padding: 0 5vw;
+`;
+
+const Title = styled.div`
+  color: #fff;
+  text-align: center;
+  font-size: 3vh;
+  text-shadow: 0.2vh 0.2vh 0 #000;
+`;
+
+const Subline = styled.div`
+  color: #bbb;
+  text-align: center;
+  font-size: 2vh;
+  text-shadow: 0.2vh 0.2vh 0 #000;
+`;
+
+const TagContainer = styled.div`
+  position: absolute;
+  bottom: calc(5vh + env(safe-area-inset-bottom));
+  left: calc(5vw + env(safe-area-inset-left));
+  width: 100%;
+`;
+
+const Tag = styled.div`
+  color: #fff;
+  text-align: left;
+  font-size: 1.8vh;
+  line-height: 2.4vh;
+`;

--- a/packages/client/src/app/components/boot/index.ts
+++ b/packages/client/src/app/components/boot/index.ts
@@ -1,2 +1,3 @@
 export { BootScreen } from './BootScreen';
 export { LoadingState } from './LoadingState';
+export { MaintenanceScreen } from './MaintenanceScreen';

--- a/packages/client/src/boot.tsx
+++ b/packages/client/src/boot.tsx
@@ -1,11 +1,31 @@
+import ReactDOM from 'react-dom/client';
+
 import { getComponentValue, removeComponent, setComponent } from 'engine/recs';
 
 import { boot as bootReact, mountReact, setLayers } from 'app/boot';
+// direct file import: keeps the maintenance bundle free of the boot barrel's
+// LoadingState dependency graph (caches, network hooks)
+import { MaintenanceScreen } from 'app/components/boot/MaintenanceScreen';
 import { DefaultChain } from 'constants/chains';
 import { Layers, createNetworkConfig, createNetworkLayer } from 'network/';
 
+// Hard maintenance wall for prod deploy ceremonies. Checked before anything
+// else boots: when on, the network layer (RPC, kamigaze, wallet) never
+// initializes, so users cannot transact against a half-migrated world.
+// Takes precedence over VITE_STATE=DISABLED (soft season-over screen in
+// LoadingState, which still boots infra). Build-time flag: toggling it is a
+// redeploy each way.
+const MAINTENANCE = import.meta.env.VITE_MAINTENANCE === 'true';
+
 // boot the whole thing
 export async function boot() {
+  if (MAINTENANCE) {
+    const rootElement = document.getElementById('react-root');
+    if (!rootElement) return console.warn('React root not found');
+    ReactDOM.createRoot(rootElement).render(<MaintenanceScreen />);
+    return;
+  }
+
   bootReact();
   mountReact.current(false);
   const layers = await bootGame();

--- a/packages/client/src/vite-env.d.ts
+++ b/packages/client/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+// Env files are gitignored; the client gate flags are documented here.
+// Live values are set per-deploy as Vercel project env vars.
+interface ImportMetaEnv {
+  // hard maintenance wall: skips the entire network boot (see src/boot.tsx)
+  readonly VITE_MAINTENANCE?: 'true' | 'false';
+  // soft season-over screen, still boots infra (see LoadingState.tsx)
+  readonly VITE_STATE?: string;
+}


### PR DESCRIPTION
## why

during a prod system-redeploy ceremony, systems are deprecated and re-registered one at a time. a user transacting mid-swap hits `OwnableWritable__NotWriter` reverts or acts on stale state. the existing `VITE_STATE=DISABLED` flag only hides the ui: `bootGame()` still runs, so the client still connects to rpc/kamigaze/privy.

## what

- new `MaintenanceScreen`: self-contained wall styled like the boot screen (random community banner + credit tag, dim overlay, pixel title). no store/provider/network deps: it renders from a bare `createRoot` before any of that exists, and imports `font.css` itself
- gate at the top of `boot()`: when `VITE_MAINTENANCE=true`, render only the wall and return before `bootReact()`/`bootGame()`. the network layer never initializes, zero infra requests
- precedence: `VITE_MAINTENANCE` (hard wall, temporary during ops) beats `VITE_STATE=DISABLED` (soft season-over screen, unchanged)
- `boot.ts` renamed to `boot.tsx` for jsx; `src/index.ts` import is extensionless so no other changes
- `vite-env.d.ts` documents the gate flags: client env files are gitignored, so this is the only in-repo home for them

## toggle

build-time flag (vite inlines `import.meta.env`), absent defaults to off via strict `=== 'true'`. operator flow: set `VITE_MAINTENANCE=true` on the vercel project, redeploy, do the ceremony, set false, redeploy.

## verification

- headless chrome against a `vite preview` of a real production build, flag on: wall renders, zero non-localhost requests, zero console errors
- flag off: no wall, normal boot to `BOOTED`, rpc/kamigaze/privy traffic flows
- `tsc --noEmit`: identical pre-existing error count on main and this branch, none from these files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a full-screen maintenance mode with branded visuals and messaging.
  * The application can now display the maintenance screen before initializing normal services.
  * Added support for configuring maintenance and loading states through environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->