### PR TITLE
onboarding(p1.4): bridge auto-advances new players to registration

### DIFF
--- a/packages/client/src/app/components/modals/bridge/Bridge.tsx
+++ b/packages/client/src/app/components/modals/bridge/Bridge.tsx
@@ -86,6 +86,7 @@ export const BridgeModal: UIComponent = {
     const previousWalletChainIdRef = useRef<string | null>(null);
     const closedDuringWalletPromptRef = useRef(false);
     const bridgeAbortRef = useRef<AbortController>(new AbortController());
+    const autoAdvanceTimerRef = useRef<number | null>(null);
 
     const setUpdates = (value: BridgeUpdateEntry[] | ((prev: BridgeUpdateEntry[]) => BridgeUpdateEntry[])) => {
       const next = typeof value === 'function' ? value(updatesRef.current) : value;
@@ -135,7 +136,15 @@ export const BridgeModal: UIComponent = {
       clearBridgePolling();
     };
 
+    const cancelAutoAdvance = () => {
+      if (autoAdvanceTimerRef.current !== null) {
+        window.clearTimeout(autoAdvanceTimerRef.current);
+        autoAdvanceTimerRef.current = null;
+      }
+    };
+
     const clearBridgeState = (bridging: boolean) => {
+      cancelAutoAdvance();
       bridgeAbortRef.current.abort();
       bridgeAbortRef.current = new AbortController();
       resetBridgeUiState();
@@ -361,7 +370,9 @@ export const BridgeModal: UIComponent = {
     // (topping up mid-game) keep the modal open
     const scheduleAutoAdvance = () => {
       if (queryAccountFromEmbedded(network)) return;
-      window.setTimeout(() => {
+      cancelAutoAdvance();
+      autoAdvanceTimerRef.current = window.setTimeout(() => {
+        autoAdvanceTimerRef.current = null;
         // callers reset phase to idle right after completion; anything else
         // means a new bridge attempt started during the delay
         if (phaseRef.current !== 'idle') return;
@@ -446,6 +457,7 @@ export const BridgeModal: UIComponent = {
     };
 
     const handleBridgeModalClose = () => {
+      cancelAutoAdvance(); // a manual close during the celebration wins
       if (!isOpen || phaseRef.current === 'idle') return true;
       if (phaseRef.current === 'awaitingApproval') {
         closedDuringWalletPromptRef.current = true;

--- a/packages/client/src/app/components/modals/bridge/Bridge.tsx
+++ b/packages/client/src/app/components/modals/bridge/Bridge.tsx
@@ -4,8 +4,10 @@ import styled from 'styled-components';
 import { formatEther, parseEther } from 'viem';
 
 import { ModalHeader, ModalWrapper } from 'app/components/library';
+import { useLayers } from 'app/root/hooks';
 import { UIComponent } from 'app/root/types';
 import { useNetwork, useVisibility } from 'app/stores';
+import { queryAccountFromEmbedded } from 'network/shapes/Account';
 import { getEvmWalletProvider, getInjectedWallet } from 'app/utils';
 import { MenuIcons } from 'assets/images/icons/menu';
 import { DEAD_ADDRESS } from 'constants/addresses';
@@ -48,13 +50,19 @@ import {
   waitForWalletChain,
 } from './helpers/utils';
 
+// how long the "Bridge Complete" celebration stays up before the modal
+// auto-advances a new player to the registration screen
+const AUTO_ADVANCE_DELAY_MS = 2500;
+
 export const BridgeModal: UIComponent = {
   id: 'BridgeModal',
   Render: () => {
     /////////////////
     // PREPARATION
 
+    const { network } = useLayers();
     const isOpen = useVisibility((s) => s.modals.bridge);
+    const setModals = useVisibility((s) => s.setModals);
     const setBridgeProcessActive = useVisibility((s) => s.setBridgeProcessActive);
     const selectedAddress = useNetwork((s) => s.selectedAddress);
     const { wallets } = useWallets();
@@ -348,6 +356,22 @@ export const BridgeModal: UIComponent = {
       if (persisted) saveBridgePolling({ ...persisted, updates: updatesRef.current, completed: true });
     };
 
+    // after a successful bridge, advance a new player to the registration
+    // screen instead of leaving them parked on the modal. existing accounts
+    // (topping up mid-game) keep the modal open
+    const scheduleAutoAdvance = () => {
+      if (queryAccountFromEmbedded(network)) return;
+      window.setTimeout(() => {
+        // callers reset phase to idle right after completion; anything else
+        // means a new bridge attempt started during the delay
+        if (phaseRef.current !== 'idle') return;
+        if (queryAccountFromEmbedded(network)) return;
+        setShouldResetOnNextOpen(true);
+        setBridgeProcessActive(false);
+        setModals({ bridge: false });
+      }, AUTO_ADVANCE_DELAY_MS);
+    };
+
     const waitForBridgeCompletion = async (
       pollingSourceChain: EVMChainOption,
       yominetStartBlock: number,
@@ -400,6 +424,7 @@ export const BridgeModal: UIComponent = {
           appendUpdate('success', `**Yominet** Tx: ${receivedOnYominet}`, `${DefaultChain.blockExplorers?.default.url}/tx/${receivedOnYominet}`);
           appendUpdate('celebrate', 'Bridge Complete Congratulations');
           persistCompletion();
+          scheduleAutoAdvance();
           return;
         }
       }


### PR DESCRIPTION
## What
KW fix-list P1.4. On successful bridge completion, a player **without an account** is auto-advanced to the registration (username) screen after a 2.5s "Bridge Complete" celebration — previously the modal just sat there and you had to X out to discover the next step.

## Behavior
- Fires on both the live polling path and the resume-after-reload path (both funnel through `waitForBridgeCompletion`).
- Existing accounts (topping up mid-game) keep the modal open — gated on `queryAccountFromEmbedded`.
- Bails if a new bridge attempt starts during the delay (phase guard), and re-checks account state at fire time.
- Uses the same close semantics as a manual X (reset-on-next-open + release bridge process), so the AccountRegistrar overlay takes over cleanly.

## Testing
- `vite build` (production) passes.
- Will conflict trivially with #2448 in the import block (both touch Bridge.tsx) — whichever merges second needs a 2-line rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic progression after a successful bridge completion on Yominet.
  * Bridge completion now closes the modal and advances after a brief delay when applicable.
* **Bug Fixes**
  * Improved bridge completion handling to avoid advancing for embedded accounts or when the modal is no longer active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->