### PR TITLE
client: dialogue qol + map switching

### DIFF
--- a/packages/client/src/app/components/library/modals/ModalWrapper.tsx
+++ b/packages/client/src/app/components/library/modals/ModalWrapper.tsx
@@ -22,6 +22,7 @@ export const ModalWrapper = ({
   shuffle = false,
   truncate,
   noScroll,
+  showScrollBar,
 }: {
   canExit?: boolean;
   children: React.ReactNode;
@@ -44,6 +45,7 @@ export const ModalWrapper = ({
   shuffle?: boolean;
   truncate?: boolean;
   noScroll?: boolean;
+  showScrollBar?: boolean; // slim scrollbar for modals with long content
 }) => {
   const isVisible = useVisibility((s) => s.modals[id]);
   const setModals = useVisibility((s) => s.setModals);
@@ -117,6 +119,7 @@ export const ModalWrapper = ({
           scrollBarColor={scrollBarColor}
           noScroll={noScroll}
           noPadding={noPadding}
+          showScrollBar={showScrollBar}
           // data-scroll-container='true'
           // data-modal-id={id}
         >
@@ -229,6 +232,7 @@ const Children = styled.div<{
   noPadding?: boolean;
   scrollBarColor?: string;
   noScroll?: boolean;
+  showScrollBar?: boolean;
 }>`
   position: relative;
   overflow: ${({ noScroll }) => (noScroll ? 'hidden' : 'auto')};
@@ -238,8 +242,25 @@ const Children = styled.div<{
   display: flex;
   flex-flow: column nowrap;
   padding: ${({ noPadding }) => (noPadding ? `0` : `.6vw`)};
-  scrollbar-width: none;
-  &::-webkit-scrollbar { display: none; }
+  ${({ showScrollBar }) =>
+    showScrollBar
+      ? `
+    scrollbar-width: thin;
+    scrollbar-color: #b6b6b6 transparent;
+    &::-webkit-scrollbar {
+      width: 0.3vw;
+      background: transparent;
+    }
+    &::-webkit-scrollbar-thumb {
+      background-color: #b6b6b6;
+      border-radius: 0.3vw;
+      background-clip: padding-box;
+    }
+  `
+      : `
+    scrollbar-width: none;
+    &::-webkit-scrollbar { display: none; }
+  `}
 `;
 
 const fadeIn = keyframes`

--- a/packages/client/src/app/components/library/modals/ModalWrapper.tsx
+++ b/packages/client/src/app/components/library/modals/ModalWrapper.tsx
@@ -50,11 +50,14 @@ export const ModalWrapper = ({
   const [gridStyle, setGridStyle] = useState<React.CSSProperties>({});
   const [shouldDisplay, setShouldDisplay] = useState(false);
 
+  // keep rendering through the fade-out before hiding; closed modals are
+  // already click-transparent (Content drops pointer-events immediately)
   useEffect(() => {
     if (isVisible) {
       setShouldDisplay(true);
     } else {
-      setShouldDisplay(false);
+      const timeout = setTimeout(() => setShouldDisplay(false), 280);
+      return () => clearTimeout(timeout);
     }
   }, [isVisible]);
 
@@ -90,7 +93,14 @@ export const ModalWrapper = ({
   }, [positionOverride]);
 
   return (
-    <Wrapper id={id} isOpen={shouldDisplay} overlay={!!overlay} style={gridStyle} shuffle={shuffle}>
+    <Wrapper
+      id={id}
+      isOpen={isVisible}
+      isDisplayed={shouldDisplay}
+      overlay={!!overlay}
+      style={gridStyle}
+      shuffle={shuffle}
+    >
       <Content
         backgroundColor={backgroundColor}
         isOpen={isVisible}
@@ -131,12 +141,14 @@ const Shuffle = keyframes`
 `;
 
 // Wrapper is an invisible animated wrapper around all modals sans any frills.
+// isOpen drives the fade animations; isDisplayed lags close by the fade-out duration.
 const Wrapper = styled.div<{
   isOpen: boolean;
+  isDisplayed: boolean;
   overlay: boolean;
   shuffle: boolean;
 }>`
-  display: ${({ isOpen }) => (isOpen ? 'block' : 'none')};
+  display: ${({ isDisplayed }) => (isDisplayed ? 'block' : 'none')};
   position: ${({ overlay }) => (overlay ? 'relative' : 'static')};
   z-index: ${({ overlay }) => (overlay ? 3 : 0)};
   ${({ isOpen, shuffle }) => css`
@@ -145,7 +157,7 @@ const Wrapper = styled.div<{
             ${fadeIn} 0.5s ease-in-out
           `
         : css`
-            ${fadeOut} 0.5s ease-in-out
+            ${fadeOut} 0.3s ease-in-out forwards
           `}
       ${shuffle && css`, ${Shuffle} 0.4s ease-in-out`};
   `}
@@ -235,8 +247,6 @@ const fadeIn = keyframes`
   to { opacity: 1; }
 `;
 
-// NOTE: this is not actually used atm as we set display:none on close. This is
-// done to avoid having active, invisible buttons lingering on the UI after close.
 const fadeOut = keyframes`
   from { opacity: 1; }
   to { opacity: 0; }

--- a/packages/client/src/app/components/library/modals/ModalWrapper.tsx
+++ b/packages/client/src/app/components/library/modals/ModalWrapper.tsx
@@ -154,6 +154,8 @@ const Wrapper = styled.div<{
   display: ${({ isDisplayed }) => (isDisplayed ? 'block' : 'none')};
   position: ${({ overlay }) => (overlay ? 'relative' : 'static')};
   z-index: ${({ overlay }) => (overlay ? 3 : 0)};
+  /* fading-out modals must not eat clicks; Content drops pointer-events too */
+  pointer-events: ${({ isOpen }) => (isOpen ? 'auto' : 'none')};
   ${({ isOpen, shuffle }) => css`
     animation: ${isOpen
         ? css`

--- a/packages/client/src/app/components/library/poppers/Popover.tsx
+++ b/packages/client/src/app/components/library/poppers/Popover.tsx
@@ -176,10 +176,9 @@ const PopoverContent = styled.div.attrs<{
   isVisible?: boolean;
   popoverPosition: { x: number; y: number };
   maxHeight?: number;
-}>(({ isVisible, popoverPosition, maxHeight }) => ({
+}>(({ popoverPosition, maxHeight }) => ({
   style: {
     maxHeight: maxHeight ? `${maxHeight}vh` : '22vh',
-    visibility: isVisible ? 'visible' : 'hidden',
     top: popoverPosition?.y,
     left: popoverPosition?.x,
   },
@@ -201,6 +200,14 @@ const PopoverContent = styled.div.attrs<{
   font-size: 0.6vw;
   white-space: normal;
   overflow-wrap: break-word;
+
+  /* fade open/closed; visibility flips after the fade so layout stays put */
+  opacity: ${({ isVisible }) => (isVisible ? 1 : 0)};
+  visibility: ${({ isVisible }) => (isVisible ? 'visible' : 'hidden')};
+  pointer-events: ${({ isVisible }) => (isVisible ? 'auto' : 'none')};
+  transition:
+    opacity 0.2s ease-in-out,
+    visibility 0s linear ${({ isVisible }) => (isVisible ? '0s' : '0.2s')};
 
   scrollbar-width: none;
   &::-webkit-scrollbar { display: none; }

--- a/packages/client/src/app/components/modals/account/Factions.tsx
+++ b/packages/client/src/app/components/modals/account/Factions.tsx
@@ -43,7 +43,7 @@ export const Factions = ({
             </TextTooltip>
             <ProgressBar
               width={15}
-              total={300}
+              total={500}
               current={faction.current}
               icon={faction.icon}
               colors={{

--- a/packages/client/src/app/components/modals/account/bottom/PartyBottom.tsx
+++ b/packages/client/src/app/components/modals/account/bottom/PartyBottom.tsx
@@ -41,4 +41,9 @@ const Container = styled.div`
   align-items: center;
 
   overflow-y: auto;
+
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;

--- a/packages/client/src/app/components/modals/account/bottom/SocialBottom/SocialBottom.tsx
+++ b/packages/client/src/app/components/modals/account/bottom/SocialBottom/SocialBottom.tsx
@@ -98,6 +98,11 @@ const Container = styled.div`
   align-items: center;
 
   overflow-y: auto;
+
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const EmptyText = styled.div`

--- a/packages/client/src/app/components/modals/account/bottom/StatsBottom.tsx
+++ b/packages/client/src/app/components/modals/account/bottom/StatsBottom.tsx
@@ -76,6 +76,11 @@ const Container = styled.div`
   align-items: flex-start;
 
   user-select: none;
+
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const Content = styled.div`

--- a/packages/client/src/app/components/modals/chat/feed/Feed.tsx
+++ b/packages/client/src/app/components/modals/chat/feed/Feed.tsx
@@ -553,6 +553,11 @@ const Wrapper = styled.div`
   overflow-y: auto;
   overflow-x: hidden;
   font-size: 0.6vw;
+
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const Buttons = styled.div`

--- a/packages/client/src/app/components/modals/dialogue/Dialogue.tsx
+++ b/packages/client/src/app/components/modals/dialogue/Dialogue.tsx
@@ -424,6 +424,7 @@ export const DialogueModal: UIComponent = {
             npcName={npc.name}
             npcImage={npc.mood || npc.img}
             dialogueText={getText(dialogueNode.text[step])}
+            textKey={`${dialogueIndex}:${step}`}
             twoColumnText={dialogueIndex === 20018}
             onDialogueComplete={handleNpcDialogueComplete}
             onTextAdvance={canAdvance ? advanceDialogue : undefined}

--- a/packages/client/src/app/components/modals/dialogue/Dialogue.tsx
+++ b/packages/client/src/app/components/modals/dialogue/Dialogue.tsx
@@ -405,6 +405,7 @@ export const DialogueModal: UIComponent = {
             position: 'fixed',
           }}
           noScroll
+          truncate
         >
           <NpcDialogue
             hasAvailableQuests={availableQuests}

--- a/packages/client/src/app/components/modals/dialogue/Dialogue.tsx
+++ b/packages/client/src/app/components/modals/dialogue/Dialogue.tsx
@@ -93,6 +93,14 @@ export const DialogueModal: UIComponent = {
     const setDialogue = useSelected((s) => s.setDialogue);
 
     const [step, setStep] = useState(0);
+    // bumps only on open transitions: remounting NpcDialogue on close would
+    // visibly retype the text during the fade-out
+    const [openCount, setOpenCount] = useState(0);
+    const [prevOpen, setPrevOpen] = useState(dialogueModalOpen);
+    if (prevOpen !== dialogueModalOpen) {
+      setPrevOpen(dialogueModalOpen);
+      if (dialogueModalOpen) setOpenCount((c) => c + 1);
+    }
     const [dialogueHistory, setDialogueHistory] = useState<number[]>([]);
     const [availableQuests, setAvailableQuests] = useState<Quest[]>([]);
     const [ongoingQuests, setOngoingQuests] = useState<Quest[]>([]);
@@ -127,17 +135,19 @@ export const DialogueModal: UIComponent = {
     /////////////////
     // SUBSCRIPTIONS
 
-    // reset the step to 0 whenever the dialogue modal is toggled
+    // reset the step when the modal opens; on close only clear history so the
+    // content doesn't visibly jump back to step 0 during the fade-out
     useEffect(() => {
-      setStep(0);
-      if (!dialogueModalOpen) setDialogueHistory([]);
+      if (dialogueModalOpen) setStep(0);
+      else setDialogueHistory([]);
     }, [dialogueModalOpen]);
 
     // reset text step when changing dialogue entry
     // clear history only when dialogue root is changed externally while modal is still open
     useEffect(() => {
+      if (!dialogueModalOpen) return;
       setStep(0);
-      if (dialogueModalOpen && !internalDialogueTransitionRef.current) {
+      if (!internalDialogueTransitionRef.current) {
         setDialogueHistory([]);
       }
       internalDialogueTransitionRef.current = false;
@@ -407,7 +417,7 @@ export const DialogueModal: UIComponent = {
           truncate
         >
           <NpcDialogue
-            key={String(dialogueModalOpen)} /* remount per open so text retypes fresh */
+            key={openCount} /* remount per open so text retypes fresh */
             hasAvailableQuests={availableQuests}
             hasOngoingQuests={ongoingQuests}
             npcColor='#000000ff'

--- a/packages/client/src/app/components/modals/dialogue/Dialogue.tsx
+++ b/packages/client/src/app/components/modals/dialogue/Dialogue.tsx
@@ -326,8 +326,22 @@ export const DialogueModal: UIComponent = {
       );
     };
 
+    const canAdvance = step < dialogueLength - 1 || !!dialogueNode.npc?.nextDialogue;
+
+    // shared by the next arrow and clicks on completed dialogue text
+    const advanceDialogue = () => {
+      if (step < dialogueLength - 1) {
+        setStep(step + 1);
+        return;
+      }
+      if (dialogueNode.npc?.nextDialogue) {
+        setDialogueHistory((prev) => [...prev, dialogueIndex]);
+        setStep(0);
+        transitionDialogue(dialogueNode.npc.nextDialogue);
+      }
+    };
+
     const NextButton = () => {
-      const canAdvance = step < dialogueLength - 1 || !!dialogueNode.npc?.nextDialogue;
       const disabled = !canAdvance;
       return (
         <div
@@ -335,22 +349,7 @@ export const DialogueModal: UIComponent = {
             visibility: disabled ? 'hidden' : 'visible',
           }}
         >
-          <IconButton
-            scale={1.8}
-            img={ArrowIcons.right}
-            disabled={disabled}
-            onClick={() => {
-              if (step < dialogueLength - 1) {
-                setStep(step + 1);
-                return;
-              }
-              if (dialogueNode.npc?.nextDialogue) {
-                setDialogueHistory((prev) => [...prev, dialogueIndex]);
-                setStep(0);
-                transitionDialogue(dialogueNode.npc.nextDialogue);
-              }
-            }}
-          />
+          <IconButton scale={1.8} img={ArrowIcons.right} disabled={disabled} onClick={advanceDialogue} />
         </div>
       );
     };
@@ -416,6 +415,7 @@ export const DialogueModal: UIComponent = {
             dialogueText={getText(dialogueNode.text[step])}
             twoColumnText={dialogueIndex === 20018}
             onDialogueComplete={handleNpcDialogueComplete}
+            onTextAdvance={canAdvance ? advanceDialogue : undefined}
             dialogueOptions={dialogueOptions.map(([label, nextIndex]) => ({
               label,
               onClick: () => {

--- a/packages/client/src/app/components/modals/dialogue/Dialogue.tsx
+++ b/packages/client/src/app/components/modals/dialogue/Dialogue.tsx
@@ -407,6 +407,7 @@ export const DialogueModal: UIComponent = {
           truncate
         >
           <NpcDialogue
+            key={String(dialogueModalOpen)} /* remount per open so text retypes fresh */
             hasAvailableQuests={availableQuests}
             hasOngoingQuests={ongoingQuests}
             npcColor='#000000ff'

--- a/packages/client/src/app/components/modals/dialogue/NpcDialogue.tsx
+++ b/packages/client/src/app/components/modals/dialogue/NpcDialogue.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import styled from 'styled-components';
 
 import { Overlay } from 'app/components/library';
@@ -45,27 +46,60 @@ export const NpcDialogue = ({
   const leftColumnText = twoColumnText ? (columnTexts[0] ?? '') : dialogueText;
   const rightColumnText = twoColumnText ? (columnTexts[1] ?? '') : '';
 
+  // click-to-skip: interrupting fills the text instantly; done gates the cursor
+  const [skipped, setSkipped] = useState(false);
+  const [doneCount, setDoneCount] = useState(0);
+  const typingDone = doneCount >= (twoColumnText ? 2 : 1);
+
+  // stable per-text key: retriggers only on text change, not on every render
+  const retriggerKey = useMemo(() => `${dialogueText}:${Date.now()}`, [dialogueText]);
+
+  useEffect(() => {
+    setSkipped(false);
+    setDoneCount(0);
+  }, [retriggerKey, twoColumnText]);
+
+  const handleMainComplete = useCallback(() => {
+    setDoneCount((c) => c + 1);
+    onDialogueComplete?.();
+  }, [onDialogueComplete]);
+
+  const handleSideComplete = useCallback(() => {
+    setDoneCount((c) => c + 1);
+  }, []);
+
+  const handleTextClick = () => {
+    if (!typingDone) setSkipped(true);
+  };
+
   return (
     <>
       {twoColumnText ? (
-        <ParallelColumns>
-          <Text color={npcColor}>
+        <ParallelColumns onClick={handleTextClick}>
+          <Text color={npcColor} $typing={!typingDone}>
             <TypewriterComponent
               text={leftColumnText}
-              retrigger={`${leftColumnText}${Date.now()}`}
-              onComplete={onDialogueComplete}
+              retrigger={`${retriggerKey}:L`}
+              interrupted={skipped}
+              onComplete={handleMainComplete}
             />
           </Text>
-          <Text color={npcColor}>
-            <TypewriterComponent text={rightColumnText} retrigger={`${rightColumnText}${Date.now()}`} />
+          <Text color={npcColor} $typing={!typingDone}>
+            <TypewriterComponent
+              text={rightColumnText}
+              retrigger={`${retriggerKey}:R`}
+              interrupted={skipped}
+              onComplete={handleSideComplete}
+            />
           </Text>
         </ParallelColumns>
       ) : (
-        <Text color={npcColor}>
+        <Text color={npcColor} $typing={!typingDone} onClick={handleTextClick}>
           <TypewriterComponent
             text={dialogueText}
-            retrigger={`${dialogueText}${Date.now()}`}
-            onComplete={onDialogueComplete}
+            retrigger={retriggerKey}
+            interrupted={skipped}
+            onComplete={handleMainComplete}
           />
         </Text>
       )}
@@ -155,6 +189,7 @@ export const NpcDialogue = ({
 
 const Text = styled.div<{
   color?: string;
+  $typing?: boolean;
 }>`
   color: ${({ color }) => color || 'black'};
   position: relative;
@@ -162,6 +197,7 @@ const Text = styled.div<{
   width: 100%;
   padding: 0vw 1vw;
   flex-grow: 1;
+  min-height: 8vh;
   flex-flow: column nowrap;
   justify-content: flex-start;
   top: 0;
@@ -170,7 +206,7 @@ const Text = styled.div<{
   white-space: pre-line;
   word-wrap: break-word;
   overflow-y: auto;
-  cursor: auto;
+  cursor: ${({ $typing }) => ($typing ? 'pointer' : 'auto')};
   transition:
     height 0.3s ease,
     visibility 0.3s ease;
@@ -245,11 +281,9 @@ const DialogueOptionButton = styled.button<{ color?: string; $fullRow?: boolean 
 `;
 
 const NpcSprite = styled.img`
-  position: absolute;
-  left: 0;
-  bottom: -4%;
+  align-self: flex-end;
   width: auto;
-  height: 100%;
+  height: 24vh;
   max-width: 40%;
   object-fit: contain;
   object-position: bottom left;
@@ -272,25 +306,24 @@ const Bottom = styled.div<{ hasQuests: boolean }>`
   position: relative;
   display: flex;
   flex-flow: row nowrap;
+  align-items: flex-end;
   border-top: solid grey 0.15vw;
-  height: ${({ hasQuests }) => (hasQuests ? '60%' : '40%')};
-  transition: height 0.3s ease;
+  flex-shrink: 0;
+  min-height: ${({ hasQuests }) => (hasQuests ? '16vh' : '12vh')};
+  transition: min-height 0.3s ease;
 `;
 
 const OptionColumn = styled.div<{ color: string }>`
-  margin-top: 0.5vw;
-  position: absolute;
-  right: 0;
-  top: 0;
+  flex: 1;
+  align-self: stretch;
   display: flex;
   flex-flow: column;
-  width: 100%;
-  height: 100%;
-  justify-content: flex-start;
+  justify-content: center;
+  justify-content: safe center;
   align-items: flex-end;
   gap: 0.9vw;
-  padding-top: 1vw;
-  padding-right: 1vw;
+  padding: 1vw 1vw 1vw 0;
+  max-height: 40vh;
   overflow-y: auto;
   ::-webkit-scrollbar {
     background: transparent;

--- a/packages/client/src/app/components/modals/dialogue/NpcDialogue.tsx
+++ b/packages/client/src/app/components/modals/dialogue/NpcDialogue.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
 import styled from 'styled-components';
 
 import { Overlay } from 'app/components/library';
@@ -53,14 +53,11 @@ export const NpcDialogue = ({
   const [doneCount, setDoneCount] = useState(0);
   const typingDone = doneCount >= (twoColumnText ? 2 : 1);
 
-  // stable per-text key: retriggers only on text change, not on every render
-  const retriggerKey = useMemo(() => `${dialogueText}:${Date.now()}`, [dialogueText]);
-
   // reset synchronously on text change: an effect would run after the child
   // typewriter's, leaking a stale skip into the next step (it renders pre-filled)
-  const [lastKey, setLastKey] = useState(retriggerKey);
-  if (lastKey !== retriggerKey) {
-    setLastKey(retriggerKey);
+  const [lastText, setLastText] = useState(dialogueText);
+  if (lastText !== dialogueText) {
+    setLastText(dialogueText);
     setSkipped(false);
     setDoneCount(0);
   }
@@ -92,7 +89,7 @@ export const NpcDialogue = ({
           <Text color={npcColor} $clickable={clickable}>
             <TypewriterComponent
               text={leftColumnText}
-              retrigger={`${retriggerKey}:L`}
+              retrigger={`${dialogueText}:L`}
               interrupted={skipped}
               onComplete={handleMainComplete}
             />
@@ -100,7 +97,7 @@ export const NpcDialogue = ({
           <Text color={npcColor} $clickable={clickable}>
             <TypewriterComponent
               text={rightColumnText}
-              retrigger={`${retriggerKey}:R`}
+              retrigger={`${dialogueText}:R`}
               interrupted={skipped}
               onComplete={handleSideComplete}
             />
@@ -110,7 +107,7 @@ export const NpcDialogue = ({
         <Text color={npcColor} $clickable={clickable} onClick={handleTextClick}>
           <TypewriterComponent
             text={dialogueText}
-            retrigger={retriggerKey}
+            retrigger={dialogueText}
             interrupted={skipped}
             onComplete={handleMainComplete}
           />
@@ -252,7 +249,6 @@ const NavigationRow = styled.div`
   gap: 0.4vw;
   padding: 0.4vw 1.2vw 0.7vw;
   flex-shrink: 0;
-  z-index: 6;
 `;
 
 const DialogueOptionsSection = styled.div`

--- a/packages/client/src/app/components/modals/dialogue/NpcDialogue.tsx
+++ b/packages/client/src/app/components/modals/dialogue/NpcDialogue.tsx
@@ -21,6 +21,7 @@ export const NpcDialogue = ({
   dialogueButtons = { BackButton: () => <></>, NextButton: () => <></>, MiddleButton: () => <></> },
   special,
   onDialogueComplete,
+  onTextAdvance,
   twoColumnText = false,
 }: {
   hasAvailableQuests?: Quest[];
@@ -37,6 +38,7 @@ export const NpcDialogue = ({
   };
   special?: { name: string; onclick: () => void };
   onDialogueComplete?: () => void;
+  onTextAdvance?: () => void;
   twoColumnText?: boolean;
 }) => {
   const columnTexts = dialogueText
@@ -54,10 +56,14 @@ export const NpcDialogue = ({
   // stable per-text key: retriggers only on text change, not on every render
   const retriggerKey = useMemo(() => `${dialogueText}:${Date.now()}`, [dialogueText]);
 
-  useEffect(() => {
+  // reset synchronously on text change: an effect would run after the child
+  // typewriter's, leaking a stale skip into the next step (it renders pre-filled)
+  const [lastKey, setLastKey] = useState(retriggerKey);
+  if (lastKey !== retriggerKey) {
+    setLastKey(retriggerKey);
     setSkipped(false);
     setDoneCount(0);
-  }, [retriggerKey, twoColumnText]);
+  }
 
   const handleMainComplete = useCallback(() => {
     setDoneCount((c) => c + 1);
@@ -68,15 +74,22 @@ export const NpcDialogue = ({
     setDoneCount((c) => c + 1);
   }, []);
 
+  // while typing a click fills the text; once done it advances like the next arrow
   const handleTextClick = () => {
-    if (!typingDone) setSkipped(true);
+    if (!typingDone) {
+      setSkipped(true);
+    } else if (onTextAdvance) {
+      playClick();
+      onTextAdvance();
+    }
   };
+  const clickable = !typingDone || !!onTextAdvance;
 
   return (
     <>
       {twoColumnText ? (
         <ParallelColumns onClick={handleTextClick}>
-          <Text color={npcColor} $typing={!typingDone}>
+          <Text color={npcColor} $clickable={clickable}>
             <TypewriterComponent
               text={leftColumnText}
               retrigger={`${retriggerKey}:L`}
@@ -84,7 +97,7 @@ export const NpcDialogue = ({
               onComplete={handleMainComplete}
             />
           </Text>
-          <Text color={npcColor} $typing={!typingDone}>
+          <Text color={npcColor} $clickable={clickable}>
             <TypewriterComponent
               text={rightColumnText}
               retrigger={`${retriggerKey}:R`}
@@ -94,7 +107,7 @@ export const NpcDialogue = ({
           </Text>
         </ParallelColumns>
       ) : (
-        <Text color={npcColor} $typing={!typingDone} onClick={handleTextClick}>
+        <Text color={npcColor} $clickable={clickable} onClick={handleTextClick}>
           <TypewriterComponent
             text={dialogueText}
             retrigger={retriggerKey}
@@ -189,7 +202,7 @@ export const NpcDialogue = ({
 
 const Text = styled.div<{
   color?: string;
-  $typing?: boolean;
+  $clickable?: boolean;
 }>`
   color: ${({ color }) => color || 'black'};
   position: relative;
@@ -206,7 +219,7 @@ const Text = styled.div<{
   white-space: pre-line;
   word-wrap: break-word;
   overflow-y: auto;
-  cursor: ${({ $typing }) => ($typing ? 'pointer' : 'auto')};
+  cursor: ${({ $clickable }) => ($clickable ? 'pointer' : 'auto')};
   transition:
     height 0.3s ease,
     visibility 0.3s ease;
@@ -280,8 +293,8 @@ const DialogueOptionButton = styled.button<{ color?: string; $fullRow?: boolean 
 const NpcSprite = styled.img`
   align-self: flex-end;
   width: auto;
-  height: 24vh;
-  max-width: 40%;
+  height: max(24vh, 15vw);
+  max-width: 48%;
   object-fit: contain;
   object-position: bottom left;
   image-rendering: pixelated;
@@ -321,7 +334,7 @@ const OptionColumn = styled.div<{ color: string }>`
   justify-content: safe center;
   align-items: flex-end;
   gap: 0.9vw;
-  padding: 0.5vw 0;
+  padding: 0.5vw 0.4vw 0.6vw 0;
   max-height: 40vh;
   overflow-y: auto;
   ::-webkit-scrollbar {

--- a/packages/client/src/app/components/modals/dialogue/NpcDialogue.tsx
+++ b/packages/client/src/app/components/modals/dialogue/NpcDialogue.tsx
@@ -23,6 +23,7 @@ export const NpcDialogue = ({
   onDialogueComplete,
   onTextAdvance,
   twoColumnText = false,
+  textKey,
 }: {
   hasAvailableQuests?: Quest[];
   hasOngoingQuests?: Quest[];
@@ -40,7 +41,9 @@ export const NpcDialogue = ({
   onDialogueComplete?: () => void;
   onTextAdvance?: () => void;
   twoColumnText?: boolean;
+  textKey?: string; // step identity; keys resets so same-text transitions still retype
 }) => {
+  const resetKey = textKey ?? dialogueText;
   const columnTexts = dialogueText
     .split('\n')
     .map((line) => line.trim())
@@ -48,16 +51,22 @@ export const NpcDialogue = ({
   const leftColumnText = twoColumnText ? (columnTexts[0] ?? '') : dialogueText;
   const rightColumnText = twoColumnText ? (columnTexts[1] ?? '') : '';
 
-  // click-to-skip: interrupting fills the text instantly; done gates the cursor
+  // click-to-skip: interrupting fills the text instantly; done gates the cursor.
+  // empty columns never fire onComplete, so only count the ones that render text
   const [skipped, setSkipped] = useState(false);
   const [doneCount, setDoneCount] = useState(0);
-  const typingDone = doneCount >= (twoColumnText ? 2 : 1);
+  const typingTarget = twoColumnText
+    ? (leftColumnText ? 1 : 0) + (rightColumnText ? 1 : 0)
+    : dialogueText
+      ? 1
+      : 0;
+  const typingDone = doneCount >= typingTarget;
 
-  // reset synchronously on text change: an effect would run after the child
+  // reset synchronously on step change: an effect would run after the child
   // typewriter's, leaking a stale skip into the next step (it renders pre-filled)
-  const [lastText, setLastText] = useState(dialogueText);
-  if (lastText !== dialogueText) {
-    setLastText(dialogueText);
+  const [lastKey, setLastKey] = useState(resetKey);
+  if (lastKey !== resetKey) {
+    setLastKey(resetKey);
     setSkipped(false);
     setDoneCount(0);
   }
@@ -89,7 +98,7 @@ export const NpcDialogue = ({
           <Text color={npcColor} $clickable={clickable}>
             <TypewriterComponent
               text={leftColumnText}
-              retrigger={`${dialogueText}:L`}
+              retrigger={`${resetKey}:L`}
               interrupted={skipped}
               onComplete={handleMainComplete}
             />
@@ -97,7 +106,7 @@ export const NpcDialogue = ({
           <Text color={npcColor} $clickable={clickable}>
             <TypewriterComponent
               text={rightColumnText}
-              retrigger={`${dialogueText}:R`}
+              retrigger={`${resetKey}:R`}
               interrupted={skipped}
               onComplete={handleSideComplete}
             />
@@ -107,7 +116,7 @@ export const NpcDialogue = ({
         <Text color={npcColor} $clickable={clickable} onClick={handleTextClick}>
           <TypewriterComponent
             text={dialogueText}
-            retrigger={dialogueText}
+            retrigger={resetKey}
             interrupted={skipped}
             onComplete={handleMainComplete}
           />

--- a/packages/client/src/app/components/modals/dialogue/NpcDialogue.tsx
+++ b/packages/client/src/app/components/modals/dialogue/NpcDialogue.tsx
@@ -103,7 +103,7 @@ export const NpcDialogue = ({
           />
         </Text>
       )}
-      <Overlay bottom={1} left={1.5}>
+      <Overlay bottom={1.3} left={1.8}>
         <NpcName>{npcName}</NpcName>
       </Overlay>
       {dialogueOptions.length > 0 ? (
@@ -129,14 +129,14 @@ export const NpcDialogue = ({
           </DialogueOptionsRow>
         </DialogueOptionsSection>
       ) : null}
+      {dialogueButtons && (
+        <NavigationRow>
+          {dialogueButtons.BackButton()}
+          {dialogueButtons.MiddleButton()}
+          {dialogueButtons.NextButton()}
+        </NavigationRow>
+      )}
       <Bottom hasQuests={hasAvailableQuests.length > 0 || hasOngoingQuests.length > 0}>
-        {dialogueButtons && (
-          <NavigationRow>
-            {dialogueButtons.BackButton()}
-            {dialogueButtons.MiddleButton()}
-            {dialogueButtons.NextButton()}
-          </NavigationRow>
-        )}
         {npcImage ? <NpcSprite src={npcImage} /> : null}
         <OptionColumn color={npcColor}>
           {special && (
@@ -195,7 +195,7 @@ const Text = styled.div<{
   position: relative;
   text-align: justify;
   width: 100%;
-  padding: 0vw 1vw;
+  padding: 0.9vw 1.2vw 0.4vw;
   flex-grow: 1;
   min-height: 8vh;
   flex-flow: column nowrap;
@@ -232,22 +232,19 @@ const ParallelColumns = styled.div`
 `;
 
 const NavigationRow = styled.div`
-  position: absolute;
-  right: 2%;
-  top: -2vw;
   display: flex;
   flex-flow: row nowrap;
   justify-content: flex-end;
   align-items: center;
-  gap: 0.3vw;
+  gap: 0.4vw;
+  padding: 0.4vw 1.2vw 0.7vw;
+  flex-shrink: 0;
   z-index: 6;
 `;
 
 const DialogueOptionsSection = styled.div`
   width: 100%;
-  padding: 0 0.6vw 0.2vw 0.6vw;
-  margin-top: -0.15vw;
-  margin-bottom: 2vw;
+  padding: 0.2vw 1.2vw 0.3vw;
 `;
 
 const DialogueOptionsRow = styled.div`
@@ -307,8 +304,10 @@ const Bottom = styled.div<{ hasQuests: boolean }>`
   display: flex;
   flex-flow: row nowrap;
   align-items: flex-end;
+  gap: 1vw;
   border-top: solid grey 0.15vw;
   flex-shrink: 0;
+  padding: 1vw 1.2vw 1.2vw;
   min-height: ${({ hasQuests }) => (hasQuests ? '16vh' : '12vh')};
   transition: min-height 0.3s ease;
 `;
@@ -322,7 +321,7 @@ const OptionColumn = styled.div<{ color: string }>`
   justify-content: safe center;
   align-items: flex-end;
   gap: 0.9vw;
-  padding: 1vw 1vw 1vw 0;
+  padding: 0.5vw 0;
   max-height: 40vh;
   overflow-y: auto;
   ::-webkit-scrollbar {

--- a/packages/client/src/app/components/modals/gacha/display/auctions/Chart.tsx
+++ b/packages/client/src/app/components/modals/gacha/display/auctions/Chart.tsx
@@ -215,6 +215,11 @@ const Container = styled.div`
   justify-content: center;
 
   overflow: scroll;
+
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const Title = styled.div`

--- a/packages/client/src/app/components/modals/gacha/display/pool/KamiView.tsx
+++ b/packages/client/src/app/components/modals/gacha/display/pool/KamiView.tsx
@@ -228,6 +228,11 @@ const Container = styled.div<{ isVisible: boolean }>`
   align-items: flex-start;
   justify-content: center;
   overflow-y: auto;
+
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 // Helper function for not blocking renders on large computations

--- a/packages/client/src/app/components/modals/gacha/display/reroll/KamiView.tsx
+++ b/packages/client/src/app/components/modals/gacha/display/reroll/KamiView.tsx
@@ -109,4 +109,9 @@ const Container = styled.div<{ isVisible: boolean }>`
   justify-content: center;
 
   overflow-y: scroll;
+
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;

--- a/packages/client/src/app/components/modals/gacha/display/reroll/Reroll.tsx
+++ b/packages/client/src/app/components/modals/gacha/display/reroll/Reroll.tsx
@@ -52,4 +52,9 @@ const Container = styled.div<{ isVisible: boolean }>`
 
   display: ${({ isVisible }) => (isVisible ? 'flex' : 'none')};
   overflow-y: scroll;
+
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;

--- a/packages/client/src/app/components/modals/gacha/sidebar/controls/Controls.tsx
+++ b/packages/client/src/app/components/modals/gacha/sidebar/controls/Controls.tsx
@@ -108,4 +108,9 @@ const Container = styled.div`
   align-items: stretch;
 
   overflow-y: scroll;
+
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;

--- a/packages/client/src/app/components/modals/gacha/sidebar/controls/pool/KamiPanel.tsx
+++ b/packages/client/src/app/components/modals/gacha/sidebar/controls/pool/KamiPanel.tsx
@@ -163,6 +163,11 @@ const Container = styled.div<{ isVisible: boolean }>`
   align-items: stretch;
 
   overflow-y: scroll;
+
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const Section = styled.div`

--- a/packages/client/src/app/components/modals/gacha/sidebar/controls/pool/Pool.tsx
+++ b/packages/client/src/app/components/modals/gacha/sidebar/controls/pool/Pool.tsx
@@ -50,4 +50,9 @@ const Container = styled.div<{ isVisible: boolean }>`
   width: 100%;
   display: ${({ isVisible }) => (isVisible ? 'flex' : 'none')};
   overflow-y: scroll;
+
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;

--- a/packages/client/src/app/components/modals/gacha/sidebar/controls/reroll/Reroll.tsx
+++ b/packages/client/src/app/components/modals/gacha/sidebar/controls/reroll/Reroll.tsx
@@ -47,4 +47,9 @@ const Container = styled.div<{ isVisible: boolean }>`
   width: 100%;
   display: ${({ isVisible }) => (isVisible ? 'flex' : 'none')};
   overflow-y: scroll;
+
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;

--- a/packages/client/src/app/components/modals/goals/Leaderboard.tsx
+++ b/packages/client/src/app/components/modals/goals/Leaderboard.tsx
@@ -57,6 +57,11 @@ const Container = styled.div`
   overflow: auto;
   scroll: auto;
   height: 100%;
+
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const Row = styled.div`

--- a/packages/client/src/app/components/modals/kami/skills/Details.tsx
+++ b/packages/client/src/app/components/modals/kami/skills/Details.tsx
@@ -173,6 +173,11 @@ const Container = styled.div`
   flex-flow: column nowrap;
   justify-content: flex-start;
   overflow-y: auto;
+
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const ImageSection = styled.div`

--- a/packages/client/src/app/components/modals/kami/skills/matrix/Matrix.tsx
+++ b/packages/client/src/app/components/modals/kami/skills/matrix/Matrix.tsx
@@ -89,6 +89,11 @@ const Content = styled.div`
   flex-flow: column nowrap;
   justify-content: flex-start;
   overflow-y: auto;
+
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const Row = styled.div<{ locked: boolean }>`

--- a/packages/client/src/app/components/modals/leaderboard/Table.tsx
+++ b/packages/client/src/app/components/modals/leaderboard/Table.tsx
@@ -61,6 +61,11 @@ const Container = styled.div`
   scroll: auto;
   height: 100%;
   margin-bottom: 1vh;
+
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const Row = styled.div`

--- a/packages/client/src/app/components/modals/map/Exits.tsx
+++ b/packages/client/src/app/components/modals/map/Exits.tsx
@@ -81,6 +81,11 @@ const Options = styled.div`
   width: 100%;
   height: 100%;
   overflow-y: scroll;
+
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 // TODO: merge this with Description using props

--- a/packages/client/src/app/components/modals/map/Grid.tsx
+++ b/packages/client/src/app/components/modals/map/Grid.tsx
@@ -33,7 +33,7 @@ const options = [
 ];
 
 export const Grid = ({
-  data: { account, accountKamis, rooms, roomIndex, zone },
+  data: { account, accountKamis, rooms, roomIndex, zone, isViewingDifferentZone = false },
   actions: { move },
   state: { tick },
   utils,
@@ -48,6 +48,7 @@ export const Grid = ({
     rooms: Map<number, Room>;
     roomIndex: number; // index of current room
     zone: number;
+    isViewingDifferentZone?: boolean;
   };
   state: { tick: number };
   utils: {
@@ -215,31 +216,37 @@ export const Grid = ({
 
     const { world, components } = network;
     const room = contextMenu.room;
+    const options = [];
 
-    const pathResult = findPath(world, components, roomIndex, room.index);
-    const staminaCost = pathResult.reachable ? calculatePathStaminaCost(pathResult.distance) : -1;
-    const canTravel =
-      room.index !== roomIndex && staminaCost >= 0 && account.stamina.total >= staminaCost;
+    // pathfinding only applies to the zone the player is standing in
+    if (!isViewingDifferentZone) {
+      const pathResult = findPath(world, components, roomIndex, room.index);
+      const staminaCost = pathResult.reachable ? calculatePathStaminaCost(pathResult.distance) : -1;
+      const canTravel =
+        room.index !== roomIndex && staminaCost >= 0 && account.stamina.total >= staminaCost;
 
-    return [
-      {
+      options.push({
         text: `Auto Travel (${staminaCost >= 0 ? staminaCost : '?'})`,
         onClick: () => handleAutoTravel(room),
         image: StaminaIcon,
         disabled: !canTravel || !pathResult.reachable || pathResult.distance <= 1,
-      },
-      {
-        text: 'Show Node',
-        onClick: () => triggerNodeModal(room.index),
-        disabled: false,
-      },
-      {
-        text: 'Cancel',
-        onClick: () => setContextMenu(null),
-        disabled: false,
-      },
-    ];
-  }, [contextMenu, network, roomIndex, account.stamina.total, handleAutoTravel]);
+      });
+    }
+
+    options.push({
+      text: 'Show Node',
+      onClick: () => triggerNodeModal(room.index),
+      disabled: false,
+    });
+
+    options.push({
+      text: 'Cancel',
+      onClick: () => setContextMenu(null),
+      disabled: false,
+    });
+
+    return options;
+  }, [contextMenu, network, roomIndex, account.stamina.total, handleAutoTravel, isViewingDifferentZone]);
 
   // populate the GridFilter details for room stats
   const { kamiCountMap, operatorCountMap, kamiAverage, operatorAverage } = useMemo(() => {
@@ -326,9 +333,12 @@ export const Grid = ({
                   <Tile
                     key={j}
                     backgroundColor={backgroundColor}
-                    onClick={() =>
-                      room.index !== 0 && !isRoomBlocked(room) && handleRoomMove(room.index)
-                    }
+                    onClick={() => {
+                      // walking a tile only applies to the zone the player is standing in
+                      if (!isViewingDifferentZone && room.index !== 0 && !isRoomBlocked(room)) {
+                        handleRoomMove(room.index);
+                      }
+                    }}
                     onContextMenu={(e) => handleRightClick(e, room)}
                     hasRoom={room.index !== 0}
                     isHighlighted={!!backgroundColor}

--- a/packages/client/src/app/components/modals/map/Grid.tsx
+++ b/packages/client/src/app/components/modals/map/Grid.tsx
@@ -233,11 +233,14 @@ export const Grid = ({
       });
     }
 
-    options.push({
-      text: 'Show Node',
-      onClick: () => triggerNodeModal(room.index),
-      disabled: false,
-    });
+    // rooms without a harvesting node have nothing to show
+    if (queryNodeByIndex(room.index)) {
+      options.push({
+        text: 'Show Node',
+        onClick: () => triggerNodeModal(room.index),
+        disabled: false,
+      });
+    }
 
     options.push({
       text: 'Cancel',

--- a/packages/client/src/app/components/modals/map/Map.tsx
+++ b/packages/client/src/app/components/modals/map/Map.tsx
@@ -196,6 +196,7 @@ export const MapModal: UIComponent = {
               closeOnClick
             >
               <TextTooltip text={['Switch Map']}>
+                {/* empty handler keeps the click sound; Popover owns the toggle */}
                 <IconButton img={ResetIcon} onClick={() => {}} noBorder scale={2.5} />
               </TextTooltip>
             </Popover>

--- a/packages/client/src/app/components/modals/map/Map.tsx
+++ b/packages/client/src/app/components/modals/map/Map.tsx
@@ -1,15 +1,19 @@
 import { EntityID, EntityIndex } from 'engine/recs';
 import { useEffect, useState } from 'react';
 
+import styled from 'styled-components';
+
 import { getAccount as _getAccount } from 'app/cache/account';
 import { getKami as _getKami } from 'app/cache/kami';
 import { getNodeByIndex } from 'app/cache/node';
 import { getRoom as _getRoom, getRoomByIndex as _getRoomByIndex } from 'app/cache/room';
-import { ModalHeader, ModalWrapper } from 'app/components/library';
+import { IconButton, ModalWrapper, Popover, TextTooltip } from 'app/components/library';
 import { useLayers } from 'app/root/hooks';
 import { UIComponent } from 'app/root/types';
 import { useSelected, useVisibility } from 'app/stores';
 import { MapIcon } from 'assets/images/icons/menu';
+import ResetIcon from 'assets/images/icons/menu/reset.png';
+import { playClick } from 'utils/sounds';
 import {
   queryRoomAccounts as _queryRoomAccounts,
   queryAccountFromEmbedded,
@@ -92,6 +96,7 @@ export const MapModal: UIComponent = {
     const [roomMap, setRoomMap] = useState<Map<number, Room>>(new Map());
     const [zone, setZone] = useState(0);
     const [tick, setTick] = useState(Date.now());
+    const [selectedZone, setSelectedZone] = useState<number | null>(null); // null = follow player
 
     // ticking
     useEffect(() => {
@@ -100,24 +105,34 @@ export const MapModal: UIComponent = {
       return () => clearInterval(timerID);
     }, []);
 
-    // query the set of rooms whenever the zone changes
+    // opening the modal always shows the map the player is currently in;
+    // reset during render so the old zone never flashes on reopen
+    const [wasOpen, setWasOpen] = useState(mapModalOpen);
+    if (wasOpen !== mapModalOpen) {
+      setWasOpen(mapModalOpen);
+      if (mapModalOpen) setSelectedZone(null);
+    }
+
+    const currentPlayerZone = getRoomByIndex(roomIndex).location.z;
+    const displayZone = selectedZone !== null ? selectedZone : currentPlayerZone;
+    const isViewingDifferentZone = displayZone !== currentPlayerZone;
+
+    // query the set of rooms whenever the displayed zone changes
     // NOTE: roomIndex is controlled by canvas/Scene.tsx
     useEffect(() => {
       if (!mapModalOpen) return;
-      const newRoom = getRoomByIndex(roomIndex);
-      const newZone = newRoom.location.z;
-      if (zone == newZone) return;
+      if (zone == displayZone) return;
 
       const roomMap = new Map<number, Room>();
       const roomEntities = queryAllRooms();
       // Load rooms WITH exits for pathfinding to work
       const rooms = roomEntities.map((entity) => getRoom(entity));
-      const filteredRooms = rooms.filter((room) => room.location.z == newZone);
+      const filteredRooms = rooms.filter((room) => room.location.z == displayZone);
       filteredRooms.forEach((r) => roomMap.set(r.index, r));
 
-      setZone(newZone);
+      setZone(displayZone);
       setRoomMap(roomMap);
-    }, [mapModalOpen, roomIndex]);
+    }, [mapModalOpen, roomIndex, displayZone]);
 
     ///////////////////
     // ACTIONS
@@ -136,10 +151,56 @@ export const MapModal: UIComponent = {
     ///////////////////
     // RENDER
 
+    const ZONE_NAMES: { [zone: number]: string } = {
+      1: 'The Wilds',
+      3: 'The Caves',
+      4: 'The Castle',
+    };
+
+    // when exploring another map the header carries its name instead of the room's
+    const headerTitle = isViewingDifferentZone
+      ? (ZONE_NAMES[displayZone] ?? 'Map')
+      : (roomMap.get(roomIndex)?.name ?? 'Map');
+
+    // selecting the zone the player stands in returns to follow mode
+    const zoneOptions = Object.entries(ZONE_NAMES).map(([z, name]) => {
+      const zoneNum = Number(z);
+      return {
+        text: name,
+        disabled: zoneNum === displayZone,
+        onClick: () => setSelectedZone(zoneNum === currentPlayerZone ? null : zoneNum),
+      };
+    });
+
     return (
       <ModalWrapper
         id='map'
-        header={<ModalHeader title={roomMap.get(roomIndex)?.name ?? 'Map'} icon={MapIcon} />}
+        header={
+          <MapHeader>
+            <HeaderIcon src={MapIcon} alt={headerTitle} />
+            <HeaderTitle>{headerTitle}</HeaderTitle>
+            <Popover
+              content={zoneOptions.map((option, i) => (
+                <ZoneOption
+                  key={i}
+                  disabled={option.disabled}
+                  onClick={() => {
+                    if (option.disabled) return;
+                    playClick();
+                    option.onClick();
+                  }}
+                >
+                  {option.text}
+                </ZoneOption>
+              ))}
+              closeOnClick
+            >
+              <TextTooltip text={['Switch Map']}>
+                <IconButton img={ResetIcon} onClick={() => {}} noBorder scale={2.5} />
+              </TextTooltip>
+            </Popover>
+          </MapHeader>
+        }
         canExit
         noPadding
         truncate
@@ -153,6 +214,7 @@ export const MapModal: UIComponent = {
             roomIndex,
             zone,
             rooms: roomMap,
+            isViewingDifferentZone,
           }}
           state={{ tick }}
           utils={{
@@ -176,3 +238,45 @@ export const MapModal: UIComponent = {
     );
   },
 };
+
+const MapHeader = styled.div`
+  padding: 0.6vw 1vw;
+  gap: 0.7vw;
+  line-height: 1.5vw;
+
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+  justify-content: flex-start;
+  user-select: none;
+`;
+
+const HeaderIcon = styled.img`
+  height: 2vw;
+  width: auto;
+  user-drag: none;
+`;
+
+const HeaderTitle = styled.div`
+  font-size: 1.2vw;
+  color: #333;
+  text-align: left;
+  font-family: Pixel;
+  margin-right: 0.3vw;
+  line-height: 1.2vw;
+  display: flex;
+  align-items: center;
+`;
+
+const ZoneOption = styled.div<{ disabled?: boolean }>`
+  padding: 0.6vw 1.2vw;
+  font-size: 0.9vw;
+  font-family: Pixel;
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  background-color: ${({ disabled }) => (disabled ? '#bbb' : '#fff')};
+  user-select: none;
+
+  &:hover {
+    background-color: ${({ disabled }) => (disabled ? '#bbb' : '#e8e8e8')};
+  }
+`;

--- a/packages/client/src/app/components/modals/map/Map.tsx
+++ b/packages/client/src/app/components/modals/map/Map.tsx
@@ -13,6 +13,7 @@ import { UIComponent } from 'app/root/types';
 import { useSelected, useVisibility } from 'app/stores';
 import { MapIcon } from 'assets/images/icons/menu';
 import ResetIcon from 'assets/images/icons/menu/reset.png';
+import { SEXTANT_INDEX } from 'constants/items';
 import { playClick } from 'utils/sounds';
 import {
   queryRoomAccounts as _queryRoomAccounts,
@@ -20,6 +21,7 @@ import {
   queryAccountKamis,
 } from 'network/shapes/Account';
 import { Allo, parseAllos as _parseAllos } from 'network/shapes/Allo';
+import { getItemBalance } from 'network/shapes/Item';
 import { getKamiLocation as _getKamiLocation } from 'network/shapes/Kami';
 import {
   queryNodeByIndex as _queryNodeByIndex,
@@ -53,6 +55,7 @@ export const MapModal: UIComponent = {
         parseAllos,
         queryScavInstance,
         getValue,
+        getSextantBalance,
       },
     } = (() => {
       const { network } = layers;
@@ -85,6 +88,8 @@ export const MapModal: UIComponent = {
           queryScavInstance: (index: number, holderID: EntityID) =>
             _queryScavInstance(world, 'NODE', index, holderID),
           getValue: (entity: EntityIndex) => _getValue(components, entity),
+          getSextantBalance: () =>
+            getItemBalance(world, components, world.entities[accountEntity], SEXTANT_INDEX),
         },
       };
     })();
@@ -151,10 +156,11 @@ export const MapModal: UIComponent = {
     ///////////////////
     // RENDER
 
+    // zone 4's name is concealed on purpose: lore stays hidden even with access
     const ZONE_NAMES: { [zone: number]: string } = {
       1: 'Lost Woods',
       3: 'Sanctuary Caves',
-      4: 'Caer Golud',
+      4: '??????',
     };
 
     // when exploring another map the header carries its name instead of the room's
@@ -162,15 +168,21 @@ export const MapModal: UIComponent = {
       ? (ZONE_NAMES[displayZone] ?? 'Map')
       : (roomMap.get(roomIndex)?.name ?? 'Map');
 
+    // zone 4 stays out of the dropdown until the player carries the Aetheric Sextant
+    const zoneVisible = (zone: number) =>
+      zone !== 4 || currentPlayerZone === 4 || getSextantBalance() > 0;
+
     // selecting the zone the player stands in returns to follow mode
-    const zoneOptions = Object.entries(ZONE_NAMES).map(([z, name]) => {
-      const zoneNum = Number(z);
-      return {
-        text: name,
-        disabled: zoneNum === displayZone,
-        onClick: () => setSelectedZone(zoneNum === currentPlayerZone ? null : zoneNum),
-      };
-    });
+    const zoneOptions = Object.entries(ZONE_NAMES)
+      .filter(([z]) => zoneVisible(Number(z)))
+      .map(([z, name]) => {
+        const zoneNum = Number(z);
+        return {
+          text: name,
+          disabled: zoneNum === displayZone,
+          onClick: () => setSelectedZone(zoneNum === currentPlayerZone ? null : zoneNum),
+        };
+      });
 
     return (
       <ModalWrapper

--- a/packages/client/src/app/components/modals/map/Map.tsx
+++ b/packages/client/src/app/components/modals/map/Map.tsx
@@ -152,9 +152,9 @@ export const MapModal: UIComponent = {
     // RENDER
 
     const ZONE_NAMES: { [zone: number]: string } = {
-      1: 'The Wilds',
-      3: 'The Caves',
-      4: 'The Castle',
+      1: 'Lost Woods',
+      3: 'Sanctuary Caves',
+      4: 'Caer Golud',
     };
 
     // when exploring another map the header carries its name instead of the room's

--- a/packages/client/src/app/components/modals/map/Players.tsx
+++ b/packages/client/src/app/components/modals/map/Players.tsx
@@ -74,6 +74,11 @@ const PlayerRow = styled.div`
   width: 100%;
   height: 100%;
   overflow-y: scroll;
+
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const Player = styled.div`

--- a/packages/client/src/app/components/modals/map/RoomInfo.tsx
+++ b/packages/client/src/app/components/modals/map/RoomInfo.tsx
@@ -57,4 +57,9 @@ const Description = styled.div`
   text-align: left;
   line-height: 1.2vw;
   overflow-y: scroll;
+
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;

--- a/packages/client/src/app/components/modals/marketplace/create/Buy.tsx
+++ b/packages/client/src/app/components/modals/marketplace/create/Buy.tsx
@@ -543,6 +543,11 @@ const ResultsList = styled.div`
   border-bottom: none;
   border-radius: 0.4vw 0.4vw 0 0;
   z-index: 9999;
+
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const ResultItem = styled.div`

--- a/packages/client/src/app/components/modals/marketplace/tabs/orders/History.tsx
+++ b/packages/client/src/app/components/modals/marketplace/tabs/orders/History.tsx
@@ -147,6 +147,11 @@ const HistoryBody = styled.div`
   flex-direction: column;
   overflow-y: auto;
   flex: 1;
+
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const Row = styled.div`

--- a/packages/client/src/app/components/modals/merchant/cart/Cart.tsx
+++ b/packages/client/src/app/components/modals/merchant/cart/Cart.tsx
@@ -113,6 +113,11 @@ const Items = styled.div`
   overflow-x: hidden;
   scrollbar-gutter: stable;
   scrollbar-color: transparent transparent;
+
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const Checkout = styled.div`

--- a/packages/client/src/app/components/modals/merchant/catalog/Catalog.tsx
+++ b/packages/client/src/app/components/modals/merchant/catalog/Catalog.tsx
@@ -89,4 +89,9 @@ const Items = styled.div`
   overflow-x: hidden;
   scrollbar-gutter: stable;
   scrollbar-color: transparent transparent;
+
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;

--- a/packages/client/src/app/components/modals/node/kards/Kards.tsx
+++ b/packages/client/src/app/components/modals/node/kards/Kards.tsx
@@ -145,8 +145,15 @@ const Container = styled.div`
   gap: 0.3vw;
   scrollbar-gutter: stable;
 
-  scrollbar-width: none;
+  scrollbar-width: thin;
+  scrollbar-color: #b6b6b6 transparent;
   &::-webkit-scrollbar {
-    display: none;
+    width: 0.3vw;
+    background: transparent;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: #b6b6b6;
+    border-radius: 0.3vw;
+    background-clip: padding-box;
   }
 `;

--- a/packages/client/src/app/components/modals/node/kards/Kards.tsx
+++ b/packages/client/src/app/components/modals/node/kards/Kards.tsx
@@ -144,4 +144,9 @@ const Container = styled.div`
   overflow-y: auto;
   gap: 0.3vw;
   scrollbar-gutter: stable;
+
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;

--- a/packages/client/src/app/components/modals/obol/Obol.tsx
+++ b/packages/client/src/app/components/modals/obol/Obol.tsx
@@ -11,6 +11,7 @@ import { OBOL_INDEX } from 'constants/items';
 import { queryAccountFromEmbedded } from 'network/shapes/Account';
 import { getItemBalance } from 'network/shapes/Item';
 import { didActionSucceed } from 'network/utils';
+import { playClick } from 'utils/sounds';
 
 const obolsPerEgg = 5;
 const arrowButtons = [
@@ -144,6 +145,7 @@ export const ObolModal: UIComponent = {
             <Button
               disabled={isDisabled || eggsQuantity * obolsPerEgg > getObolsBalance()}
               onClick={() => {
+                playClick();
                 craft(10001, eggsQuantity);
               }}
             >
@@ -151,6 +153,7 @@ export const ObolModal: UIComponent = {
             </Button>
             <Button
               onClick={() => {
+                playClick();
                 setModals({ lootBox: false });
               }}
             >

--- a/packages/client/src/app/components/modals/party/Party.tsx
+++ b/packages/client/src/app/components/modals/party/Party.tsx
@@ -302,6 +302,7 @@ export const PartyModal: UIComponent = {
         canExit
         truncate
         noPadding
+        showScrollBar
       >
         <Toolbar
           actions={{

--- a/packages/client/src/app/components/modals/pool/Pool.tsx
+++ b/packages/client/src/app/components/modals/pool/Pool.tsx
@@ -294,15 +294,9 @@ export const PoolModal: UIComponent = {
           <SideBlock>
             <HeadRow>
               <Text size={0.95}>You're selling</Text>
-              <MaxLabel
-                onClick={() => {
-                  playClick();
-                  setSwapInput(balance);
-                }}
-                title='fill max'
-              >
+              <Text size={0.75} color='#999'>
                 balance: {balance}
-              </MaxLabel>
+              </Text>
             </HeadRow>
             <TradeCard>
               <ItemBlock item={swapIn} />
@@ -400,15 +394,9 @@ export const PoolModal: UIComponent = {
           <SideBlock>
             <HeadRow>
               <Text size={0.95}>Add liquidity</Text>
-              <MaxLabel
-                onClick={() => {
-                  playClick();
-                  setAddAmountA(maxAddA);
-                }}
-                title='fill max'
-              >
+              <Text size={0.75} color='#999'>
                 balance: {balA}
-              </MaxLabel>
+              </Text>
             </HeadRow>
             <TradeCard>
               <ItemBlock item={pool.itemA} />
@@ -440,15 +428,9 @@ export const PoolModal: UIComponent = {
               <SideBlock>
                 <HeadRow>
                   <Text size={0.95}>Remove liquidity</Text>
-                  <MaxLabel
-                    onClick={() => {
-                      playClick();
-                      setRemoveShares(playerShares);
-                    }}
-                    title='fill max'
-                  >
+                  <Text size={0.75} color='#999'>
                     shares: {playerShares}
-                  </MaxLabel>
+                  </Text>
                 </HeadRow>
                 <TradeCard>
                   <Text size={0.95}>shares</Text>
@@ -652,19 +634,6 @@ const HeadRow = styled.div`
   align-items: center;
   gap: 0.6vw;
   padding: 0 0.2vw;
-`;
-
-// clickable balance/shares readout that fills the paired input to its max
-const MaxLabel = styled.div`
-  font-family: Pixel;
-  font-size: 0.75vw;
-  color: #999;
-  cursor: pointer;
-  pointer-events: auto;
-  &:hover {
-    color: #333;
-    text-decoration: underline;
-  }
 `;
 
 const TradeCard = styled.div`

--- a/packages/client/src/app/components/modals/pool/Pool.tsx
+++ b/packages/client/src/app/components/modals/pool/Pool.tsx
@@ -485,6 +485,7 @@ export const PoolModal: UIComponent = {
         id='pool'
         header={<ModalHeader title='Item Pools' icon={LpFountainIcon} />}
         canExit
+        showScrollBar
       >
         <Container>
           {renderPicker()}

--- a/packages/client/src/app/components/modals/questDetails/Typewriter.tsx
+++ b/packages/client/src/app/components/modals/questDetails/Typewriter.tsx
@@ -1,32 +1,61 @@
-import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import styled from 'styled-components';
 
-const boldName = (text: string, key: number | string) => (
-  <strong style={{ color: 'inherit' }} key={key}>
-    {text}
-  </strong>
-);
 const SPEAKER_TAG_AT_START = /^([A-Z][A-Z0-9 ]{1,24})(?=:)/;
 const SPEAKER_TAG_GLOBAL = /([A-Z][A-Z0-9 ]{1,24})(?=:)/g;
 
-const renderSpeakerTags = (text: string): ReactNode[] => {
-  const result: ReactNode[] = [];
+type Segment = { bold: boolean; content: string };
+
+// split text into plain runs and bolded speaker tags
+const segmentText = (text: string): Segment[] => {
+  const segments: Segment[] = [];
   let cursor = 0;
-  let key = 0;
 
   for (const match of text.matchAll(SPEAKER_TAG_GLOBAL)) {
     const index = match.index ?? 0;
     const speaker = match[1];
-
-    if (index > cursor) result.push(text.slice(cursor, index));
-    result.push(boldName(speaker, key));
-
-    key += 1;
+    if (index > cursor) segments.push({ bold: false, content: text.slice(cursor, index) });
+    segments.push({ bold: true, content: speaker });
     cursor = index + speaker.length;
   }
 
-  if (cursor < text.length) result.push(text.slice(cursor));
-  return result;
+  if (cursor < text.length) segments.push({ bold: false, content: text.slice(cursor) });
+  return segments;
+};
+
+// render the full text with characters beyond revealCount kept in the DOM but
+// invisible: word wrapping is computed against the complete text, so lines
+// never reflow mid-reveal and the container holds its final size from the start
+const renderSegments = (segments: Segment[], revealCount: number): ReactNode[] => {
+  const parts: ReactNode[] = [];
+  let offset = 0;
+
+  segments.forEach((segment, i) => {
+    const visibleCount = Math.max(0, Math.min(segment.content.length, revealCount - offset));
+    const visible = segment.content.slice(0, visibleCount);
+    const hidden = segment.content.slice(visibleCount);
+
+    if (segment.bold) {
+      // hidden part stays inside the strong so reserved width matches the final render
+      parts.push(
+        <strong style={{ color: 'inherit' }} key={i}>
+          {visible}
+          {hidden && <span style={{ visibility: 'hidden' }}>{hidden}</span>}
+        </strong>
+      );
+    } else {
+      if (visible) parts.push(<span key={`${i}v`}>{visible}</span>);
+      if (hidden)
+        parts.push(
+          <span key={`${i}h`} style={{ visibility: 'hidden' }}>
+            {hidden}
+          </span>
+        );
+    }
+    offset += segment.content.length;
+  });
+
+  return parts;
 };
 
 export const useTypewriter = (
@@ -37,11 +66,12 @@ export const useTypewriter = (
   interrupted?: boolean,
   onComplete?: () => void
 ) => {
-  const [displayedText, setDisplayedText] = useState<ReactNode[]>([]);
+  const [revealCount, setRevealCount] = useState(0);
   const indexRef = useRef(0);
+  const segments = useMemo(() => segmentText(text), [text]);
 
   useEffect(() => {
-    setDisplayedText([]);
+    setRevealCount(0);
     indexRef.current = 0;
   }, [retrigger]);
 
@@ -49,8 +79,8 @@ export const useTypewriter = (
     if (!text) return;
 
     if (interrupted) {
-      setDisplayedText(renderSpeakerTags(text));
       indexRef.current = text.length;
+      setRevealCount(text.length);
       onComplete?.();
       return;
     }
@@ -62,16 +92,11 @@ export const useTypewriter = (
         return;
       }
 
+      // speaker tags reveal in one beat, regular text char by char
       const remaining = text.substring(indexRef.current);
-      const speakerMatch = remaining.match(SPEAKER_TAG_AT_START);
-      const speaker = speakerMatch?.[1];
-      if (speaker) {
-        setDisplayedText((prev) => [...prev, boldName(speaker, indexRef.current)]);
-        indexRef.current += speaker.length;
-      } else {
-        setDisplayedText((prev) => [...prev, remaining[0]]);
-        indexRef.current += 1;
-      }
+      const speaker = remaining.match(SPEAKER_TAG_AT_START)?.[1];
+      indexRef.current += speaker ? speaker.length : 1;
+      setRevealCount(indexRef.current);
 
       if (onUpdate) onUpdate();
     }, speed);
@@ -79,14 +104,14 @@ export const useTypewriter = (
     return () => clearInterval(interval);
   }, [text, speed, retrigger, onUpdate, interrupted, onComplete]);
 
-  return displayedText;
+  return useMemo(() => renderSegments(segments, revealCount), [segments, revealCount]);
 };
 
 // all in one block
 const SingleLineTypewriter = ({
   text = '',
   retrigger,
-  speed = 30,
+  speed = 20,
   onUpdate,
   interrupted = false,
   onComplete,
@@ -114,7 +139,7 @@ const SingleLineTypewriter = ({
 const MultiLineTypewriter = ({
   text = '',
   retrigger,
-  speed = 30,
+  speed = 20,
   onUpdate,
   onAllLinesComplete,
 }: {
@@ -189,7 +214,7 @@ const MultiLineTypewriter = ({
 export const TypewriterComponent = ({
   text = '',
   retrigger,
-  speed = 30,
+  speed = 20,
   onUpdate,
   interrupted = false,
   onComplete,

--- a/packages/client/src/app/components/modals/questDetails/Typewriter.tsx
+++ b/packages/client/src/app/components/modals/questDetails/Typewriter.tsx
@@ -79,9 +79,13 @@ export const useTypewriter = (
     if (!text) return;
 
     if (interrupted) {
-      indexRef.current = text.length;
-      setRevealCount(text.length);
-      onComplete?.();
+      // skip if already fully revealed: a late interrupt (e.g. a shared skip
+      // flag across columns) must not re-fire completion
+      if (indexRef.current < text.length) {
+        indexRef.current = text.length;
+        setRevealCount(text.length);
+        onComplete?.();
+      }
       return;
     }
 

--- a/packages/client/src/app/components/modals/reveal/Commits.tsx
+++ b/packages/client/src/app/components/modals/reveal/Commits.tsx
@@ -95,6 +95,11 @@ const Container = styled.div`
   overflow-y: scroll;
 
   gap: 0.6vh 0.4vw;
+
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const CellContainer = styled.div`

--- a/packages/client/src/app/components/modals/tokenPortal/TokenPortal.tsx
+++ b/packages/client/src/app/components/modals/tokenPortal/TokenPortal.tsx
@@ -236,10 +236,8 @@ export const TokenPortalModal: UIComponent = {
       setMode(m);
     };
 
-    const toggleQueue = () => {
-      playClick();
-      setShowQueue(!showQueue);
-    };
+    // IconButton plays the click sound itself
+    const toggleQueue = () => setShowQueue(!showQueue);
 
     return (
       <ModalWrapper
@@ -287,6 +285,7 @@ export const TokenPortalModal: UIComponent = {
               data={{ config, inventory: account.inventories ?? [] }}
               state={{ mode, selected }}
             />
+            <Rule />
             <BottomRow>
               <BuyWrapper>
                 <IconButton
@@ -379,6 +378,10 @@ const TabButton = styled.button<{ $color: string; $active: boolean }>`
     cursor: default;
     pointer-events: none;
   }
+`;
+
+const Rule = styled.div`
+  border-top: 0.12vw solid #e0e0e0;
 `;
 
 const BottomRow = styled.div`

--- a/packages/client/src/app/components/modals/tokenPortal/TokenPortal.tsx
+++ b/packages/client/src/app/components/modals/tokenPortal/TokenPortal.tsx
@@ -5,9 +5,10 @@ import { v4 as uuid } from 'uuid';
 import { getAccount as _getAccount, getAccountByID } from 'app/cache/account';
 import { getPortalConfig } from 'app/cache/config';
 import { getItem as _getItem, getItemByIndex as _getItemByIndex } from 'app/cache/item';
-import { EmptyText, HelpChip, ModalWrapper } from 'app/components/library';
+import { EmptyText, HelpChip, IconButton, ModalWrapper } from 'app/components/library';
 import { UIComponent, useLayers } from 'app/root';
 import { useNetwork, useVisibility } from 'app/stores';
+import { TriggerIcons } from 'assets/images/icons/triggers';
 import { TokenIcons } from 'assets/images/tokens';
 import { getKamidenClient } from 'clients/kamiden';
 import { PortalReceipt, TokenPortalRequest } from 'clients/kamiden/proto';
@@ -25,6 +26,7 @@ import { getResultWithdraw, openBaselineLink } from './utils';
 
 // kamiswap (marketplace) tab pastels: blue for deposit, orange for withdraw
 const DEPOSIT_BLUE = '#E0EEFF';
+const GREEN = '#C2F0C2';
 const WITHDRAW_ORANGE = '#FFF0E0';
 
 const KamidenClient = getKamidenClient();
@@ -252,7 +254,6 @@ export const TokenPortalModal: UIComponent = {
         canExit
         overlay
         truncate
-        showScrollBar
       >
         {!accountEntity ? (
           <EmptyText text={['Failed to Connect Account']} size={1} />
@@ -287,12 +288,19 @@ export const TokenPortalModal: UIComponent = {
               state={{ mode, selected }}
             />
             <BottomRow>
-              <PillButton onClick={toggleQueue}>
-                {showQueue ? 'Hide Queue' : 'Queue'}
-              </PillButton>
-              <PillButton onClick={() => openBaselineLink(selected.token?.address ?? '')}>
-                Purchase $ONYX
-              </PillButton>
+              <BuyWrapper>
+                <IconButton
+                  fullWidth
+                  scale={2.2}
+                  color={GREEN}
+                  text='Purchase $ONYX'
+                  onClick={() => openBaselineLink(selected.token?.address ?? '')}
+                />
+              </BuyWrapper>
+              <IconButton
+                img={showQueue ? TriggerIcons.eyeOpen : TriggerIcons.eyeClosed}
+                onClick={toggleQueue}
+              />
             </BottomRow>
             {showQueue && (
               <Queue
@@ -380,21 +388,6 @@ const BottomRow = styled.div`
   gap: 0.6vw;
 `;
 
-const PillButton = styled.button`
-  border: 0.12vw solid #ccc;
-  border-radius: 0.5vw;
-  background: #fafafa;
-  color: #555;
-  padding: 0.4vw 0.9vw;
-  font-family: Pixel;
-  font-size: 0.75vw;
-  cursor: pointer;
-  pointer-events: auto;
-  transition:
-    background 0.12s,
-    border-color 0.12s;
-  &:hover {
-    background: #e8f0fe;
-    border-color: #a0c0e8;
-  }
+const BuyWrapper = styled.div`
+  flex: 1;
 `;

--- a/packages/client/src/app/components/modals/tokenPortal/TokenPortal.tsx
+++ b/packages/client/src/app/components/modals/tokenPortal/TokenPortal.tsx
@@ -5,7 +5,7 @@ import { v4 as uuid } from 'uuid';
 import { getAccount as _getAccount, getAccountByID } from 'app/cache/account';
 import { getPortalConfig } from 'app/cache/config';
 import { getItem as _getItem, getItemByIndex as _getItemByIndex } from 'app/cache/item';
-import { EmptyText, HelpChip, ModalHeader, ModalWrapper } from 'app/components/library';
+import { EmptyText, HelpChip, ModalWrapper } from 'app/components/library';
 import { UIComponent, useLayers } from 'app/root';
 import { useNetwork, useVisibility } from 'app/stores';
 import { TokenIcons } from 'assets/images/tokens';
@@ -17,13 +17,15 @@ import { Account, NullAccount, queryAccountFromEmbedded } from 'network/shapes/A
 import { Item, NullItem, queryItems } from 'network/shapes/Item';
 import { getCompAddr } from 'network/shapes/utils';
 import { playClick } from 'utils/sounds';
-import { HELP_TEXT } from './constants';
+import { getHelpText } from './constants';
 import { Queue } from './queue';
 import { Swap } from './swap';
 import { Mode } from './swap/types';
 import { getResultWithdraw, openBaselineLink } from './utils';
 
-type Tab = Mode | 'QUEUE';
+// kamiswap (marketplace) tab pastels: blue for deposit, orange for withdraw
+const DEPOSIT_BLUE = '#E0EEFF';
+const WITHDRAW_ORANGE = '#FFF0E0';
 
 const KamidenClient = getKamidenClient();
 
@@ -73,7 +75,8 @@ export const TokenPortalModal: UIComponent = {
     const [selected, setSelected] = useState<Item>(NullItem); // selected item for import/export
     const [myReceipts, setMyReceipts] = useState<PortalReceipt[]>([]);
     const [othersReceipts, setOthersReceipts] = useState<PortalReceipt[]>([]);
-    const [tab, setTab] = useState<Tab>('DEPOSIT');
+    const [mode, setMode] = useState<Mode>('DEPOSIT');
+    const [showQueue, setShowQueue] = useState<boolean>(false);
     const [tick, setTick] = useState(Date.now());
 
     /////////////////
@@ -226,15 +229,26 @@ export const TokenPortalModal: UIComponent = {
     /////////////////
     // DISPLAY
 
-    const switchTab = (t: Tab) => {
+    const switchMode = (m: Mode) => {
       playClick();
-      setTab(t);
+      setMode(m);
+    };
+
+    const toggleQueue = () => {
+      playClick();
+      setShowQueue(!showQueue);
     };
 
     return (
       <ModalWrapper
         id='tokenPortal'
-        header={<ModalHeader title='Token Portal' icon={TokenIcons.onyx} />}
+        header={
+          <PortalHeader>
+            <HeaderIcon src={TokenIcons.onyx} alt='Token Portal' />
+            <HeaderTitle>Token Portal</HeaderTitle>
+            <HelpChip tooltip={{ text: getHelpText(config), size: 0.6 }} size={1.2} />
+          </PortalHeader>
+        }
         canExit
         overlay
         truncate
@@ -244,28 +258,43 @@ export const TokenPortalModal: UIComponent = {
           <EmptyText text={['Failed to Connect Account']} size={1} />
         ) : (
           <Container>
-            <TopRow>
-              <HelpChip tooltip={{ text: HELP_TEXT, size: 0.6 }} size={1.2} />
-              <BuyButton onClick={() => openBaselineLink(selected.token?.address ?? '')}>
-                Purchase $ONYX ↗
-              </BuyButton>
-            </TopRow>
             <Tabs>
-              <TabButton onClick={() => switchTab('DEPOSIT')} disabled={tab === 'DEPOSIT'}>
+              <TabButton
+                $color={DEPOSIT_BLUE}
+                $active={mode === 'DEPOSIT'}
+                onClick={() => switchMode('DEPOSIT')}
+                disabled={mode === 'DEPOSIT'}
+              >
                 Deposit
               </TabButton>
-              <TabButton onClick={() => switchTab('WITHDRAW')} disabled={tab === 'WITHDRAW'}>
-                Withdraw
-              </TabButton>
               <TabButton
-                onClick={() => switchTab('QUEUE')}
-                disabled={tab === 'QUEUE'}
+                $color={WITHDRAW_ORANGE}
+                $active={mode === 'WITHDRAW'}
+                onClick={() => switchMode('WITHDRAW')}
+                disabled={mode === 'WITHDRAW'}
                 style={{ borderRight: 'none' }}
               >
-                Queue
+                Withdraw
               </TabButton>
             </Tabs>
-            {tab === 'QUEUE' ? (
+            <Swap
+              actions={{
+                approve: approveTx,
+                deposit: depositTx,
+                withdraw: withdrawTx,
+              }}
+              data={{ config, inventory: account.inventories ?? [] }}
+              state={{ mode, selected }}
+            />
+            <BottomRow>
+              <PillButton onClick={toggleQueue}>
+                {showQueue ? 'Hide Queue' : 'Queue'}
+              </PillButton>
+              <PillButton onClick={() => openBaselineLink(selected.token?.address ?? '')}>
+                Purchase $ONYX
+              </PillButton>
+            </BottomRow>
+            {showQueue && (
               <Queue
                 actions={{
                   claim: claimTx,
@@ -273,16 +302,6 @@ export const TokenPortalModal: UIComponent = {
                 }}
                 data={{ myReceipts, othersReceipts, config, account }}
                 utils={utils}
-              />
-            ) : (
-              <Swap
-                actions={{
-                  approve: approveTx,
-                  deposit: depositTx,
-                  withdraw: withdrawTx,
-                }}
-                data={{ config, inventory: account.inventories ?? [] }}
-                state={{ mode: tab, options, selected, setSelected }}
               />
             )}
           </Container>
@@ -301,30 +320,28 @@ const Container = styled.div`
   gap: 1vh;
 `;
 
-const TopRow = styled.div`
+const PortalHeader = styled.div`
+  padding: 0.6vw 1vw;
+  gap: 0.7vw;
+  line-height: 1.5vw;
+
   display: flex;
-  justify-content: space-between;
+  flex-flow: row nowrap;
   align-items: center;
-  gap: 0.6vw;
+  justify-content: flex-start;
+  user-select: none;
 `;
 
-const BuyButton = styled.button`
-  border: 0.1vw solid #9c9;
-  border-radius: 0.4vw;
-  background: #eefaee;
-  color: #383;
-  padding: 0.3vw 0.6vw;
+const HeaderIcon = styled.img`
+  height: 2vw;
+  width: auto;
+  user-drag: none;
+`;
+
+const HeaderTitle = styled.div`
+  font-size: 1.2vw;
+  color: #333;
   font-family: Pixel;
-  font-size: 0.7vw;
-  cursor: pointer;
-  pointer-events: auto;
-  transition:
-    background 0.12s,
-    border-color 0.12s;
-  &:hover {
-    background: #dff5df;
-    border-color: #6b6;
-  }
 `;
 
 const Tabs = styled.div`
@@ -336,7 +353,7 @@ const Tabs = styled.div`
   flex-flow: row nowrap;
 `;
 
-const TabButton = styled.button`
+const TabButton = styled.button<{ $color: string; $active: boolean }>`
   border: none;
   border-right: solid black 0.15vw;
   padding: 0.5vw;
@@ -346,12 +363,38 @@ const TabButton = styled.button`
   font-size: 0.9vw;
   text-align: center;
   cursor: pointer;
+  background-color: ${({ $active, $color }) => ($active ? $color : 'white')};
   &:hover {
-    background-color: #ddd;
+    background-color: ${({ $color }) => $color}88;
   }
   &:disabled {
-    background-color: #b2b2b2;
     cursor: default;
     pointer-events: none;
+  }
+`;
+
+const BottomRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.6vw;
+`;
+
+const PillButton = styled.button`
+  border: 0.12vw solid #ccc;
+  border-radius: 0.5vw;
+  background: #fafafa;
+  color: #555;
+  padding: 0.4vw 0.9vw;
+  font-family: Pixel;
+  font-size: 0.75vw;
+  cursor: pointer;
+  pointer-events: auto;
+  transition:
+    background 0.12s,
+    border-color 0.12s;
+  &:hover {
+    background: #e8f0fe;
+    border-color: #a0c0e8;
   }
 `;

--- a/packages/client/src/app/components/modals/tokenPortal/TokenPortal.tsx
+++ b/packages/client/src/app/components/modals/tokenPortal/TokenPortal.tsx
@@ -1,21 +1,13 @@
 import { useEffect, useState } from 'react';
+import styled from 'styled-components';
 import { v4 as uuid } from 'uuid';
 
 import { getAccount as _getAccount, getAccountByID } from 'app/cache/account';
 import { getPortalConfig } from 'app/cache/config';
 import { getItem as _getItem, getItemByIndex as _getItemByIndex } from 'app/cache/item';
-import {
-  EmptyText,
-  HelpChip,
-  IconButton,
-  ModalHeader,
-  ModalWrapper,
-  Overlay,
-  Text,
-} from 'app/components/library';
+import { EmptyText, HelpChip, ModalHeader, ModalWrapper } from 'app/components/library';
 import { UIComponent, useLayers } from 'app/root';
 import { useNetwork, useVisibility } from 'app/stores';
-import { TriggerIcons } from 'assets/images/icons/triggers';
 import { TokenIcons } from 'assets/images/tokens';
 import { getKamidenClient } from 'clients/kamiden';
 import { PortalReceipt, TokenPortalRequest } from 'clients/kamiden/proto';
@@ -24,10 +16,14 @@ import { EntityID, EntityIndex } from 'engine/recs';
 import { Account, NullAccount, queryAccountFromEmbedded } from 'network/shapes/Account';
 import { Item, NullItem, queryItems } from 'network/shapes/Item';
 import { getCompAddr } from 'network/shapes/utils';
+import { playClick } from 'utils/sounds';
 import { HELP_TEXT } from './constants';
 import { Queue } from './queue';
 import { Swap } from './swap';
+import { Mode } from './swap/types';
 import { getResultWithdraw, openBaselineLink } from './utils';
+
+type Tab = Mode | 'QUEUE';
 
 const KamidenClient = getKamidenClient();
 
@@ -77,7 +73,7 @@ export const TokenPortalModal: UIComponent = {
     const [selected, setSelected] = useState<Item>(NullItem); // selected item for import/export
     const [myReceipts, setMyReceipts] = useState<PortalReceipt[]>([]);
     const [othersReceipts, setOthersReceipts] = useState<PortalReceipt[]>([]);
-    const [showQueue, setShowQueue] = useState<boolean>(false);
+    const [tab, setTab] = useState<Tab>('DEPOSIT');
     const [tick, setTick] = useState(Date.now());
 
     /////////////////
@@ -230,56 +226,132 @@ export const TokenPortalModal: UIComponent = {
     /////////////////
     // DISPLAY
 
+    const switchTab = (t: Tab) => {
+      playClick();
+      setTab(t);
+    };
+
     return (
       <ModalWrapper
         id='tokenPortal'
         header={<ModalHeader title='Token Portal' icon={TokenIcons.onyx} />}
         canExit
         overlay
-        noPadding
         truncate
+        showScrollBar
       >
-        <Overlay left={0.6} top={0.6}>
-          <HelpChip tooltip={{ text: HELP_TEXT, size: 0.6 }} size={1.2} />
-        </Overlay>
-        <Overlay right={0.6} top={0.6}>
-          <Text
-            size={0.6}
-            color='#3b3'
-            onClick={() => openBaselineLink(selected.token?.address ?? '')}
-          >
-            Purchase $ONYX
-          </Text>
-        </Overlay>
         {!accountEntity ? (
           <EmptyText text={['Failed to Connect Account']} size={1} />
         ) : (
-          <Swap
-            actions={{
-              approve: approveTx,
-              deposit: depositTx,
-              withdraw: withdrawTx,
-            }}
-            data={{ config, inventory: account.inventories ?? [] }}
-            state={{ options, selected, setSelected }}
-          />
+          <Container>
+            <TopRow>
+              <HelpChip tooltip={{ text: HELP_TEXT, size: 0.6 }} size={1.2} />
+              <BuyButton onClick={() => openBaselineLink(selected.token?.address ?? '')}>
+                Purchase $ONYX ↗
+              </BuyButton>
+            </TopRow>
+            <Tabs>
+              <TabButton onClick={() => switchTab('DEPOSIT')} disabled={tab === 'DEPOSIT'}>
+                Deposit
+              </TabButton>
+              <TabButton onClick={() => switchTab('WITHDRAW')} disabled={tab === 'WITHDRAW'}>
+                Withdraw
+              </TabButton>
+              <TabButton
+                onClick={() => switchTab('QUEUE')}
+                disabled={tab === 'QUEUE'}
+                style={{ borderRight: 'none' }}
+              >
+                Queue
+              </TabButton>
+            </Tabs>
+            {tab === 'QUEUE' ? (
+              <Queue
+                actions={{
+                  claim: claimTx,
+                  cancel: cancelTx,
+                }}
+                data={{ myReceipts, othersReceipts, config, account }}
+                utils={utils}
+              />
+            ) : (
+              <Swap
+                actions={{
+                  approve: approveTx,
+                  deposit: depositTx,
+                  withdraw: withdrawTx,
+                }}
+                data={{ config, inventory: account.inventories ?? [] }}
+                state={{ mode: tab, options, selected, setSelected }}
+              />
+            )}
+          </Container>
         )}
-        <Overlay right={0.6} top={12.5}>
-          <IconButton
-            img={showQueue ? TriggerIcons.eyeOpen : TriggerIcons.eyeClosed}
-            onClick={() => setShowQueue(!showQueue)}
-          />
-        </Overlay>
-        <Queue
-          actions={{
-            claim: claimTx,
-            cancel: cancelTx,
-          }}
-          data={{ myReceipts, othersReceipts, config, account }}
-          isVisible={showQueue}
-          utils={utils}
-        />
       </ModalWrapper>
     );
   },
 };
+
+/////////////////
+// STYLES
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1vh;
+`;
+
+const TopRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.6vw;
+`;
+
+const BuyButton = styled.button`
+  border: 0.1vw solid #9c9;
+  border-radius: 0.4vw;
+  background: #eefaee;
+  color: #383;
+  padding: 0.3vw 0.6vw;
+  font-family: Pixel;
+  font-size: 0.7vw;
+  cursor: pointer;
+  pointer-events: auto;
+  transition:
+    background 0.12s,
+    border-color 0.12s;
+  &:hover {
+    background: #dff5df;
+    border-color: #6b6;
+  }
+`;
+
+const Tabs = styled.div`
+  border: solid 0.15vw black;
+  border-radius: 0.3vw 0.3vw 0 0;
+  width: 100%;
+  background-color: white;
+  display: flex;
+  flex-flow: row nowrap;
+`;
+
+const TabButton = styled.button`
+  border: none;
+  border-right: solid black 0.15vw;
+  padding: 0.5vw;
+  flex: 1 1 0;
+  color: black;
+  font-family: Pixel;
+  font-size: 0.9vw;
+  text-align: center;
+  cursor: pointer;
+  &:hover {
+    background-color: #ddd;
+  }
+  &:disabled {
+    background-color: #b2b2b2;
+    cursor: default;
+    pointer-events: none;
+  }
+`;

--- a/packages/client/src/app/components/modals/tokenPortal/constants.ts
+++ b/packages/client/src/app/components/modals/tokenPortal/constants.ts
@@ -1,24 +1,34 @@
-export const HELP_TEXT = [
-  'You can deposit and withdraw supported',
-  'ERC20 tokens through the Token Portal.',
-  '\n',
-  'Once deposited, assets are converted into',
-  'in-world items you can freely spend and use.',
-  'Deposited assets are available instantly,',
-  'but withdrawals generate a pending Receipt',
-  'which can be claimed after a delay (1wk atm).',
-  '\n',
-  'Import and Export taxes apply (1% + 1)',
-  'are non-refundable and subject to change.',
-  '\n',
-  'Thank you for your patronage ^^',
-  '\n',
-  '---',
-  '\n',
-  'In all seriousness, the withdrawal delay is',
-  'a safety measure, and the plan is to use fees',
-  'as an economic heuristic to lower the delay',
-  'for honest players. This mechanism remains',
-  'unsolved and is open to discussion in the',
-  'community Discord.',
-];
+import { PortalConfigs } from 'app/cache/config';
+
+// tooltip copy for the header help chip. taxes and delay read from the live
+// portal config so the numbers can never drift from what the world charges
+export const getHelpText = (config: PortalConfigs) => {
+  const imp = config.tax.import;
+  const exp = config.tax.export;
+  const delayDays = (config.delay ?? 0) / 86400;
+  return [
+    'You can deposit and withdraw supported',
+    'ERC20 tokens through the Token Portal.',
+    '\n',
+    'Once deposited, assets are converted into',
+    'in-world items you can freely spend and use.',
+    'Deposited assets are available instantly,',
+    'but withdrawals generate a pending Receipt',
+    `which can be claimed after a delay (~${delayDays.toFixed(0)}d atm).`,
+    '\n',
+    `Import tax: ${imp.rate * 100}% + ${imp.flat} flat per deposit.`,
+    `Export tax: ${exp.rate * 100}% + ${exp.flat} flat per withdrawal.`,
+    'Taxes are non-refundable and subject to change.',
+    '\n',
+    'Thank you for your patronage ^^',
+    '\n',
+    '---',
+    '\n',
+    'In all seriousness, the withdrawal delay is',
+    'a safety measure, and the plan is to use fees',
+    'as an economic heuristic to lower the delay',
+    'for honest players. This mechanism remains',
+    'unsolved and is open to discussion in the',
+    'community Discord.',
+  ];
+};

--- a/packages/client/src/app/components/modals/tokenPortal/queue/Queue.tsx
+++ b/packages/client/src/app/components/modals/tokenPortal/queue/Queue.tsx
@@ -9,8 +9,6 @@ import { Table } from './table/Table';
 export const Queue = ({
   actions,
   data,
-
-  isVisible,
   utils,
 }: {
   actions: {
@@ -23,8 +21,6 @@ export const Queue = ({
     config: Configs;
     account: Account;
   };
-
-  isVisible: boolean;
   utils: {
     getItemByIndex: (index: number) => Item;
     getAccountByID: (id: EntityID) => Account;
@@ -34,21 +30,22 @@ export const Queue = ({
   // DISPLAY
 
   return (
-    <Container isVisible={isVisible}>
+    <Container>
       <Table actions={actions} data={data} utils={utils} />
     </Container>
   );
 };
 
-const Container = styled.div<{ isVisible: boolean }>`
+const Container = styled.div`
   position: relative;
-  display: ${({ isVisible }) => (isVisible ? 'flex' : 'none')};
-  border-top: 0.15vw solid black;
+  display: flex;
+  border: 0.12vw solid #ddd;
+  border-radius: 0.6vw;
   width: 100%;
 
   flex-flow: column nowrap;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
 
-  overflow-y: hidden;
+  overflow: hidden;
 `;

--- a/packages/client/src/app/components/modals/tokenPortal/queue/table/Table.tsx
+++ b/packages/client/src/app/components/modals/tokenPortal/queue/table/Table.tsx
@@ -154,13 +154,21 @@ export const Table = ({
 const Container = styled.div`
   position: relative;
   width: 100%;
+  max-height: 42vh;
   flex-flow: column nowrap;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
   overflow-y: auto;
 
-  scrollbar-width: none;
+  scrollbar-width: thin;
+  scrollbar-color: #b6b6b6 transparent;
   &::-webkit-scrollbar {
-    display: none;
+    width: 0.3vw;
+    background: transparent;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: #b6b6b6;
+    border-radius: 0.3vw;
+    background-clip: padding-box;
   }
 `;

--- a/packages/client/src/app/components/modals/tokenPortal/queue/table/Table.tsx
+++ b/packages/client/src/app/components/modals/tokenPortal/queue/table/Table.tsx
@@ -158,4 +158,9 @@ const Container = styled.div`
   justify-content: center;
   align-items: center;
   overflow-y: auto;
+
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;

--- a/packages/client/src/app/components/modals/tokenPortal/queue/table/Table.tsx
+++ b/packages/client/src/app/components/modals/tokenPortal/queue/table/Table.tsx
@@ -160,15 +160,8 @@ const Container = styled.div`
   align-items: center;
   overflow-y: auto;
 
-  scrollbar-width: thin;
-  scrollbar-color: #b6b6b6 transparent;
+  scrollbar-width: none;
   &::-webkit-scrollbar {
-    width: 0.3vw;
-    background: transparent;
-  }
-  &::-webkit-scrollbar-thumb {
-    background-color: #b6b6b6;
-    border-radius: 0.3vw;
-    background-clip: padding-box;
+    display: none;
   }
 `;

--- a/packages/client/src/app/components/modals/tokenPortal/swap/Swap.tsx
+++ b/packages/client/src/app/components/modals/tokenPortal/swap/Swap.tsx
@@ -1,17 +1,24 @@
-import { ChangeEvent, KeyboardEvent, useState } from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 
 import { PortalConfigs } from 'app/cache/config';
 import { getInventoryBalance } from 'app/cache/inventory';
-import { IconListButton, IconListButtonOption, Text, TextTooltip } from 'app/components/library';
+import { Popover, StepButton, Text } from 'app/components/library';
 import { IconButton } from 'app/components/library/buttons';
 import { useTokens } from 'app/stores';
-import { ArrowIcons } from 'assets/images/icons/arrows';
 import { TokenIcons } from 'assets/images/tokens';
 import { Inventory, Item } from 'network/shapes';
 import { playClick } from 'utils/sounds';
 import { getNeededDeposit, getResultWithdraw, getSwapRate } from '../utils';
 import { Mode } from './types';
+
+// pastel action colors, shared with the FundOperator and Pool modals
+const GREEN = '#C2F0C2';
+const RED = '#F8D6D6';
+
+// floor to a safe non-negative integer. guards negatives / non-finite so a bad
+// amount can never reach the tx builders
+const safeAmt = (v: number) => (!Number.isFinite(v) || v < 0 ? 0 : Math.floor(v));
 
 export const Swap = ({
   actions,
@@ -28,6 +35,7 @@ export const Swap = ({
     inventory: Inventory[];
   };
   state: {
+    mode: Mode;
     options: Item[];
     selected: Item;
     setSelected: (item: Item) => void;
@@ -35,222 +43,443 @@ export const Swap = ({
 }) => {
   const { approve, deposit, withdraw } = actions;
   const { config, inventory } = data;
-  const { options, selected, setSelected } = state;
+  const { mode, options, selected, setSelected } = state;
   // hardcoded for now to just onyx
   const { allowance: onyxAllowance, balance: onyxBalance } = useTokens((s) => s.onyx);
 
-  const [mode, setMode] = useState<Mode>('DEPOSIT');
   const [amt, setAmt] = useState<number>(0);
-
-  /////////////////
-  // INTERACTION
-
-  // toggle between depositing and withdrawing
-  const toggleMode = () => {
-    if (mode === 'DEPOSIT') setMode('WITHDRAW');
-    else setMode('DEPOSIT');
-  };
-
-  // adjust and clean the Want amounts in the trade offer in respoonse to a form change
-  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const quantityStr = event.target.value.replace(/[^\d.]/g, '');
-    const rawQuantity = parseInt(quantityStr.replaceAll(',', '') || '0');
-    const amt = cleanAmount(rawQuantity);
-    setAmt(amt);
-  };
-
-  // trigger the action when the user presses enter
-  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === 'Enter' && !isDisabled()) {
-      triggerAction();
-      playClick();
-    }
-  };
-
-  // get the action to perform based on the mode
-  const triggerAction = () => {
-    if (mode === 'DEPOSIT') {
-      const neededAmt = getNeededDeposit(config, amt);
-      const tokenAmt = neededAmt / getSwapRate(selected);
-      if (tokenAmt > onyxAllowance) approve(selected, tokenAmt);
-      else deposit(selected, amt, neededAmt);
-    } else {
-      withdraw(selected, amt);
-    }
-  };
 
   /////////////////
   // INTERPRETATION
 
-  // clean input balances within min/max bounds, based on mode
-  const cleanAmount = (raw: number) => {
-    let max = Number.MAX_SAFE_INTEGER;
-    if (mode === 'WITHDRAW') max = getInventoryBalance(inventory, selected.index);
-    else max = getTokenBalance(selected) * getSwapRate(selected);
-    return Math.max(0, Math.min(max, raw));
-  };
+  const rate = getSwapRate(selected); // item units per 1 token
+  const scale = selected.token?.scale ?? 0;
+  const itemBalance = getInventoryBalance(inventory, selected.index);
+  const tokenBalanceUnits = Math.trunc(onyxBalance * rate); // wallet balance in item units
 
-  // generate the selectable list of ERC20 items
-  const getItemOptions = (): IconListButtonOption[] => {
-    return options.map((item) => ({
-      text: item.name,
-      image: item.image,
-      onClick: () => setSelected(item),
-    }));
-  };
+  // deposit: the largest receivable amount whose taxed cost fits the wallet.
+  // getNeededDeposit = floor((amt+flat)/(1-rate)) <= wallet units
+  const maxDeposit = Math.max(
+    0,
+    Math.floor(tokenBalanceUnits * (1 - config.tax.import.rate)) - config.tax.import.flat
+  );
+  const maxAmt = mode === 'DEPOSIT' ? maxDeposit : itemBalance;
 
-  // get the conversion rate from item balance to token balance with tax applied
-  const getTokenConversion = (amt: number) => {
-    let converted = 0;
-    if (mode === 'DEPOSIT') converted = getNeededDeposit(config, amt);
-    else converted = getResultWithdraw(config, amt);
-    return converted / getSwapRate(selected);
-  };
+  const neededUnits = getNeededDeposit(config, amt); // item units the deposit consumes
+  const receivedUnits = getResultWithdraw(config, amt); // item units a withdrawal pays out
+  const tokenAmt = (mode === 'DEPOSIT' ? neededUnits : receivedUnits) / rate;
 
-  // get the token balance of the selected item
-  // NOTE: hardcoded to onyx for now
-  const getTokenBalance = (item: Item) => {
-    const scale = getSwapRate(item);
-    return (1.0 * Math.trunc(onyxBalance * scale)) / scale;
-  };
+  const needsApproval = mode === 'DEPOSIT' && neededUnits / rate > onyxAllowance;
+  const insufficient = amt > maxAmt;
+  const zeroOutput = mode === 'WITHDRAW' && amt > 0 && receivedUnits <= 0;
+  const blocked = amt <= 0 || insufficient || zeroOutput;
 
   /////////////////
-  // DISPLAY
+  // ACTIONS
 
-  // get the action text of the submission button
-  const getActionText = () => {
+  const triggerAction = () => {
+    if (blocked) return;
     if (mode === 'DEPOSIT') {
-      const tokenAmt = amt / getSwapRate(selected);
-      if (tokenAmt > onyxAllowance) return 'Approve';
-      else return 'Deposit';
-    } else return 'Withdraw';
-  };
-
-  // get the icon for the Mode toggle
-  const getModeIcon = (mode: Mode) => {
-    if (mode === 'DEPOSIT') return ArrowIcons.left;
-    else return ArrowIcons.right;
-  };
-
-  // get the tooltip for the tax rate
-  const getRateTooltip = () => {
-    const swapRate = getSwapRate(selected);
-    if (mode === 'DEPOSIT') {
-      const { flat, rate: taxRate } = config.tax.import;
-      const taxAmt = Math.floor(amt * taxRate) + flat;
-      const effectiveTaxRate = (100 * taxAmt) / amt;
-
-      return [
-        `The base conversion rate from $ONYX to ${selected.name} is 1:${swapRate}`,
-        `\n`,
-        `A tax rate of ${taxRate * 100}% (rounded down) is applied to the converted item balance. As well as a flat fee of ${flat} unit(s) per deposit.`,
-        `\n`,
-        `This will result in a total import tax of ${taxAmt} unit(s) or ${effectiveTaxRate.toFixed(2)}% of the total deposit.`,
-      ];
-    } else if (mode === 'WITHDRAW') {
-      const { flat, rate: taxRate } = config.tax.export;
-      const taxAmt = Math.floor(amt * taxRate) + flat;
-      const effectiveTaxRate = (100 * taxAmt) / amt;
-
-      return [
-        `The base conversion rate from ${selected.name} to $ONYX is ${swapRate}:1`,
-        `\n`,
-        `A tax rate of ${taxRate * 100}% (rounded down) is applied to the withdrawn item balance. As well as a flat fee of ${flat} unit(s) per withdrawal.`,
-        `\n`,
-        `This will result in a total export tax of ${taxAmt} unit(s) or ${effectiveTaxRate.toFixed(2)}% of the total withdrawal.`,
-      ];
+      if (needsApproval) approve(selected, neededUnits / rate);
+      else deposit(selected, amt, neededUnits);
+    } else {
+      withdraw(selected, amt);
     }
-    return [];
-  };
-
-  const isDisabled = () => {
-    if (amt === 0) return true;
+    setAmt(0);
   };
 
   /////////////////
   // DISPLAY
+
+  const taxCfg = mode === 'DEPOSIT' ? config.tax.import : config.tax.export;
+  const delayDays = (config.delay ?? 0) / 86400;
+
+  const actionText = () => {
+    if (insufficient) return mode === 'DEPOSIT' ? 'insufficient $ONYX' : 'insufficient balance';
+    if (zeroOutput) return 'amount too small';
+    if (mode === 'DEPOSIT') return needsApproval ? `approve $ONYX` : 'deposit';
+    return 'withdraw';
+  };
+
+  const renderPicker = () => (
+    <Popover
+      fullWidth
+      content={
+        <PickerList>
+          {options.map((item) => (
+            <PickerItem
+              key={item.index}
+              onClick={() => {
+                playClick();
+                setSelected(item);
+                setAmt(0);
+              }}
+            >
+              <Sprite src={item.image} />
+              <Text size={0.85}>{item.name}</Text>
+            </PickerItem>
+          ))}
+        </PickerList>
+      }
+    >
+      <PickerTrigger onClick={() => playClick()}>
+        <PickerLabel>
+          <Sprite src={selected.image} />
+          <Text size={1}>{selected.name}</Text>
+        </PickerLabel>
+        <Caret>▾</Caret>
+      </PickerTrigger>
+    </Popover>
+  );
+
+  const itemCard = (
+    <SideBlock>
+      <HeadRow>
+        <Text size={0.95}>
+          {mode === 'DEPOSIT' ? `You're receiving (in-game)` : `You're withdrawing (in-game)`}
+        </Text>
+        <MaxLabel
+          onClick={() => {
+            playClick();
+            setAmt(maxAmt);
+          }}
+          title='fill max'
+        >
+          {mode === 'DEPOSIT' ? `max: ${maxAmt}` : `balance: ${itemBalance}`}
+        </MaxLabel>
+      </HeadRow>
+      <TradeCard>
+        <ItemBlockBox>
+          <BigSprite src={selected.image} alt={selected.name} />
+          <ItemName>{selected.name}</ItemName>
+        </ItemBlockBox>
+        <AmountBox value={amt} set={setAmt} max={maxAmt} />
+      </TradeCard>
+    </SideBlock>
+  );
+
+  const tokenCard = (
+    <SideBlock>
+      <HeadRow>
+        <Text size={0.95}>
+          {mode === 'DEPOSIT' ? `You're paying (wallet)` : `You're receiving (wallet)`}
+        </Text>
+        <Text size={0.75} color='#999'>
+          wallet: {onyxBalance.toFixed(scale > 0 ? 2 : 0)} $ONYX
+        </Text>
+      </HeadRow>
+      <TradeCard>
+        <ItemBlockBox>
+          <BigSprite src={TokenIcons.onyx} alt='$ONYX' />
+          <ItemName>$ONYX</ItemName>
+        </ItemBlockBox>
+        <OutputField>{amt > 0 ? `~${tokenAmt.toFixed(scale)}` : '0'}</OutputField>
+      </TradeCard>
+    </SideBlock>
+  );
 
   return (
-    <Container>
-      <Row>
-        <Column>
-          <IconListButton
-            img={selected.image}
-            scale={4.2}
-            options={getItemOptions()}
-            balance={getInventoryBalance(inventory, selected.index)}
-            tooltip={{ text: [`Select an item to ${mode}`] }}
-          />
-          <Input type='text' value={amt} onChange={handleInputChange} onKeyDown={handleKeyDown} />
-        </Column>
-        <Column style={{ width: '6vw' }}>
-          <Text size={0.9}>{mode}</Text>
-          <IconButton img={getModeIcon(mode)} onClick={toggleMode} />
-          <TextTooltip text={getRateTooltip()} size={0.6} maxWidth={24}>
-            <Text size={0.6}>{`(${getSwapRate(selected)}:1)`}</Text>
-          </TextTooltip>
-        </Column>
-        <Column>
-          <IconButton
-            img={TokenIcons.onyx} // hardcoded for now
-            scale={4.2}
-            balance={getTokenBalance(selected)}
-            onClick={() => {}}
-            disabled
-          />
-          <Input type='text' value={getTokenConversion(amt)} disabled />
-        </Column>
-      </Row>
+    <Section>
+      {renderPicker()}
+      {mode === 'DEPOSIT' ? (
+        <>
+          {tokenCard}
+          {itemCard}
+        </>
+      ) : (
+        <>
+          {itemCard}
+          {tokenCard}
+        </>
+      )}
+
+      <Info>
+        <Text size={0.72} color='#888'>
+          rate 1 $ONYX = {rate} {selected.name} · {mode === 'DEPOSIT' ? 'import' : 'export'} tax{' '}
+          {taxCfg.rate * 100}% + {taxCfg.flat} flat
+        </Text>
+        {mode === 'WITHDRAW' && (
+          <Text size={0.72} color='#888'>
+            withdrawals unlock after ~{delayDays.toFixed(0)}d · claim from the Queue tab
+          </Text>
+        )}
+        {mode === 'DEPOSIT' && needsApproval && amt > 0 && (
+          <Text size={0.72} color='#888'>
+            approval required before depositing
+          </Text>
+        )}
+        {zeroOutput && (
+          <Text size={0.72} color='#b23b3b'>
+            ⚠ amount too small: taxes consume the entire withdrawal
+          </Text>
+        )}
+      </Info>
+
       <IconButton
-        text={getActionText()}
-        scale={3}
+        fullWidth
+        scale={2.6}
+        color={blocked ? RED : GREEN}
+        disabled={blocked}
         onClick={triggerAction}
-        disabled={isDisabled()}
+        text={actionText()}
       />
-    </Container>
+    </Section>
   );
 };
 
-const Container = styled.div`
-  width: 100%;
-  gap: 1.2vw;
-  padding: 3.6vw 0.6vw 1.2vw 0.6vw;
+/////////////////
+// SUBCOMPONENTS
 
+// gas-modal-style amount control: centered input flanked by press-and-hold
+// steppers, with a MAX chip. `max` clamps typing and the steppers
+const AmountBox = ({ value, set, max }: { value: number; set: (n: number) => void; max: number }) => {
+  const [focused, setFocused] = useState(false);
+  const cap = (n: number) => Math.min(n, max);
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const v = e.target.value;
+    if (v === '') return set(0);
+    if (/^\d+$/.test(v)) set(cap(safeAmt(Number(v))));
+  };
+  return (
+    <AmountRow>
+      <StepButton label='-' onStep={() => set(safeAmt(value - 1))} />
+      <AmountField
+        type='text'
+        inputMode='numeric'
+        placeholder={focused ? 'amount' : '0'}
+        value={value === 0 ? '' : String(value)}
+        onChange={onChange}
+        // clear on focus so a click starts a fresh number (mirrors FundOperator)
+        onFocus={() => {
+          setFocused(true);
+          set(0);
+        }}
+        onBlur={() => setFocused(false)}
+        style={{ pointerEvents: 'auto' }}
+      />
+      <StepButton label='+' onStep={() => set(cap(safeAmt(value + 1)))} />
+      <MaxChip
+        onClick={() => {
+          playClick();
+          set(max);
+        }}
+      >
+        MAX
+      </MaxChip>
+    </AmountRow>
+  );
+};
+
+/////////////////
+// STYLES
+
+const Section = styled.div`
   display: flex;
-  flex-flow: column nowrap;
-  justify-content: center;
-  align-items: center;
+  flex-direction: column;
+  gap: 1vh;
 `;
 
-const Row = styled.div`
-  width: 100%;
+const SideBlock = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5vh;
+`;
+
+const HeadRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   gap: 0.6vw;
-
-  display: flex;
-  flex-flow: row nowrap;
-  justify-content: space-around;
-  align-items: center;
+  padding: 0 0.2vw;
 `;
 
-const Column = styled.div`
-  gap: 0.6vw;
-
-  display: flex;
-  flex-flow: column nowrap;
-  justify-content: center;
-  align-items: center;
+const MaxLabel = styled.div`
+  font-family: Pixel;
+  font-size: 0.75vw;
+  color: #999;
+  cursor: pointer;
+  pointer-events: auto;
+  &:hover {
+    color: #333;
+    text-decoration: underline;
+  }
 `;
 
-const Input = styled.input`
-  border-radius: 0.45vw;
-  background-color: #eee;
-  width: 9vw;
-  height: 100%;
+const TradeCard = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8vw;
+  border: 0.12vw solid #ddd;
+  border-radius: 0.6vw;
+  padding: 0.7vw 0.8vw;
+`;
 
-  padding: 0.3vw;
+const ItemBlockBox = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5vw;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+`;
 
-  color: black;
-  font-size: 1vw;
-  line-height: 1.5vw;
+const BigSprite = styled.img`
+  width: 2.6vw;
+  height: 2.6vw;
+  image-rendering: pixelated;
+  user-drag: none;
+`;
+
+const ItemName = styled.div`
+  flex: 1;
+  min-width: 0;
+  font-family: Pixel;
+  font-size: 0.95vw;
+  color: #333;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const AmountRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.4vw;
+  flex-shrink: 0;
+  width: 16vw;
+`;
+
+const AmountField = styled.input`
+  flex: 1;
+  min-width: 0;
+  background: #fafafa;
+  border: 0.12vw solid #ccc;
+  border-radius: 0.5vw;
+  color: #333;
+  height: 2.4vw;
+  padding: 0.5vw 0.4vw;
+
+  font-family: Pixel;
+  font-size: 1.05vw;
   text-align: center;
+  caret-color: transparent;
+  cursor: pointer;
+
+  &::selection {
+    background: transparent;
+  }
+  &::placeholder {
+    color: #bbb;
+  }
+
+  &:focus {
+    border-color: #a0c0e8;
+    background: #fff9e0;
+    outline: none;
+  }
+`;
+
+const OutputField = styled.div`
+  flex-shrink: 0;
+  width: 11vw;
+  height: 2.4vw;
+  background: #f4f4f4;
+  border: 0.12vw solid #e0e0e0;
+  border-radius: 0.5vw;
+  color: #555;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  font-family: Pixel;
+  font-size: 1.05vw;
+`;
+
+const Info = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.4vh;
+  padding: 0 0.2vw;
+`;
+
+const MaxChip = styled.button`
+  flex-shrink: 0;
+  height: 1.8vw;
+  padding: 0 0.5vw;
+  border: 0.1vw solid #ccc;
+  border-radius: 0.4vw;
+  background: #fafafa;
+  color: #555;
+  font-family: Pixel;
+  font-size: 0.65vw;
+  cursor: pointer;
+  pointer-events: auto;
+  transition:
+    background 0.12s,
+    border-color 0.12s;
+  &:hover {
+    background: #e8f0fe;
+    border-color: #a0c0e8;
+  }
+`;
+
+/////////////////
+// PICKER
+
+const PickerTrigger = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6vw;
+  width: 100%;
+  border: 0.15vw solid black;
+  border-radius: 0.5vw;
+  background: #fff;
+  padding: 0.4vw 0.8vw;
+  cursor: pointer;
+  pointer-events: auto;
+  &:hover {
+    background: #f2f2f2;
+  }
+`;
+
+const PickerLabel = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5vw;
+`;
+
+const Caret = styled.div`
+  font-size: 0.8vw;
+  color: #666;
+`;
+
+const Sprite = styled.img`
+  width: 1.6vw;
+  height: 1.6vw;
+  image-rendering: pixelated;
+  user-drag: none;
+`;
+
+const PickerList = styled.div`
+  display: flex;
+  flex-direction: column;
+  background: #fff;
+  border: 0.15vw solid black;
+  border-radius: 0.5vw;
+  overflow: hidden;
+`;
+
+const PickerItem = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5vw;
+  padding: 0.5vw 0.8vw;
+  cursor: pointer;
+  pointer-events: auto;
+  &:hover {
+    background: #f2f2f2;
+  }
 `;

--- a/packages/client/src/app/components/modals/tokenPortal/swap/Swap.tsx
+++ b/packages/client/src/app/components/modals/tokenPortal/swap/Swap.tsx
@@ -11,9 +11,8 @@ import { playClick } from 'utils/sounds';
 import { getNeededDeposit, getResultWithdraw, getSwapRate } from '../utils';
 import { Mode } from './types';
 
-// pastel action colors, shared with the FundOperator and Pool modals
+// pastel action color, shared with the FundOperator and Pool modals
 const GREEN = '#C2F0C2';
-const RED = '#F8D6D6';
 
 // floor to a safe non-negative integer. guards negatives / non-finite so a bad
 // amount can never reach the tx builders
@@ -176,7 +175,7 @@ export const Swap = ({
       </Info>
 
       <ActionButton
-        $color={blocked ? RED : GREEN}
+        $color={GREEN}
         disabled={blocked}
         onClick={() => {
           playClick();
@@ -262,8 +261,7 @@ const ActionButton = styled.button<{ $color: string }>`
   background: ${({ $color }) => $color};
   padding: 0.6vw;
   font-family: Pixel;
-  font-size: 1vw;
-  font-weight: bold;
+  font-size: 0.9vw;
   color: black;
   cursor: pointer;
   pointer-events: auto;
@@ -271,9 +269,9 @@ const ActionButton = styled.button<{ $color: string }>`
     filter: brightness(0.95);
   }
   &:disabled {
+    background: #bbb;
     cursor: default;
     pointer-events: none;
-    opacity: 0.7;
   }
 `;
 

--- a/packages/client/src/app/components/modals/tokenPortal/swap/Swap.tsx
+++ b/packages/client/src/app/components/modals/tokenPortal/swap/Swap.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 import { PortalConfigs } from 'app/cache/config';
 import { getInventoryBalance } from 'app/cache/inventory';
 import { StepButton, Text } from 'app/components/library';
-import { IconButton } from 'app/components/library/buttons';
 import { useTokens } from 'app/stores';
 import { TokenIcons } from 'assets/images/tokens';
 import { Inventory, Item } from 'network/shapes';
@@ -105,21 +104,9 @@ export const Swap = ({
         <Text size={0.95}>
           {mode === 'DEPOSIT' ? `You're receiving (in-game)` : `You're withdrawing (in-game)`}
         </Text>
-        {mode === 'WITHDRAW' ? (
-          <MaxLabel
-            onClick={() => {
-              playClick();
-              setAmt(maxAmt);
-            }}
-            title='fill max'
-          >
-            balance: {itemBalance}
-          </MaxLabel>
-        ) : (
-          <Text size={0.75} color='#999'>
-            balance: {itemBalance}
-          </Text>
-        )}
+        <Text size={0.75} color='#999'>
+          balance: {itemBalance}
+        </Text>
       </HeadRow>
       <TradeCard>
         <ItemBlockBox>
@@ -141,21 +128,9 @@ export const Swap = ({
         <Text size={0.95}>
           {mode === 'DEPOSIT' ? `You're paying (wallet)` : `You're receiving (wallet)`}
         </Text>
-        {mode === 'DEPOSIT' ? (
-          <MaxLabel
-            onClick={() => {
-              playClick();
-              setAmt(maxAmt);
-            }}
-            title='fill max'
-          >
-            wallet: {onyxBalance.toFixed(scale > 0 ? 2 : 0)} $ONYX
-          </MaxLabel>
-        ) : (
-          <Text size={0.75} color='#999'>
-            wallet: {onyxBalance.toFixed(scale > 0 ? 2 : 0)} $ONYX
-          </Text>
-        )}
+        <Text size={0.75} color='#999'>
+          wallet: {onyxBalance.toFixed(scale > 0 ? 2 : 0)} $ONYX
+        </Text>
       </HeadRow>
       <TradeCard>
         <ItemBlockBox>
@@ -200,14 +175,16 @@ export const Swap = ({
         )}
       </Info>
 
-      <IconButton
-        fullWidth
-        scale={2.6}
-        color={blocked ? RED : GREEN}
+      <ActionButton
+        $color={blocked ? RED : GREEN}
         disabled={blocked}
-        onClick={triggerAction}
-        text={actionText()}
-      />
+        onClick={() => {
+          playClick();
+          triggerAction();
+        }}
+      >
+        {actionText()}
+      </ActionButton>
     </Section>
   );
 };
@@ -278,15 +255,25 @@ const HeadRow = styled.div`
   padding: 0 0.2vw;
 `;
 
-const MaxLabel = styled.div`
+const ActionButton = styled.button<{ $color: string }>`
+  width: 100%;
+  border: 0.15vw solid black;
+  border-radius: 0.45vw;
+  background: ${({ $color }) => $color};
+  padding: 0.6vw;
   font-family: Pixel;
-  font-size: 0.75vw;
-  color: #999;
+  font-size: 1vw;
+  font-weight: bold;
+  color: black;
   cursor: pointer;
   pointer-events: auto;
   &:hover {
-    color: #333;
-    text-decoration: underline;
+    filter: brightness(0.95);
+  }
+  &:disabled {
+    cursor: default;
+    pointer-events: none;
+    opacity: 0.7;
   }
 `;
 

--- a/packages/client/src/app/components/modals/tokenPortal/swap/Swap.tsx
+++ b/packages/client/src/app/components/modals/tokenPortal/swap/Swap.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import { PortalConfigs } from 'app/cache/config';
 import { getInventoryBalance } from 'app/cache/inventory';
-import { Popover, StepButton, Text } from 'app/components/library';
+import { StepButton, Text } from 'app/components/library';
 import { IconButton } from 'app/components/library/buttons';
 import { useTokens } from 'app/stores';
 import { TokenIcons } from 'assets/images/tokens';
@@ -36,14 +36,12 @@ export const Swap = ({
   };
   state: {
     mode: Mode;
-    options: Item[];
     selected: Item;
-    setSelected: (item: Item) => void;
   };
 }) => {
   const { approve, deposit, withdraw } = actions;
   const { config, inventory } = data;
-  const { mode, options, selected, setSelected } = state;
+  const { mode, selected } = state;
   // hardcoded for now to just onyx
   const { allowance: onyxAllowance, balance: onyxBalance } = useTokens((s) => s.onyx);
 
@@ -91,7 +89,6 @@ export const Swap = ({
   /////////////////
   // DISPLAY
 
-  const taxCfg = mode === 'DEPOSIT' ? config.tax.import : config.tax.export;
   const delayDays = (config.delay ?? 0) / 86400;
 
   const actionText = () => {
@@ -100,37 +97,6 @@ export const Swap = ({
     if (mode === 'DEPOSIT') return needsApproval ? `approve $ONYX` : 'deposit';
     return 'withdraw';
   };
-
-  const renderPicker = () => (
-    <Popover
-      fullWidth
-      content={
-        <PickerList>
-          {options.map((item) => (
-            <PickerItem
-              key={item.index}
-              onClick={() => {
-                playClick();
-                setSelected(item);
-                setAmt(0);
-              }}
-            >
-              <Sprite src={item.image} />
-              <Text size={0.85}>{item.name}</Text>
-            </PickerItem>
-          ))}
-        </PickerList>
-      }
-    >
-      <PickerTrigger onClick={() => playClick()}>
-        <PickerLabel>
-          <Sprite src={selected.image} />
-          <Text size={1}>{selected.name}</Text>
-        </PickerLabel>
-        <Caret>▾</Caret>
-      </PickerTrigger>
-    </Popover>
-  );
 
   const itemCard = (
     <SideBlock>
@@ -180,7 +146,6 @@ export const Swap = ({
 
   return (
     <Section>
-      {renderPicker()}
       {mode === 'DEPOSIT' ? (
         <>
           {tokenCard}
@@ -194,13 +159,9 @@ export const Swap = ({
       )}
 
       <Info>
-        <Text size={0.72} color='#888'>
-          rate 1 $ONYX = {rate} {selected.name} · {mode === 'DEPOSIT' ? 'import' : 'export'} tax{' '}
-          {taxCfg.rate * 100}% + {taxCfg.flat} flat
-        </Text>
         {mode === 'WITHDRAW' && (
           <Text size={0.72} color='#888'>
-            withdrawals unlock after ~{delayDays.toFixed(0)}d · claim from the Queue tab
+            withdrawals unlock after ~{delayDays.toFixed(0)}d · claim from the queue below
           </Text>
         )}
         {mode === 'DEPOSIT' && needsApproval && amt > 0 && (
@@ -425,61 +386,3 @@ const MaxChip = styled.button`
   }
 `;
 
-/////////////////
-// PICKER
-
-const PickerTrigger = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.6vw;
-  width: 100%;
-  border: 0.15vw solid black;
-  border-radius: 0.5vw;
-  background: #fff;
-  padding: 0.4vw 0.8vw;
-  cursor: pointer;
-  pointer-events: auto;
-  &:hover {
-    background: #f2f2f2;
-  }
-`;
-
-const PickerLabel = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 0.5vw;
-`;
-
-const Caret = styled.div`
-  font-size: 0.8vw;
-  color: #666;
-`;
-
-const Sprite = styled.img`
-  width: 1.6vw;
-  height: 1.6vw;
-  image-rendering: pixelated;
-  user-drag: none;
-`;
-
-const PickerList = styled.div`
-  display: flex;
-  flex-direction: column;
-  background: #fff;
-  border: 0.15vw solid black;
-  border-radius: 0.5vw;
-  overflow: hidden;
-`;
-
-const PickerItem = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 0.5vw;
-  padding: 0.5vw 0.8vw;
-  cursor: pointer;
-  pointer-events: auto;
-  &:hover {
-    background: #f2f2f2;
-  }
-`;

--- a/packages/client/src/app/components/modals/tokenPortal/swap/Swap.tsx
+++ b/packages/client/src/app/components/modals/tokenPortal/swap/Swap.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { PortalConfigs } from 'app/cache/config';
@@ -45,7 +45,9 @@ export const Swap = ({
   // hardcoded for now to just onyx
   const { allowance: onyxAllowance, balance: onyxBalance } = useTokens((s) => s.onyx);
 
+  // DEPOSIT: whole $ONYX paid in. WITHDRAW: item units withdrawn.
   const [amt, setAmt] = useState<number>(0);
+  useEffect(() => setAmt(0), [mode]);
 
   /////////////////
   // INTERPRETATION
@@ -53,23 +55,24 @@ export const Swap = ({
   const rate = getSwapRate(selected); // item units per 1 token
   const scale = selected.token?.scale ?? 0;
   const itemBalance = getInventoryBalance(inventory, selected.index);
-  const tokenBalanceUnits = Math.trunc(onyxBalance * rate); // wallet balance in item units
 
-  // deposit: the largest receivable amount whose taxed cost fits the wallet.
-  // getNeededDeposit = floor((amt+flat)/(1-rate)) <= wallet units
-  const maxDeposit = Math.max(
+  // deposit: most items receivable within the $ONYX typed in.
+  // getNeededDeposit rounds, so walk down until the charge fits
+  const unitsIn = amt * rate;
+  let receiveItems = Math.max(
     0,
-    Math.floor(tokenBalanceUnits * (1 - config.tax.import.rate)) - config.tax.import.flat
+    Math.floor(unitsIn * (1 - config.tax.import.rate)) - config.tax.import.flat
   );
-  const maxAmt = mode === 'DEPOSIT' ? maxDeposit : itemBalance;
+  while (receiveItems > 0 && getNeededDeposit(config, receiveItems) > unitsIn) receiveItems--;
+  const depositUnits = getNeededDeposit(config, receiveItems); // exact units charged
 
-  const neededUnits = getNeededDeposit(config, amt); // item units the deposit consumes
   const receivedUnits = getResultWithdraw(config, amt); // item units a withdrawal pays out
-  const tokenAmt = (mode === 'DEPOSIT' ? neededUnits : receivedUnits) / rate;
 
-  const needsApproval = mode === 'DEPOSIT' && neededUnits / rate > onyxAllowance;
+  const maxAmt = mode === 'DEPOSIT' ? Math.floor(onyxBalance) : itemBalance;
+  const needsApproval = mode === 'DEPOSIT' && depositUnits / rate > onyxAllowance;
   const insufficient = amt > maxAmt;
-  const zeroOutput = mode === 'WITHDRAW' && amt > 0 && receivedUnits <= 0;
+  const zeroOutput =
+    amt > 0 && (mode === 'DEPOSIT' ? receiveItems <= 0 : receivedUnits <= 0);
   const blocked = amt <= 0 || insufficient || zeroOutput;
 
   /////////////////
@@ -78,8 +81,8 @@ export const Swap = ({
   const triggerAction = () => {
     if (blocked) return;
     if (mode === 'DEPOSIT') {
-      if (needsApproval) approve(selected, neededUnits / rate);
-      else deposit(selected, amt, neededUnits);
+      if (needsApproval) approve(selected, depositUnits / rate);
+      else deposit(selected, receiveItems, depositUnits);
     } else {
       withdraw(selected, amt);
     }
@@ -88,8 +91,6 @@ export const Swap = ({
 
   /////////////////
   // DISPLAY
-
-  const delayDays = (config.delay ?? 0) / 86400;
 
   const actionText = () => {
     if (insufficient) return mode === 'DEPOSIT' ? 'insufficient $ONYX' : 'insufficient balance';
@@ -104,22 +105,32 @@ export const Swap = ({
         <Text size={0.95}>
           {mode === 'DEPOSIT' ? `You're receiving (in-game)` : `You're withdrawing (in-game)`}
         </Text>
-        <MaxLabel
-          onClick={() => {
-            playClick();
-            setAmt(maxAmt);
-          }}
-          title='fill max'
-        >
-          {mode === 'DEPOSIT' ? `max: ${maxAmt}` : `balance: ${itemBalance}`}
-        </MaxLabel>
+        {mode === 'WITHDRAW' ? (
+          <MaxLabel
+            onClick={() => {
+              playClick();
+              setAmt(maxAmt);
+            }}
+            title='fill max'
+          >
+            balance: {itemBalance}
+          </MaxLabel>
+        ) : (
+          <Text size={0.75} color='#999'>
+            balance: {itemBalance}
+          </Text>
+        )}
       </HeadRow>
       <TradeCard>
         <ItemBlockBox>
           <BigSprite src={selected.image} alt={selected.name} />
           <ItemName>{selected.name}</ItemName>
         </ItemBlockBox>
-        <AmountBox value={amt} set={setAmt} max={maxAmt} />
+        {mode === 'WITHDRAW' ? (
+          <AmountBox value={amt} set={setAmt} max={maxAmt} />
+        ) : (
+          <OutputField>{amt > 0 ? `${receiveItems}` : '0'}</OutputField>
+        )}
       </TradeCard>
     </SideBlock>
   );
@@ -130,16 +141,34 @@ export const Swap = ({
         <Text size={0.95}>
           {mode === 'DEPOSIT' ? `You're paying (wallet)` : `You're receiving (wallet)`}
         </Text>
-        <Text size={0.75} color='#999'>
-          wallet: {onyxBalance.toFixed(scale > 0 ? 2 : 0)} $ONYX
-        </Text>
+        {mode === 'DEPOSIT' ? (
+          <MaxLabel
+            onClick={() => {
+              playClick();
+              setAmt(maxAmt);
+            }}
+            title='fill max'
+          >
+            wallet: {onyxBalance.toFixed(scale > 0 ? 2 : 0)} $ONYX
+          </MaxLabel>
+        ) : (
+          <Text size={0.75} color='#999'>
+            wallet: {onyxBalance.toFixed(scale > 0 ? 2 : 0)} $ONYX
+          </Text>
+        )}
       </HeadRow>
       <TradeCard>
         <ItemBlockBox>
           <BigSprite src={TokenIcons.onyx} alt='$ONYX' />
           <ItemName>$ONYX</ItemName>
         </ItemBlockBox>
-        <OutputField>{amt > 0 ? `~${tokenAmt.toFixed(scale)}` : '0'}</OutputField>
+        {mode === 'DEPOSIT' ? (
+          <AmountBox value={amt} set={setAmt} max={maxAmt} />
+        ) : (
+          <OutputField>
+            {amt > 0 ? `~${(receivedUnits / rate).toFixed(scale)}` : '0'}
+          </OutputField>
+        )}
       </TradeCard>
     </SideBlock>
   );
@@ -159,11 +188,6 @@ export const Swap = ({
       )}
 
       <Info>
-        {mode === 'WITHDRAW' && (
-          <Text size={0.72} color='#888'>
-            withdrawals unlock after ~{delayDays.toFixed(0)}d · claim from the queue below
-          </Text>
-        )}
         {mode === 'DEPOSIT' && needsApproval && amt > 0 && (
           <Text size={0.72} color='#888'>
             approval required before depositing
@@ -171,7 +195,7 @@ export const Swap = ({
         )}
         {zeroOutput && (
           <Text size={0.72} color='#b23b3b'>
-            ⚠ amount too small: taxes consume the entire withdrawal
+            ⚠ amount too small: taxes consume it entirely
           </Text>
         )}
       </Info>

--- a/packages/client/src/app/components/modals/tokenPortal/utils.ts
+++ b/packages/client/src/app/components/modals/tokenPortal/utils.ts
@@ -1,6 +1,5 @@
 import { PortalConfigs } from 'app/cache/config';
 import { Item } from 'network/shapes';
-import { playClick } from 'utils/sounds';
 
 // get the necessary deposit balance to achieve the target balance (in item units)
 export const getNeededDeposit = (config: PortalConfigs, target: number) => {
@@ -17,13 +16,11 @@ export const getResultWithdraw = (config: PortalConfigs, target: number) => {
   return Math.max(0, amt);
 };
 
-// open the link to Baseline Markets ONYX listing
-// just hardcoded for now
+// open the link to Baseline Markets ONYX listing. hardcoded for now; the
+// caller (IconButton) owns the click sound
 export const openBaselineLink = (address: string) => {
-  const urlOld = `https://legacy.baseline.markets/trade/yominet/${address}`;
-  const urlNew = `https://app.baseline.markets/tokens/1/0x80Ea38D56E262457D73c0d8dFe027AE8925821e2`;
-  https: window.open(urlNew, '_blank');
-  playClick();
+  const url = `https://app.baseline.markets/tokens/1/0x80Ea38D56E262457D73c0d8dFe027AE8925821e2`;
+  window.open(url, '_blank');
 };
 
 // get the balance conversion rate from token to item

--- a/packages/client/src/app/components/modals/trading/orderbook/SearchBar.tsx
+++ b/packages/client/src/app/components/modals/trading/orderbook/SearchBar.tsx
@@ -193,6 +193,11 @@ const SuggestBox = styled.div`
   max-height: 12vw;
   overflow: auto;
   z-index: 1;
+
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const Suggest = styled.div`

--- a/packages/client/src/constants/dialogue/data/npcDialogues.csv
+++ b/packages/client/src/constants/dialogue/data/npcDialogues.csv
@@ -77,7 +77,7 @@ We accept the chosen offering. Let it be done.",,
 ,,,,,
 050001,Rob,robtransparent2.png,"You lookin’ at something, buddy? I’m busy here. Dancin’ on a pole takes a lot of focus.",050002,
 050002,Rob,robtransparent2.png,"If you want to make any chit-chat, keep it short.",,"051001, 051002, 051003, 051004, 051005"
-051001,Rob,,Ask about You,051001,
+051001,Rob,,Ask about You,050003,
 051002,Rob,,Ask about Buddy,050006,
 051003,Rob,,Ask about Dancing,050008,
 051004,Rob,,Ask about Chit-chat,050010,

--- a/packages/client/src/constants/items.ts
+++ b/packages/client/src/constants/items.ts
@@ -9,3 +9,4 @@ export const OBOL_INDEX = 1015;
 export const HOLY_DUST_INDEX = 11011;
 export const RESPEC_POTION_INDEX = 11403;
 export const WONDER_EGG_INDEX = 21003;
+export const SEXTANT_INDEX = 100004;


### PR DESCRIPTION
## dialogue modal
- typewriter renders the full text with unrevealed characters hidden: word wrap is computed once, so lines never reflow mid-reveal and the modal holds its size while typing
- typing speed 30 to 20ms per char
- clicking the text box fills it instantly while typing; once complete, a click advances to the next step (same as the next arrow)
- fixed: skip no longer leaks into the next step of the same dialogue
- fixed: typing no longer restarts on unrelated re-renders (retrigger was keyed on Date.now() per render)
- layout: navigation arrows moved into their own row (no more overlap with text), bottom section is one content-driven band (sprite left, quests vertically centered right), modal height fits content via truncate
- account modal stats: reputation bars now scale 0 to 500
- modals fade out on close (0.3s) instead of vanishing (dialogue auto-close on goodbye was the visible offender; ghost clicks already blocked by pointer-events)

## map modal
- zone switcher in the header: explore other maps without moving
- canon names per vaitarana: Lost Woods, Sanctuary Caves; zone 4 reads ?????? by design (lethe) and only appears in the dropdown when the player holds the Aetheric Sextant
- viewing another map disables tile-walk and auto travel; show node only offered on rooms that have a node
- opening the modal always shows the map the player is standing in
- selecting your current zone returns the view to follow mode; the active zone is disabled in the switcher

## verification
- typecheck error set identical to main baseline (no new errors)
- vercel build command (pnpm -F client build:prod) green
- visually verified on the urco preview deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Manually select and browse other zones from the map (follow-player mode remains available).
  - Enhanced dialogue controls: click dialogue text to skip/advance when ready.
  - Token Portal modal upgraded with deposit/withdraw tabs, queue mode, and improved help text.
- **Bug Fixes**
  - When viewing a different zone, room movement and “Auto Travel” are disabled.
  - Dialogue step/history and multi-column completion now behave more reliably.
- **Improvements**
  - Faction progress bars updated to the new range.
  - Quest dialogue typewriter now uses more stable segment-based rendering (updated default speed).
  - Many modal and panel scroll areas/poppers now hide scrollbars for a cleaner UI.
  - Modal fade-out now stays mounted briefly for smoother transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->