### PR TITLE
onboarding(p1.5a): bridge poll timeout no longer lies about completion

### DIFF
--- a/packages/client/src/app/components/modals/bridge/Bridge.tsx
+++ b/packages/client/src/app/components/modals/bridge/Bridge.tsx
@@ -502,9 +502,15 @@ export const BridgeModal: UIComponent = {
         BigInt(persisted.expectedAmountOut),
         persisted.sourceTxHash,
         bridgeAbortRef.current.signal
-      ).finally(() => {
-        setBridgePhase('idle');
-      });
+      )
+        .catch(() => {
+          // transient RPC failure — keep the recovery path available
+          appendUpdate('meta', 'Could not check right now. Try again in a moment.');
+          setPollTimedOut(true);
+        })
+        .finally(() => {
+          setBridgePhase('idle');
+        });
     };
 
     const handleBridgeModalClose = () => {
@@ -619,9 +625,14 @@ export const BridgeModal: UIComponent = {
         BigInt(persisted.expectedAmountOut),
         persisted.sourceTxHash,
         bridgeAbortRef.current.signal
-      ).finally(() => {
-        setBridgePhase('idle');
-      });
+      )
+        .catch(() => {
+          // transient RPC failure on the resumed poll — surface the retry path
+          setPollTimedOut(true);
+        })
+        .finally(() => {
+          setBridgePhase('idle');
+        });
     }, [selectedAddress]);
 
     useEffect(() => {

--- a/packages/client/src/app/components/modals/bridge/Bridge.tsx
+++ b/packages/client/src/app/components/modals/bridge/Bridge.tsx
@@ -96,6 +96,8 @@ export const BridgeModal: UIComponent = {
     const [updates, _setUpdates] = useState<BridgeUpdateEntry[]>([]);
     const updatesRef = useRef<BridgeUpdateEntry[]>([]);
     const [shouldResetOnNextOpen, setShouldResetOnNextOpen] = useState(false);
+    // polling gave up but the bridge may still land — offers a manual re-check
+    const [pollTimedOut, setPollTimedOut] = useState(false);
     const phaseRef = useRef<BridgePhase>('idle');
     const previousWalletChainIdRef = useRef<string | null>(null);
     const closedDuringWalletPromptRef = useRef(false);
@@ -144,6 +146,7 @@ export const BridgeModal: UIComponent = {
     const resetBridgeUiState = () => {
       setUpdates([]);
       setShouldResetOnNextOpen(false);
+      setPollTimedOut(false);
       setBridgePhase('idle');
       previousWalletChainIdRef.current = null;
       closedDuringWalletPromptRef.current = false;
@@ -454,20 +457,50 @@ export const BridgeModal: UIComponent = {
         }
       }
 
+      // NOT persisted as completed: the transfer may still land — polling
+      // auto-resumes on reload, and the Check Again button re-checks in place
       if (sourceTransactionStatus === 'success') {
         appendUpdate(
-          'error',
-          `Source transaction confirmed on ${pollingSourceChain.label}, but no matching Yominet transfer has been observed yet. Please check again shortly.`
+          'meta',
+          `Source transaction confirmed on ${pollingSourceChain.label} — the Yominet transfer just hasn't been observed yet. It usually lands within minutes; hit Check Again below or come back later.`
         );
-        persistCompletion();
+        setPollTimedOut(true);
         return;
       }
 
       appendUpdate(
-        'error',
-        `Source transaction is still pending on ${pollingSourceChain.label}. Please check your wallet or explorer and try again shortly.`
+        'meta',
+        `Source transaction is still pending on ${pollingSourceChain.label}. Hit Check Again below once it confirms, or come back later.`
       );
-      persistCompletion();
+      setPollTimedOut(true);
+    };
+
+    // re-enter polling from the persisted bridge state (used by the Check
+    // Again button after a poll timeout)
+    const retryPolling = () => {
+      if (phaseRef.current !== 'idle') return;
+      const persisted = loadBridgePolling();
+      if (!persisted || persisted.selectedAddress !== selectedAddress) return;
+      const chain = SOURCE_CHAIN_OPTIONS.find((o) => o.chainId === persisted.sourceChainId);
+      if (
+        !chain ||
+        typeof persisted.expectedAmountOut !== 'string' ||
+        typeof persisted.yominetStartBlock !== 'number'
+      ) {
+        return;
+      }
+      setPollTimedOut(false);
+      appendUpdate('status', 'Checking for the Yominet transfer...');
+      setBridgePhase('submitted');
+      waitForBridgeCompletion(
+        chain,
+        persisted.yominetStartBlock,
+        BigInt(persisted.expectedAmountOut),
+        persisted.sourceTxHash,
+        bridgeAbortRef.current.signal
+      ).finally(() => {
+        setBridgePhase('idle');
+      });
     };
 
     const handleBridgeModalClose = () => {
@@ -686,6 +719,11 @@ export const BridgeModal: UIComponent = {
               onSubmit={startBridge}
             />
             <BridgeUpdates updates={updates} isOpen={isOpen} />
+            {pollTimedOut && !isBridging && (
+              <CheckAgainButton type='button' onClick={retryPolling}>
+                Check again
+              </CheckAgainButton>
+            )}
           </Content>
         </ModalWrapper>
       </BridgeOverlay>
@@ -696,6 +734,21 @@ const BridgeOverlay = styled.div`
   position: relative;
   z-index: 1000;
   height: 100%;
+`;
+
+const CheckAgainButton = styled.button`
+  align-self: center;
+  margin-top: 0.4vw;
+  padding: 0.35vw 1vw;
+  border: 0.15vw solid #000000;
+  border-radius: 0.5vw;
+  background-color: #d6e4f8;
+  font-size: 0.8vw;
+  font-weight: bold;
+  cursor: pointer;
+  &:hover {
+    background-color: #c2d8f5;
+  }
 `;
 
 const Content = styled.div`

--- a/packages/client/src/app/components/modals/bridge/Bridge.tsx
+++ b/packages/client/src/app/components/modals/bridge/Bridge.tsx
@@ -23,6 +23,7 @@ import {
   buildBridgeRouteRequest,
   fetchBridgeMsgs,
   fetchBridgeRoute,
+  fetchRoutableSourceChainIds,
   getBridgeServiceStatus,
   getNativeBalance,
   getSourceTransactionStatus,
@@ -98,6 +99,9 @@ export const BridgeModal: UIComponent = {
     const [shouldResetOnNextOpen, setShouldResetOnNextOpen] = useState(false);
     // polling gave up but the bridge may still land — offers a manual re-check
     const [pollTimedOut, setPollTimedOut] = useState(false);
+    // chains the router can actually route from right now (null = not probed
+    // yet, treat as all-routable). initia de-lists sources server-side
+    const [routableChainIds, setRoutableChainIds] = useState<Set<string> | null>(null);
     const phaseRef = useRef<BridgePhase>('idle');
     const previousWalletChainIdRef = useRef<string | null>(null);
     const closedDuringWalletPromptRef = useRef(false);
@@ -282,7 +286,19 @@ export const BridgeModal: UIComponent = {
       });
 
       appendUpdate('status', `Preparing route:\n**${sourceChain.label}** → **Yominet**...`);
-      const route = await fetchBridgeRoute(routeRequest);
+      let route;
+      try {
+        route = await fetchBridgeRoute(routeRequest);
+      } catch (error) {
+        if (signal.aborted) throw createBridgeAbortError();
+        if (error instanceof Error && error.message.includes('Route not found')) {
+          failBridge(
+            `No bridge route from **${sourceChain.label}** to Yominet right now — try Ethereum Mainnet.`
+          );
+          return null;
+        }
+        throw error;
+      }
       if (signal.aborted) throw createBridgeAbortError();
       const requiredChainAddresses = route.required_chain_addresses ?? [];
       const amountOut = typeof route.amount_out === 'string' ? route.amount_out : amountInWei;
@@ -641,6 +657,26 @@ export const BridgeModal: UIComponent = {
       }
     }, [isOpen, shouldResetOnNextOpen]);
 
+    // probe which source chains the router can currently route from, and
+    // steer the selection off a de-listed chain
+    useEffect(() => {
+      if (!isOpen) return;
+      let stale = false;
+      fetchRoutableSourceChainIds(SOURCE_CHAIN_OPTIONS).then((ids) => {
+        if (!stale) setRoutableChainIds(ids);
+      });
+      return () => {
+        stale = true;
+      };
+    }, [isOpen]);
+    useEffect(() => {
+      if (!routableChainIds || routableChainIds.has(sourceChain.chainId)) return;
+      const fallback = SOURCE_CHAIN_OPTIONS.find(
+        (o) => routableChainIds.has(o.chainId) && !DISABLED_SOURCE_CHAIN_IDS.has(o.chainId)
+      );
+      if (fallback && phaseRef.current === 'idle') setSourceChain(fallback);
+    }, [routableChainIds, sourceChain.chainId]);
+
     useEffect(() => {
       if (!isOpen) return;
       refreshBalances();
@@ -719,6 +755,7 @@ export const BridgeModal: UIComponent = {
           <Content>
             <BridgeForm
               sourceChain={sourceChain}
+              routableChainIds={routableChainIds}
               amount={amount}
               parsedAmount={parsedAmount}
               sourceBalance={sourceBalance}

--- a/packages/client/src/app/components/modals/bridge/BridgeForm.tsx
+++ b/packages/client/src/app/components/modals/bridge/BridgeForm.tsx
@@ -13,6 +13,8 @@ import {
 
 type BridgeFormProps = {
   sourceChain: EVMChainOption;
+  // chains the router can currently route from; null = not probed (all enabled)
+  routableChainIds: Set<string> | null;
   amount: string;
   parsedAmount: bigint | null;
   sourceBalance: bigint;
@@ -40,6 +42,7 @@ const getDisabledReason = (
 
 export const BridgeForm = ({
   sourceChain,
+  routableChainIds,
   amount,
   parsedAmount,
   sourceBalance,
@@ -73,12 +76,15 @@ export const BridgeForm = ({
         fullWidth
         scale={2.2}
         disabled={isBridging}
-        options={SOURCE_CHAIN_OPTIONS.map((option) => ({
-          text: option.label,
-          image: SOURCE_CHAIN_ICON_BY_CHAIN_ID[option.chainId],
-          disabled: DISABLED_SOURCE_CHAIN_IDS.has(option.chainId),
-          onClick: () => onSourceChainChange(option),
-        }))}
+        options={SOURCE_CHAIN_OPTIONS.map((option) => {
+          const unroutable = routableChainIds !== null && !routableChainIds.has(option.chainId);
+          return {
+            text: unroutable ? `${option.label} (unavailable)` : option.label,
+            image: SOURCE_CHAIN_ICON_BY_CHAIN_ID[option.chainId],
+            disabled: DISABLED_SOURCE_CHAIN_IDS.has(option.chainId) || unroutable,
+            onClick: () => onSourceChainChange(option),
+          };
+        })}
       />
       <Label>Destination Chain</Label>
       <DestinationText>Yominet</DestinationText>

--- a/packages/client/src/app/components/modals/bridge/helpers/api.ts
+++ b/packages/client/src/app/components/modals/bridge/helpers/api.ts
@@ -114,6 +114,34 @@ async function postRouterApi<T>(path: RouterApiPath, body: Record<string, unknow
   return response.json() as Promise<T>;
 }
 
+/// chain ids whose native asset the router can currently route. the router
+/// de-lists sources server-side by marking the asset hidden (e.g. arbitrum
+/// and base natives as of 2026-07) — probing live means the picker heals
+/// itself when initia re-enables a route. fails open so a flaky probe never
+/// bricks the picker.
+export async function fetchRoutableSourceChainIds(
+  options: { chainId: string; denom: string }[]
+): Promise<Set<string>> {
+  const all = new Set(options.map((o) => o.chainId));
+  try {
+    const ids = options.map((o) => o.chainId).join(',');
+    const response = await fetch(`${ROUTER_API_BASE_URL}/assets?chain_ids=${ids}`);
+    if (!response.ok) return all;
+    const data = (await response.json()) as {
+      chain_to_assets_map?: Record<string, { assets?: { denom?: string; hidden?: boolean }[] }>;
+    };
+    const routable = new Set<string>();
+    for (const option of options) {
+      const assets = data.chain_to_assets_map?.[option.chainId]?.assets ?? [];
+      const native = assets.find((a) => a.denom === option.denom);
+      if (native && !native.hidden) routable.add(option.chainId);
+    }
+    return routable.size > 0 ? routable : all;
+  } catch {
+    return all;
+  }
+}
+
 export async function fetchBridgeRoute(body: BridgeRouteRequest): Promise<BridgeRouteResponse> {
   const route = await postRouterApi<BridgeRouteResponse>('route', body);
   if (!route || typeof route !== 'object' || !Array.isArray(route.operations)) {

--- a/packages/client/src/app/components/modals/bridge/helpers/constants.ts
+++ b/packages/client/src/app/components/modals/bridge/helpers/constants.ts
@@ -57,7 +57,13 @@ export const SOURCE_CHAIN_OPTIONS: EVMChainOption[] = [
   },
 ];
 
-export const DISABLED_SOURCE_CHAIN_IDS = new Set(['10']);
+// 42161/8453 (2026-07): Initia's router de-listed arbitrum/base native ETH
+// (assets marked hidden; only USDC routes from those chains — verified against
+// router-api and Skip's global API). Our modal bridges ETH, so they're hard-
+// disabled until re-listed. The live routability probe (fetchRoutableSourceChainIds)
+// stays as a second layer and will show them enabled-again the release after
+// this set is pruned.
+export const DISABLED_SOURCE_CHAIN_IDS = new Set(['10', '42161', '8453']);
 
 ////////////////
 // DISPLAY

--- a/packages/client/src/app/components/modals/bridge/helpers/constants.ts
+++ b/packages/client/src/app/components/modals/bridge/helpers/constants.ts
@@ -79,6 +79,7 @@ export const MIN_BRIDGE_AMOUNT = 1_000_000_000_000n; // 0.000001 ETH
 
 export const POLL_INTERVAL_MS = 15_000;
 export const DEGRADED_POLL_INTERVAL_MS = 45_000;
-export const POLL_MAX_ATTEMPTS = 40;
+// 80 x 15s = 20 minutes — relays regularly exceed the old 10-minute window
+export const POLL_MAX_ATTEMPTS = 80;
 export const STATUS_RECHECK_EVERY_ATTEMPTS = 4;
 


### PR DESCRIPTION
## What
Fixes the bug velas hit twice hand-testing today: the bridge's 10-minute poller gave up, marked the session `completed:true`, and showed a permanent red "no matching Yominet transfer observed" error — **even after the funds arrived** (balance visibly updated next to the error).

## Changes
- **Timeouts no longer persist completion** — only true completion and source-tx reverts are terminal. On reload, polling auto-resumes from persisted state and picks up late-landing transfers.
- **"Check again" button** appears after a timeout — re-enters polling in place from the persisted bridge state (guarded against running during a new attempt).
- **Softer messaging** — timeout notes are `meta` tone ("usually lands within minutes; check again or come back later") instead of a red error implying failure.
- **Poll window doubled to 20 min** (80 × 15s) — today's relay took ~20 min against the old 10-min window.

## Notes
- Stacked on #2455 (both touch Bridge.tsx) — merge that first, then this is a clean ~60-line diff.
- Pre-existing sessions already stamped `completed:true` by the old code won't retro-heal (cosmetic only — funds unaffected).
- `vite build` (production) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)