### PR TITLE
fix: reject duplicate ids in commit-reveal entrypoints

### DIFF
--- a/packages/client/abi/KamiGachaRevealSystem.json
+++ b/packages/client/abi/KamiGachaRevealSystem.json
@@ -132,7 +132,7 @@
       "name": "reveal",
       "inputs": [
         {
-          "name": "rawCommitIDs",
+          "name": "commitIDs",
           "type": "uint256[]",
           "internalType": "uint256[]"
         }

--- a/packages/client/types/ethers-contracts/KamiGachaRevealSystem.ts
+++ b/packages/client/types/ethers-contracts/KamiGachaRevealSystem.ts
@@ -238,7 +238,7 @@ export interface KamiGachaRevealSystem extends BaseContract {
   requestOwnershipHandover: TypedContractMethod<[], [void], "payable">;
 
   reveal: TypedContractMethod<
-    [rawCommitIDs: BigNumberish[]],
+    [commitIDs: BigNumberish[]],
     [bigint[]],
     "nonpayable"
   >;
@@ -282,11 +282,7 @@ export interface KamiGachaRevealSystem extends BaseContract {
   ): TypedContractMethod<[], [void], "payable">;
   getFunction(
     nameOrSignature: "reveal"
-  ): TypedContractMethod<
-    [rawCommitIDs: BigNumberish[]],
-    [bigint[]],
-    "nonpayable"
-  >;
+  ): TypedContractMethod<[commitIDs: BigNumberish[]], [bigint[]], "nonpayable">;
   getFunction(
     nameOrSignature: "transferOwnership"
   ): TypedContractMethod<[newOwner: AddressLike], [void], "payable">;

--- a/packages/contracts/src/libraries/LibCommit.sol
+++ b/packages/contracts/src/libraries/LibCommit.sol
@@ -9,9 +9,7 @@ import { getAddrByID, getCompByID } from "solecs/utils.sol";
 import { BlockRevealComponent as BlockRevComponent, ID as BlockRevealCompID } from "components/BlockRevealComponent.sol";
 import { IdHolderComponent, ID as IdHolderCompID } from "components/IdHolderComponent.sol";
 import { TypeComponent, ID as TypeCompID } from "components/TypeComponent.sol";
-
 import { LibComp } from "libraries/utils/LibComp.sol";
-import { LibRandom } from "libraries/utils/LibRandom.sol";
 
 /** @notice library for commit/reveal patters
  * Commits are designed to be extended upon depending on its use, but have a minimum shape

--- a/packages/contracts/src/libraries/LibDroptable.sol
+++ b/packages/contracts/src/libraries/LibDroptable.sol
@@ -30,6 +30,8 @@ import { LibRandom } from "libraries/utils/LibRandom.sol";
 uint256 constant MAX_ROLLS_PER_REVEAL = 5000;
 
 library LibDroptable {
+  using LibString for string;
+
   /**
    * @notice creates a reveal entity for an item droptable
    *   used for all item droptables, including lootboxes.
@@ -252,7 +254,12 @@ library LibDroptable {
       itemAmounts: amounts
     });
 
-    LibEmitter.emitEvent(world, "DROPTABLE_REVEAL", _schema(), _encodeDroptableRevealEvent(eventData));
+    LibEmitter.emitEvent(
+      world,
+      "DROPTABLE_REVEAL",
+      _schema(),
+      _encodeDroptableRevealEvent(eventData)
+    );
   }
 
   struct DroptableRevealEventData {
@@ -266,17 +273,27 @@ library LibDroptable {
 
   function _schema() internal pure returns (uint8[] memory) {
     uint8[] memory schema = new uint8[](6);
-    schema[0] = uint8(LibTypes.SchemaValue.UINT256);      // commitID
-    schema[1] = uint8(LibTypes.SchemaValue.UINT256);      // holderID
-    schema[2] = uint8(LibTypes.SchemaValue.UINT256);      // dtID
-    schema[3] = uint8(LibTypes.SchemaValue.UINT256);      // timestamp
+    schema[0] = uint8(LibTypes.SchemaValue.UINT256); // commitID
+    schema[1] = uint8(LibTypes.SchemaValue.UINT256); // holderID
+    schema[2] = uint8(LibTypes.SchemaValue.UINT256); // dtID
+    schema[3] = uint8(LibTypes.SchemaValue.UINT256); // timestamp
     schema[4] = uint8(LibTypes.SchemaValue.UINT32_ARRAY); // itemIndices
-    schema[5] = uint8(LibTypes.SchemaValue.UINT256_ARRAY);// itemAmounts
+    schema[5] = uint8(LibTypes.SchemaValue.UINT256_ARRAY); // itemAmounts
     return schema;
   }
 
-  function _encodeDroptableRevealEvent(DroptableRevealEventData memory data) internal pure returns (bytes memory) {
-    return abi.encode(data.commitID, data.holderID, data.dtID, data.timestamp, data.itemIndices, data.itemAmounts);
+  function _encodeDroptableRevealEvent(
+    DroptableRevealEventData memory data
+  ) internal pure returns (bytes memory) {
+    return
+      abi.encode(
+        data.commitID,
+        data.holderID,
+        data.dtID,
+        data.timestamp,
+        data.itemIndices,
+        data.itemAmounts
+      );
   }
 
   /////////////////

--- a/packages/contracts/src/libraries/LibGacha.sol
+++ b/packages/contracts/src/libraries/LibGacha.sol
@@ -6,7 +6,6 @@ import { IUint256Component as IUintComp } from "solecs/interfaces/IUint256Compon
 import { IWorld } from "solecs/interfaces/IWorld.sol";
 import { getAddrByID, getCompByID } from "solecs/utils.sol";
 import { LibString } from "solady/utils/LibString.sol";
-import { LibSort } from "solady/utils/LibSort.sol";
 
 import { IDOwnsKamiComponent, ID as IDOwnsKamiCompID } from "components/IDOwnsKamiComponent.sol";
 import { RerollComponent, ID as RerollCompID } from "components/RerollComponent.sol";
@@ -22,6 +21,7 @@ uint256 constant GACHA_ID = uint256(keccak256("gacha.id"));
 
 library LibGacha {
   using LibComp for IComponent;
+  using LibString for string;
 
   /// @notice Creates a commit for multiple gacha rolls (same account)
   function commit(
@@ -69,18 +69,6 @@ library LibGacha {
   }
 
   /////////////////
-  // CALC
-
-  /// @notice sort based on entityID
-  function sortCommits(
-    IUintComp components,
-    uint256[] memory ids
-  ) internal view returns (uint256[] memory) {
-    LibSort.insertionSort(ids);
-    return ids;
-  }
-
-  /////////////////
   // RANDOMS
 
   /// @notice gets random pets from gacha with seeds
@@ -124,7 +112,7 @@ library LibGacha {
   function checkAndExtractIsCommit(IUintComp components, uint256[] memory ids) internal {
     string[] memory types = LibCommit.extractTypes(components, ids);
     for (uint256 i; i < ids.length; i++) {
-      if (!LibString.eq(types[i], "GACHA_COMMIT")) revert("not gacha commit");
+      if (!types[i].eq("GACHA_COMMIT")) revert("LibGacha: invalid commit ID");
     }
   }
 

--- a/packages/contracts/src/libraries/utils/LibArray.sol
+++ b/packages/contracts/src/libraries/utils/LibArray.sol
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.8.28;
 
+import { LibSort } from "solady/utils/LibSort.sol";
+
 /// @notice a general utility library for memory array operations
 library LibArray {
+  using LibSort for uint256[];
+
   /////////////////
   // CALCS
 
@@ -75,5 +79,15 @@ library LibArray {
     uint256[] memory result = new uint256[](size);
     for (uint256 i; i < size; i++) result[i] = arr[i];
     return result;
+  }
+
+  // verify there are no repeats in an array of commits
+  // achieves this by sorting in place, uniquifying the array and comparing start/end lengths
+  function sortAndVerifyNoRepeats(uint256[] memory ids) internal {
+    uint256 initialLength = ids.length;
+    ids.insertionSort();
+    ids.uniquifySorted();
+    uint256 finalLength = ids.length;
+    if (initialLength != finalLength) revert("LibArray: detected duplicate in array");
   }
 }

--- a/packages/contracts/src/systems/DroptableRevealSystem.sol
+++ b/packages/contracts/src/systems/DroptableRevealSystem.sol
@@ -3,13 +3,10 @@ pragma solidity >=0.8.28;
 
 import { System } from "solecs/System.sol";
 import { IWorld } from "solecs/interfaces/IWorld.sol";
-import { getAddrByID } from "solecs/utils.sol";
 
-import { LibAccount } from "libraries/LibAccount.sol";
-import { LibDroptable } from "libraries/LibDroptable.sol";
+import { LibArray } from "libraries/utils/LibArray.sol";
 import { LibCommit } from "libraries/LibCommit.sol";
-import { LibInventory } from "libraries/LibInventory.sol";
-import { LibRandom } from "libraries/utils/LibRandom.sol";
+import { LibDroptable } from "libraries/LibDroptable.sol";
 
 import { AuthRoles } from "libraries/utils/AuthRoles.sol";
 
@@ -21,9 +18,9 @@ contract DroptableRevealSystem is System, AuthRoles {
 
   function execute(bytes memory arguments) public returns (bytes memory) {
     uint256[] memory ids = abi.decode(arguments, (uint256[]));
-
-    // checks
     if (ids.length == 0) revert("ItemReveal: no reveals");
+    LibArray.sortAndVerifyNoRepeats(ids); // sort in place; must precede filterInvalid,
+    // which zeroes drained ids and would otherwise present as duplicate zeros
     LibCommit.filterInvalid(components, ids); // drop already-drained commits first
     LibDroptable.checkIsCommit(components, ids);
 

--- a/packages/contracts/src/systems/KamiGachaRerollSystem.sol
+++ b/packages/contracts/src/systems/KamiGachaRerollSystem.sol
@@ -4,13 +4,12 @@ pragma solidity >=0.8.28;
 import { System } from "solecs/System.sol";
 import { IWorld } from "solecs/interfaces/IWorld.sol";
 
+import { LibArray } from "libraries/utils/LibArray.sol";
 import { LibAccount } from "libraries/LibAccount.sol";
 import { LibEquipment } from "libraries/LibEquipment.sol";
 import { LibGacha } from "libraries/LibGacha.sol";
 import { LibInventory, REROLL_TICKET_INDEX } from "libraries/LibInventory.sol";
 import { LibKami } from "libraries/LibKami.sol";
-import { LibERC20 } from "libraries/utils/LibERC20.sol";
-import { LibInventory, REROLL_TICKET_INDEX } from "libraries/LibInventory.sol";
 
 uint256 constant ID = uint256(keccak256("system.kami.gacha.reroll"));
 
@@ -22,6 +21,7 @@ contract KamiGachaRerollSystem is System {
   function reroll(uint256[] memory kamiIDs) external returns (uint256[] memory) {
     uint256 accID = LibAccount.getByOwner(components, msg.sender);
     require(accID != 0, "no account detected");
+    LibArray.sortAndVerifyNoRepeats(kamiIDs); // sort in place in this step
     LibKami.verifyAccount(components, kamiIDs, accID);
     LibKami.verifyState(components, kamiIDs, "RESTING");
 

--- a/packages/contracts/src/systems/KamiGachaRevealSystem.sol
+++ b/packages/contracts/src/systems/KamiGachaRevealSystem.sol
@@ -3,14 +3,11 @@ pragma solidity >=0.8.28;
 
 import { System } from "solecs/System.sol";
 import { IWorld } from "solecs/interfaces/IWorld.sol";
-import { LibString } from "solady/utils/LibString.sol";
-
-import { LibAccount } from "libraries/LibAccount.sol";
-import { LibCommit } from "libraries/LibCommit.sol";
-import { LibGacha } from "libraries/LibGacha.sol";
-import { LibKami } from "libraries/LibKami.sol";
 
 import { AuthRoles } from "libraries/utils/AuthRoles.sol";
+import { LibArray } from "libraries/utils/LibArray.sol";
+import { LibCommit } from "libraries/LibCommit.sol";
+import { LibGacha } from "libraries/LibGacha.sol";
 
 uint256 constant ID = uint256(keccak256("system.kami.gacha.reveal"));
 
@@ -18,12 +15,12 @@ uint256 constant ID = uint256(keccak256("system.kami.gacha.reveal"));
 contract KamiGachaRevealSystem is System, AuthRoles {
   constructor(IWorld _world, address _components) System(_world, _components) {}
 
-  function reveal(uint256[] memory rawCommitIDs) external returns (uint256[] memory) {
-    if (rawCommitIDs.length == 0) revert("need commits to reveal");
-    LibGacha.checkAndExtractIsCommit(components, rawCommitIDs);
+  function reveal(uint256[] memory commitIDs) external returns (uint256[] memory) {
+    if (commitIDs.length == 0) revert("need commits to reveal");
+    LibArray.sortAndVerifyNoRepeats(commitIDs); // sort in place in this step
+    LibGacha.checkAndExtractIsCommit(components, commitIDs);
 
     // sorts commits by cronological order via entityID
-    uint256[] memory commitIDs = LibGacha.sortCommits(components, rawCommitIDs);
     uint256[] memory kamiIDs = LibGacha.selectPets(components, commitIDs);
     LibGacha.withdrawPets(components, kamiIDs, commitIDs);
 
@@ -35,6 +32,7 @@ contract KamiGachaRevealSystem is System, AuthRoles {
     uint256[] memory commitIDs
   ) external onlyCommManager(components) returns (uint256[] memory) {
     if (commitIDs.length == 0) revert("need commits to reveal");
+    LibArray.sortAndVerifyNoRepeats(commitIDs); // sort in place in this step
     LibGacha.checkAndExtractIsCommit(components, commitIDs);
 
     // checks if blockhash is not available

--- a/packages/contracts/test/systems/Minting/Gacha.t.sol
+++ b/packages/contracts/test/systems/Minting/Gacha.t.sol
@@ -165,6 +165,37 @@ contract GachaTest is MintTemplate {
     }
   }
 
+  /// @notice a duplicated kami ID in a reroll must revert: rolls are priced by
+  ///         array length but the pool deposit is an idempotent set, so a repeat
+  ///         would surrender one kami while receiving two rolls (supply inflation)
+  function testGachaRerollDuplicateReverts() public {
+    _batchMint(2);
+    uint256 petUser = _mintKami(alice);
+
+    uint256[] memory ids = new uint256[](2);
+    ids[0] = petUser;
+    ids[1] = petUser;
+    vm.roll(++_currBlock);
+    _giveItem(alice, REROLL_TICKET_INDEX, 2);
+    vm.prank(alice.owner);
+    vm.expectRevert("LibArray: detected duplicate in array");
+    _KamiGachaRerollSystem.reroll(ids);
+  }
+
+  /// @notice a duplicated commit ID in a gacha reveal reverts explicitly
+  function testGachaRevealDuplicateReverts() public {
+    _batchMint(2);
+    uint256 commitID = _mint(alice);
+
+    uint256[] memory ids = new uint256[](2);
+    ids[0] = commitID;
+    ids[1] = commitID;
+    vm.roll(++_currBlock);
+    vm.prank(alice.owner);
+    vm.expectRevert("LibArray: detected duplicate in array");
+    _KamiGachaRevealSystem.reveal(ids);
+  }
+
   ///////////
   // UTILS //
   ///////////

--- a/packages/contracts/test/systems/Scavenge.t.sol
+++ b/packages/contracts/test/systems/Scavenge.t.sol
@@ -452,11 +452,29 @@ contract ScavengeTest is SetupTemplate {
     vm.prank(alice.operator);
     _DroptableRevealSystem.executeTyped(ids);
 
-    // budget 5000: c1 fully (4000), then 1000 of c2
+    // budget 5000: the dedup guard sorts the batch ascending by ID, so the
+    // lower commit ID drains fully (4000) and the other gets the remaining 1000
+    uint256 first = c1 < c2 ? c1 : c2;
+    uint256 second = c1 < c2 ? c2 : c1;
     assertEq(_getItemBal(alice, 1), 5000, "per-tx budget caps total across commits");
-    assertFalse(_BlockRevealComponent.has(c1), "c1 fully drained");
-    assertTrue(_BlockRevealComponent.has(c2), "c2 partially drained");
-    assertEq(_ValueComponent.get(c2), 3000, "c2 remainder");
+    assertFalse(_BlockRevealComponent.has(first), "lower-id commit fully drained");
+    assertTrue(_BlockRevealComponent.has(second), "higher-id commit partially drained");
+    assertEq(_ValueComponent.get(second), 3000, "higher-id commit remainder");
+  }
+
+  /// @notice a duplicated commit ID in a reveal batch reverts outright
+  function testRevealDuplicateCommitReverts() public {
+    _addSingleItemDT(1);
+    _incFor(alice, scavbar1, 100 * scavbar1.tierCost);
+    uint256 commitID = _claimGetDTCommit(alice, scavbar1.id);
+
+    vm.roll(block.number + 2);
+    uint256[] memory ids = new uint256[](2);
+    ids[0] = commitID;
+    ids[1] = commitID;
+    vm.prank(alice.operator);
+    vm.expectRevert("LibArray: detected duplicate in array");
+    _DroptableRevealSystem.executeTyped(ids);
   }
 
   /// @notice re-revealing a fully-drained commit is a no-op, not a revert


### PR DESCRIPTION
## what

adds a duplicate-id guard to the four commit-reveal entrypoints that accept a caller-supplied `uint256[]` and price per array element while settling per unique element.

- `LibArray.sortAndVerifyNoRepeats`: sort in place, uniquify, compare lengths; revert on any repeat
- guards `KamiGachaRerollSystem.reroll`, `KamiGachaRevealSystem.reveal` (+ comm-manager path), `DroptableRevealSystem.execute`
- removes now-redundant `LibGacha.sortCommits` (the guard provides the ordering) + dead imports
- regression tests: duplicate reroll / gacha reveal / droptable reveal all revert; per-tx budget test made order-agnostic

## why

- `KamiGachaRerollSystem.reroll([kamiA, kamiA])` charged 2 tickets, surrendered 1 kami (idempotent pool deposit), created 2 commits: net +1 unbacked kami. repeatable
- gacha/droptable reveal duplicates were softer (incidental revert / spurious zero-amount reveal event)

## notes

- on the droptable path the guard runs BEFORE `filterInvalid` so drained-commit zeros can't present as caller duplicates
- `deploy.json` untouched (no writeAccess change)
- suites green off main base: gacha 7, scavenge 14, lootbox 3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reveal and reroll requests now reject duplicate IDs.
  - ID processing is consistently sorted before validation and execution.
  - Improved validation messaging for invalid gacha commit IDs.
  - Reveal behavior now handles batch ordering consistently.

- **Tests**
  - Added coverage confirming duplicate reveal and reroll IDs are rejected.
  - Updated batch-budget expectations to reflect sorted reveal processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->