### PR TITLE
fix: adoption agency stock refreshes after purchases

### DIFF
--- a/packages/client/src/app/components/modals/kamiAdoptionAgency/KamiAdoptionAgency.tsx
+++ b/packages/client/src/app/components/modals/kamiAdoptionAgency/KamiAdoptionAgency.tsx
@@ -54,6 +54,9 @@ export const KamiAdoptionAgency: UIComponent = {
     const [completedAdoptionsByAddress, setCompletedAdoptionsByAddress] = useState<
       Record<string, boolean>
     >({});
+    // bumped to re-read the vendor pool — world/components are stable refs,
+    // so a memo keyed on them alone would show stale stock forever
+    const [stockTick, setStockTick] = useState(0);
 
     // close the modal when the player moves to a different room (movement is
     // possible while open — e.g. the map modal occupies a different zone).
@@ -71,9 +74,17 @@ export const KamiAdoptionAgency: UIComponent = {
       }, 1000);
       return () => clearInterval(timerID);
     }, [isModalOpen, accountEntity, world, components, setModals]);
+    // refresh the stock while the modal is open — catches other players'
+    // adoptions and pool rotations, not just our own purchase
+    useEffect(() => {
+      if (!isModalOpen) return;
+      setStockTick((t) => t + 1); // fresh read on every open
+      const timerID = setInterval(() => setStockTick((t) => t + 1), 2000);
+      return () => clearInterval(timerID);
+    }, [isModalOpen]);
     const displayedKamis = useMemo(() => {
       return getDisplayedKamiEntities().map((entity) => getKami(entity));
-    }, [world, components]);
+    }, [world, components, stockTick]);
     const ownerApi = apis.get(selectedAddress);
     const hasCompletedAdoption = useMemo(
       () => (selectedAddress ? !!completedAdoptionsByAddress[selectedAddress] : false),
@@ -147,6 +158,7 @@ export const KamiAdoptionAgency: UIComponent = {
           const didComplete = await didActionSucceed(actions.Action, transaction);
           if (didComplete && selectedAddress) {
             setCompletedAdoptionsByAddress((prev) => ({ ...prev, [selectedAddress]: true }));
+            setStockTick((t) => t + 1); // drop the adopted kami from the shelf
             refetchPrice();
           }
         } finally {


### PR DESCRIPTION
## What
Hand-testing a live adoption on the vls preview surfaced this: the Adoption Agency's kami grid is computed in a `useMemo` keyed on `[world, components]` — stable object references — so the displayed stock **never refreshed**: the adopted kami stayed on the shelf after purchase, and the grid stayed stale even across modal close/reopen.

## Fix
A `stockTick` state now re-reads the vendor pool:
- on every modal open,
- every 2s while open (catches other players' adoptions + display-cycle rotations),
- immediately after our own successful buy.

Interval only runs while the modal is open (same pattern as the existing room-change watcher in this file).

## Testing
- `vite build` (production) passes.
- Verified against the repro: adopt → bought kami drops from the shelf without reopening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adoption inventory now refreshes automatically while the agency modal is open.
  * Newly adopted Kamis are removed from the displayed inventory immediately after purchase.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->