### PR TITLE
onboarding(p1.7): hide dead pre-account menu chrome

### DIFF
--- a/packages/client/src/app/components/fixtures/menu/Left.tsx
+++ b/packages/client/src/app/components/fixtures/menu/Left.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 import { useLayers } from 'app/root/hooks';
 import { UIComponent } from 'app/root/types';
-import { useSelected, useVisibility } from 'app/stores';
+import { useAccount, useSelected, useVisibility } from 'app/stores';
 import { queryNodeByIndex } from 'network/shapes/Node';
 import {
   AccountMenuButton,
@@ -19,6 +19,9 @@ export const LeftMenuFixture: UIComponent = {
   Render: () => {
     const layers = useLayers();
     const menuVisible = useVisibility((s) => s.fixtures.menu);
+    // every button here is dead pre-account — hide until registration completes
+    const accountValidations = useAccount((s) => s.validations);
+    const accountReady = accountValidations.accountChecked && accountValidations.accountExists;
 
     /////////////////
     // PREPARATION
@@ -34,7 +37,7 @@ export const LeftMenuFixture: UIComponent = {
     // RENDER
 
     return (
-      <Wrapper style={{ display: menuVisible ? 'flex' : 'none' }}>
+      <Wrapper style={{ display: menuVisible && accountReady ? 'flex' : 'none' }}>
         <AccountMenuButton />
         <PartyMenuButton />
         <MapMenuButton />

--- a/packages/client/src/app/components/fixtures/menu/Right.tsx
+++ b/packages/client/src/app/components/fixtures/menu/Right.tsx
@@ -1,5 +1,5 @@
 import { UIComponent } from 'app/root/types';
-import { useVisibility } from 'app/stores';
+import { useAccount, useVisibility } from 'app/stores';
 import styled from 'styled-components';
 import {
   ChatMenuButton,
@@ -15,9 +15,14 @@ export const RightMenuFixture: UIComponent = {
   id: 'RightMenuFixture',
   Render: () => {
     const menuVisible = useVisibility((s) => s.fixtures.menu);
+    // pre-account, every button here is a no-op except More (Settings/Bridge/
+    // Help live inside) — hide the rest until registration completes
+    const accountValidations = useAccount((s) => s.validations);
+    const accountReady = accountValidations.accountChecked && accountValidations.accountExists;
+    const showFull = menuVisible && accountReady;
     return (
       <>
-        <Wrapper style={{ display: menuVisible ? 'flex' : 'none' }}>
+        <Wrapper style={{ display: showFull ? 'flex' : 'none' }}>
           <KamiSwapMenuButton />
           <TradingMenuButton />
           <CraftMenuButton />
@@ -26,7 +31,7 @@ export const RightMenuFixture: UIComponent = {
           <ChatMenuButton />
           <MoreMenuButton />
         </Wrapper>
-        <Wrapper style={{ display: menuVisible ? 'none' : 'flex' }}>
+        <Wrapper style={{ display: showFull ? 'none' : 'flex' }}>
           <MoreMenuButton />
         </Wrapper>
       </>


### PR DESCRIPTION
## What
KW fix-list P1.7. Before an account exists, every Left/Right menu button is a no-op ("dead pre-account chrome"). Both menu fixtures now gate on the account validations store (`accountChecked && accountExists`).

**Kept visible pre-account:** the More button — Settings, Bridge, and Help live inside it and are exactly what a pre-account player needs.

## Notes
- Uses the same `useAccount((s) => s.validations)` source the AccountRegistrar maintains, so visibility flips reactively the moment registration completes.
- During initial world sync (`accountChecked=false`) menus stay hidden briefly for existing players too — covered by the load screen.

## Testing
- `vite build` (production) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)