### PR TITLE
postpatch: reconcile deployed data statuses + fountain opens pool modal

### DIFF
--- a/packages/client/src/app/triggers/index.ts
+++ b/packages/client/src/app/triggers/index.ts
@@ -7,6 +7,7 @@ export { triggerKamiBridgeModal } from './triggerKamiBridgeModal';
 export { triggerLeaderboardModal } from './triggerLeaderboardModal';
 export { triggerNodeModal } from './triggerNodeModal';
 export { triggerPetNamingModal } from './triggerPetNamingModal';
+export { triggerPoolModal } from './triggerPoolModal';
 export { triggerShopModal } from './triggerShopModal';
 export { triggerKamiAdoptionAgencyModal } from './triggerKamiAdoptionAgencyModal';
 export { triggerTempleOfTheWheelModal } from './triggerTempleOfTheWheelModal';

--- a/packages/client/src/app/triggers/triggerPoolModal.ts
+++ b/packages/client/src/app/triggers/triggerPoolModal.ts
@@ -1,0 +1,21 @@
+import { useVisibility } from 'app/stores';
+import { playClick } from 'utils/sounds';
+
+export const triggerPoolModal = () => {
+  const { modals } = useVisibility.getState();
+
+  if (!modals.pool) {
+    playClick();
+    useVisibility.setState({
+      modals: {
+        ...modals,
+        pool: true,
+        crafting: false,
+        dialogue: false,
+        kami: false,
+        leaderboard: false,
+        node: false,
+      },
+    });
+  }
+};

--- a/packages/client/src/constants/rooms/31_scrapyard-exit.ts
+++ b/packages/client/src/constants/rooms/31_scrapyard-exit.ts
@@ -1,3 +1,4 @@
+import { triggerPoolModal } from 'app/triggers/triggerPoolModal';
 import {
   bgFountainDay,
   bgFountainEvening,
@@ -13,5 +14,11 @@ export const room31: Room = {
     key: 'cave',
     path: cave,
   },
-  objects: [],
+  objects: [
+    {
+      name: 'fountain',
+      coordinates: { x1: 40, y1: 40, x2: 88, y2: 100 },
+      onClick: () => triggerPoolModal(),
+    },
+  ],
 };

--- a/packages/contracts/deployment/world/data/items/items.csv
+++ b/packages/contracts/deployment/world/data/items/items.csv
@@ -118,7 +118,7 @@ Slightly sacred. "
 ,In Game,Spirit Glue,19001,Potion,Uncommon,Enemy_Kami,,"NEXT_COOLDOWN+180,ITEM1003",,This glue even sticks to intangible things. Can be used to add additional Cooldown to an enemy Kami and temporarily lock it down to a Node.
 ,In Game,Animistic Poison,19101,Potion,Rare,Enemy_Kami,,STRAIN+50%,,"Dangerous to both living and nonliving beings. When used on Kamigotchi, it causes them to lose HP at a faster rate while Harvesting. "
 ,In Game,Cthonic Blight,19201,Potion,Rare,Enemy_Kami,BYPASS_BONUS_RESET,DTS-5%,,"Highly corrosive. Can be used to clear barriers of plant or fungal matter. It can also be used on a Kamigotchi to lower its defenses. The Blight is particularly dangerous to Normal-type Kami. "
-,To Update,Curse Tablet,19301,Potion,Rare,Enemy_Kami,,ATS-30%_KK,,"Also called a Defixio or Katadesmos. This ancient tablet is inscribed with a curse of weakness. Although it was meant for a long-dead human, Kami can use it on their own kind."
+,In Game,Curse Tablet,19301,Potion,Rare,Enemy_Kami,,ATS-30%_KK,,"Also called a Defixio or Katadesmos. This ancient tablet is inscribed with a curse of weakness. Although it was meant for a long-dead human, Kami can use it on their own kind."
 ,Shelved,Giftbox,21001,Lootbox,Uncommon,Account,,DT OG,,"The lowest tier of giftbox. You can get XP candies, cheeseburgers, and even a few rare item drops from this! "
 ,In Game,Kamigotchi World Citizen Giftbox,21002,Lootbox,Rare,Account,,DT Passport,,"A gold-trimmed and colorfully painted treasure chest. The gift inside must be particularly valuable. "
 ,In Game,Wonder Egg,21003,Lootbox,Rare,Account,,DT Wonder Egg,,"A cracked egg held together by blood-red wax. The contents are a surprise. "

