### PR TITLE
onboarding(p0.1): bridge prefill defaults to Zevana live price + operator gas

### DIFF
--- a/packages/client/src/app/components/modals/bridge/Bridge.tsx
+++ b/packages/client/src/app/components/modals/bridge/Bridge.tsx
@@ -473,7 +473,9 @@ export const BridgeModal: UIComponent = {
           if (requestedChain && !DISABLED_SOURCE_CHAIN_IDS.has(requestedChain.chainId)) {
             setSourceChain(requestedChain);
           }
-          if (routeRequest.amount_in) {
+          // the built routeRequest always carries a default amount_in — only
+          // honor it when the caller explicitly passed one
+          if (routeRequest.amount_in && details.explicitAmountIn) {
             try {
               setAmount(formatEther(BigInt(routeRequest.amount_in)));
               amountTouchedRef.current = true;

--- a/packages/client/src/app/components/modals/bridge/Bridge.tsx
+++ b/packages/client/src/app/components/modals/bridge/Bridge.tsx
@@ -492,12 +492,18 @@ export const BridgeModal: UIComponent = {
     // (~0.01 total). purely a prefill: anything the user (or a route
     // request) typed wins, and mid-bridge the amount is never changed
     const vendorSystemAddress = getSystemAddr(world, components, NEWBIE_VENDOR_BUY_SYSTEM_ID);
+    const vendorSystemKnown = !!vendorSystemAddress && vendorSystemAddress !== DEAD_ADDRESS;
     const { data: vendorPriceData } = useReadContract({
       address: vendorSystemAddress,
       abi: NewbieVendorBuySystem.abi as Abi,
       functionName: 'calcPrice',
-      query: { enabled: isOpen && !!vendorSystemAddress },
+      query: { enabled: isOpen && vendorSystemKnown },
     });
+    // a fresh open takes the live default again — edits only stick for the
+    // session the modal is open
+    useEffect(() => {
+      if (!isOpen) amountTouchedRef.current = false;
+    }, [isOpen]);
     useEffect(() => {
       if (amountTouchedRef.current || phaseRef.current !== 'idle') return;
       const price = parseBigIntSafe(vendorPriceData);

--- a/packages/client/src/app/components/modals/bridge/Bridge.tsx
+++ b/packages/client/src/app/components/modals/bridge/Bridge.tsx
@@ -1,7 +1,13 @@
 import { useWallets } from '@privy-io/react-auth';
 import { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
-import { formatEther, parseEther } from 'viem';
+import { formatEther, parseEther, type Abi } from 'viem';
+import { useReadContract } from 'wagmi';
+
+import NewbieVendorBuySystem from 'abi/NewbieVendorBuySystem.json';
+import { useLayers } from 'app/root/hooks';
+import { getSystemAddr } from 'network/shapes/utils';
+import { parseBigIntSafe } from 'utils/numbers';
 
 import { ModalHeader, ModalWrapper } from 'app/components/library';
 import { UIComponent } from 'app/root/types';
@@ -48,12 +54,20 @@ import {
   waitForWalletChain,
 } from './helpers/utils';
 
+const NEWBIE_VENDOR_BUY_SYSTEM_ID = 'system.newbievendor.buy';
+// headroom on top of Zevana's live price so the operator wallet can be funded
+// for a first session (~300+ moves) — targets a ~0.01 total default
+const PREFILL_OPERATOR_GAS_HEADROOM = 3_000_000_000_000_000n; // 0.003 ETH
+const PREFILL_ROUNDING_STEP = 100_000_000_000_000n; // round default up to 0.0001
+
 export const BridgeModal: UIComponent = {
   id: 'BridgeModal',
   Render: () => {
     /////////////////
     // PREPARATION
 
+    const { network } = useLayers();
+    const { world, components } = network;
     const isOpen = useVisibility((s) => s.modals.bridge);
     const setBridgeProcessActive = useVisibility((s) => s.setBridgeProcessActive);
     const selectedAddress = useNetwork((s) => s.selectedAddress);
@@ -65,6 +79,9 @@ export const BridgeModal: UIComponent = {
         SOURCE_CHAIN_OPTIONS[0]
     );
     const [amount, setAmount] = useState('0.001');
+    // tracks whether the amount came from the user (or an explicit route
+    // prefill) — the Zevana-price default must never clobber those
+    const amountTouchedRef = useRef(false);
 
     const [sourceBalance, setSourceBalance] = useState<bigint>(0n);
     const [yomiBalance, setYomiBalance] = useState<bigint>(0n);
@@ -459,6 +476,7 @@ export const BridgeModal: UIComponent = {
           if (routeRequest.amount_in) {
             try {
               setAmount(formatEther(BigInt(routeRequest.amount_in)));
+              amountTouchedRef.current = true;
             } catch {
               // ignore malformed prefills
             }
@@ -469,6 +487,25 @@ export const BridgeModal: UIComponent = {
       window.addEventListener(BRIDGE_OPEN_REQUEST_EVENT, handleOpen);
       return () => window.removeEventListener(BRIDGE_OPEN_REQUEST_EVENT, handleOpen);
     }, []);
+
+    // default the amount to Zevana's live price + operator gas headroom
+    // (~0.01 total). purely a prefill: anything the user (or a route
+    // request) typed wins, and mid-bridge the amount is never changed
+    const vendorSystemAddress = getSystemAddr(world, components, NEWBIE_VENDOR_BUY_SYSTEM_ID);
+    const { data: vendorPriceData } = useReadContract({
+      address: vendorSystemAddress,
+      abi: NewbieVendorBuySystem.abi as Abi,
+      functionName: 'calcPrice',
+      query: { enabled: isOpen && !!vendorSystemAddress },
+    });
+    useEffect(() => {
+      if (amountTouchedRef.current || phaseRef.current !== 'idle') return;
+      const price = parseBigIntSafe(vendorPriceData);
+      if (price === undefined) return;
+      const total = price + PREFILL_OPERATOR_GAS_HEADROOM;
+      const rounded = ((total + PREFILL_ROUNDING_STEP - 1n) / PREFILL_ROUNDING_STEP) * PREFILL_ROUNDING_STEP;
+      setAmount(formatEther(rounded));
+    }, [vendorPriceData]);
 
     useEffect(() => {
       if (!accountReady) return;
@@ -596,7 +633,10 @@ export const BridgeModal: UIComponent = {
               isBridging={isBridging}
               accountReady={accountReady}
               hasSufficientSourceBalance={hasSufficientSourceBalance}
-              onAmountChange={setAmount}
+              onAmountChange={(value) => {
+                amountTouchedRef.current = true;
+                setAmount(value);
+              }}
               onSourceChainChange={setSourceChain}
               onSubmit={startBridge}
             />

--- a/packages/client/src/app/components/modals/bridge/helpers/api.ts
+++ b/packages/client/src/app/components/modals/bridge/helpers/api.ts
@@ -65,6 +65,9 @@ type BridgeServiceStatus = {
 
 export type BridgeOpenerOptions = {
   routeRequest?: Partial<BridgeRouteRequest>;
+  // set by triggerBridgeModal when the caller explicitly passed amount_in;
+  // the built routeRequest always carries a default amount otherwise
+  explicitAmountIn?: boolean;
 };
 
 export function isBridgeOpenDetail(value: unknown): value is BridgeOpenerOptions {

--- a/packages/client/src/app/components/validators/AccountRegistrar/Registration.tsx
+++ b/packages/client/src/app/components/validators/AccountRegistrar/Registration.tsx
@@ -2,7 +2,6 @@ import InfoIcon from '@mui/icons-material/Info';
 import { EntityID } from 'engine/recs';
 import { useState } from 'react';
 import styled from 'styled-components';
-import { parseEther } from 'viem';
 
 import { IconButton, TextTooltip } from 'app/components/library';
 import { triggerBridgeModal } from 'app/triggers';
@@ -15,8 +14,6 @@ import { abbreviateAddress } from 'utils/address';
 import { playSignup } from 'utils/sounds';
 import { Description, Row } from './components';
 import { Section } from './components/shared';
-
-const REGISTRATION_BRIDGE_AMOUNT_WEI = parseEther(GasConstants.Empty.toString()).toString();
 
 export const Registration = ({
   address,
@@ -139,13 +136,9 @@ export const Registration = ({
               <IconButton
                 scale={3}
                 img={MenuIcons.kami}
-                onClick={() =>
-                  triggerBridgeModal({
-                    routeRequest: {
-                      amount_in: REGISTRATION_BRIDGE_AMOUNT_WEI,
-                    },
-                  })
-                }
+                // no amount prefill — the bridge modal defaults to Zevana's
+                // live price + operator gas headroom
+                onClick={() => triggerBridgeModal()}
                 text='Bridge ETH to Yominet'
               />
             </Description>

--- a/packages/client/src/app/triggers/triggerBridgeModal.ts
+++ b/packages/client/src/app/triggers/triggerBridgeModal.ts
@@ -14,6 +14,9 @@ export const triggerBridgeModal = (options: BridgeOpenerOptions = {}) => {
     new CustomEvent<BridgeOpenerOptions>(BRIDGE_OPEN_REQUEST_EVENT, {
       detail: {
         routeRequest: buildBridgeRouteRequest(options.routeRequest),
+        // the built request always carries a default amount_in — only callers
+        // that explicitly passed one should override the modal's own default
+        explicitAmountIn: options.routeRequest?.amount_in != null,
       },
     })
   );

--- a/packages/client/src/network/shapes/utils/addresses.ts
+++ b/packages/client/src/network/shapes/utils/addresses.ts
@@ -1,5 +1,4 @@
 import { EntityID, HasValue, QueryFragment, runQuery, World } from 'engine/recs';
-import { result } from 'lodash';
 import { Components } from 'network/';
 import { Address, getAddress, pad } from 'viem';
 import { hashArgs } from './IDs';
@@ -28,7 +27,7 @@ export const getSystemAddr = (world: World, components: Components, sysID: strin
   const { Systems } = components;
   const toQuery: QueryFragment[] = [HasValue(Systems, { value: genID(sysID) })];
   const results = Array.from(runQuery(toQuery));
-  if (result.length > 0) {
+  if (results.length > 0) {
     const address = getAddress(pad(world.entities[results[0]], { size: 20 }));
     AddressStore.set(sysID, address);
     return world.entities[results[0]] as Address;


### PR DESCRIPTION
## What
Replaces the bridge modal's static `0.001` amount default with **Zevana's live price** (`NewbieVendorBuySystem.calcPrice()`) **+ 0.003 ETH operator-gas headroom**, rounded up to the nearest 0.0001 — lands at ~0.01 total at current prices, per the KW onboarding fix-list P0.1.

## Behavior
- Pure prefill: fully editable, gates nothing.
- User-typed amounts and route-request prefills are never clobbered (tracked via `amountTouchedRef`).
- Amount is never changed once a bridge is in flight (`phaseRef` guard).
- Price read is `enabled` only while the modal is open; on any read failure the old 0.001 default stands.

## Testing
- `vite build` (production) passes on this branch.
- Live `calcPrice()` on prod world returns 0.007 ETH → default renders 0.01.

🤖 Generated with [Claude Code](https://claude.com/claude-code)