### PR TITLE
onboarding(p0.2): operator funding default no longer eats the kami budget

### DIFF
--- a/packages/client/src/app/components/modals/FundOperator.tsx
+++ b/packages/client/src/app/components/modals/FundOperator.tsx
@@ -19,10 +19,10 @@ import { playClick, playFund } from 'utils/sounds';
 const MIN_AMOUNT_ETH = 0.00001;
 const ETH_INPUT_REGEX = /^\d*\.?\d{0,7}$/;
 
+// default tiers deliberately top out at Low (0.001, ~300+ moves) — a bigger
+// default eats the owner's kami budget during onboarding. soft default only;
+// the player can type any amount
 const FUND_TIERS = [
-  GasConstants.Full,    // 0.01
-  GasConstants.Half,    // 0.005
-  GasConstants.Quarter, // 0.0025
   GasConstants.Low,     // 0.001
   GasConstants.Warning, // 0.0001
 ];

--- a/packages/client/src/app/components/validators/GasHarasser.tsx
+++ b/packages/client/src/app/components/validators/GasHarasser.tsx
@@ -19,10 +19,10 @@ import { playFund, playSuccess } from 'utils/sounds';
 const MIN_FUND_ETH = 0.00001;
 const ETH_INPUT_REGEX = /^\d*\.?\d{0,7}$/;
 
+// default tiers deliberately top out at Low (0.001, ~300+ moves) — a bigger
+// default eats the owner's kami budget during onboarding. soft default only;
+// the player can type any amount. keep in sync with FundOperator.tsx
 const FUND_TIERS = [
-  GasConstants.Full,    // 0.01
-  GasConstants.Half,    // 0.005
-  GasConstants.Quarter, // 0.0025
   GasConstants.Low,     // 0.001
   GasConstants.Warning, // 0.0001
 ];


### PR DESCRIPTION
## What
KW fix-list P0.2. The fund-operator smart default previously picked the highest affordable tier (0.01 → 0.005 → …), which drained a fresh owner wallet below Zevana's kami price. The default now tops out at **Low (0.001 ETH, ~300+ txs of gas)**, falling back to Warning (0.0001).

Soft default only — typing any amount still wins (`hasEdited` guard unchanged).

## Testing
- `vite build` (production) passes.
- `FUND_TIERS` is only consumed by `getSmartDefault`; helper copy already reads correctly for 0.001 ("This should last you for a while").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated automatic ETH funding amounts to use more conservative default tiers.
  * Funding and refund suggestions now cap at the Low tier, with Warning remaining available for lower balances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->