--- a/packages/contracts/deployment/world/data/quests/quests.csv
+++ b/packages/contracts/deployment/world/data/quests/quests.csv
@@ -1837,7 +1837,7 @@ test-1,1000001,Test,Crafting Materials,No,,,Let there be Craft,,,Move 3 Times,"1
 test-2,1000002,Test,Lottery Loving,No,,,Stop being Kamiless,,,,20x Gacha Tickets (Test)
 test-3,1000003,Test,Crafting Materials II,No,,,More crafting materials,,Complete test-1,Give 5 Wooden Sticks,"100x Chalkberry,100x Shroom,100x Resin,100x Holy Dust,100x Scrap Metals"
 test-4,1000004,Test,Crafting Toolkit,No,,,You need equipment to make new items.,,Complete test-1,,"1x Screwdriver,1x Grinder,1x Burner"
-MIN100,2100,To Deploy,A Short Pilgrimage,No,SIDE,MINA,"MINA: ""This shabby world is lacking beauty.”
+MIN100,2100,In Game,A Short Pilgrimage,No,SIDE,MINA,"MINA: ""This shabby world is lacking beauty.”
 MINA: “I've brought something to improve that.""
 MINA: ""There is now a fountain at the crossroads leading out of the junkyard.""
 MINA: ""A monument to all that flows.""
@@ -1846,7 +1846,7 @@ MINA: ""I have something to show you.”","MINA: ""This fountain holds a share o
 MINA: ""Here, you may choose to make an offering.""
 MINA: “Currency, of course, but the waters accept many things.""
 MINA: ""And here, the waters flow back many things in return.”",Complete MIN007,Move to the Scrapyard Exit,
-MIN101,2101,To Deploy,The Fountain of All That Flows,No,SIDE,MINA,"MINA: ""The fountain's pool is really a multitude, overlapping.""
+MIN101,2101,In Game,The Fountain of All That Flows,No,SIDE,MINA,"MINA: ""The fountain's pool is really a multitude, overlapping.""
 MINA: ""Each pool holds two items.""
 MINA: ""Anyone can throw in some of one, and the waters return some of the other.""
 MINA: ""You can also make an offering of both.""

--- a/packages/contracts/deployment/world/data/rooms/nodes.csv
+++ b/packages/contracts/deployment/world/data/rooms/nodes.csv
@@ -29,7 +29,7 @@
 ,In Game,51,Scrap-Littered Undergrowth,"Bottle Scrap Resin ",Insect,,1,300,
 ,In Game,52,Airplane Crash,Bottle Scrap Jar,Eerie,,1,300,
 ,In Game,53,Blooming Tree,Stick Cone Amber,Eerie,,1,300,
-,To Update,55,Shady Path,Stick Stone Daffodil,Normal,15,1,200,
+,In Game,55,Shady Path,Stick Stone Daffodil,Normal,15,1,200,
 ,In Game,56,Butterfly Forest,Stick Stone Resin,Insect,,1,200,
 ,In Game,57,River Crossing,Stick Stone Cone,Normal,,1,200,
 ,In Game,58,Mouth of Scrap,Stone Scrap Burger,Scrap,,1,100,


### PR DESCRIPTION
follow-up to the item pools ship (#2425). two small postpatch changes on the fork of the just-landed work.

**data reconciliation**
- quests 2100/2101, item 19301 (curse tablet), node 55 (shady path) were deployed live during the item-pools window; flip their csv status (to deploy / to update -> in game) to mirror the now-live on-chain state. notion is being flipped separately, so world:notion:diff reads clean for these rows.

**client: fountain -> pool modal**
- add triggerPoolModal: opens the item pools / LP modal (center zone), mirrors triggerTradingModal
- add a central fountain clickbox to room 31 (scrapyard exit) wired to it: clicking the fountain opens the LP interface directly
- same pattern as room 13's cash register (onClick -> trigger*Modal). no dialogue box yet, easy to add later
- hotspot is a big centered box (0-128 grid); coords can be nudged after eyeballing in-client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive fountain to the Scrapyard exit.
  * Clicking the fountain opens the Pool modal and closes other open modals to keep the interface focused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->