### PR TITLE
feat(contracts): emit POOL_SYNC with pool reserves and LP supply

### DIFF
--- a/packages/contracts/src/libraries/LibPool.sol
+++ b/packages/contracts/src/libraries/LibPool.sol
@@ -300,6 +300,40 @@ library LibPool {
     );
   }
 
+  /// @notice emit the pool's post-action reserves and LP supply
+  /// @dev emits absolute state, never deltas. reserves can be inflated out of band
+  ///      (ItemTransferSystem and harvest tax both accept an arbitrary target id), so
+  ///      reading state here is what lets the next call self-correct rather than
+  ///      compound the drift. never accept these values from the caller.
+  function logSync(
+    IWorld world,
+    IUintComp comps,
+    uint256 poolID,
+    uint32 indexA,
+    uint32 indexB
+  ) public {
+    (uint32 lo, uint32 hi) = LibRegistry.sortIndices(indexA, indexB);
+    LibEmitter.emitEvent(world, "POOL_SYNC", syncEventSchema(), _encodeSync(comps, poolID, lo, hi));
+  }
+
+  function _encodeSync(
+    IUintComp comps,
+    uint256 poolID,
+    uint32 lo,
+    uint32 hi
+  ) internal view returns (bytes memory) {
+    IUintComp valComp = IUintComp(getAddrByID(comps, ValueCompID));
+    return
+      abi.encode(
+        poolID,
+        lo,
+        hi,
+        valComp.safeGet(LibInventory.genID(poolID, lo)),
+        valComp.safeGet(LibInventory.genID(poolID, hi)),
+        valComp.safeGet(poolID)
+      );
+  }
+
   function swapEventSchema() internal pure returns (uint8[] memory) {
     uint8[] memory _schema = new uint8[](6);
     _schema[0] = uint8(LibTypes.SchemaValue.UINT256); // accID
@@ -318,6 +352,17 @@ library LibPool {
     _schema[2] = uint8(LibTypes.SchemaValue.UINT256); // amtA
     _schema[3] = uint8(LibTypes.SchemaValue.UINT256); // amtB
     _schema[4] = uint8(LibTypes.SchemaValue.UINT256); // shares
+    return _schema;
+  }
+
+  function syncEventSchema() internal pure returns (uint8[] memory) {
+    uint8[] memory _schema = new uint8[](6);
+    _schema[0] = uint8(LibTypes.SchemaValue.UINT256); // poolID
+    _schema[1] = uint8(LibTypes.SchemaValue.UINT32); // indexA
+    _schema[2] = uint8(LibTypes.SchemaValue.UINT32); // indexB
+    _schema[3] = uint8(LibTypes.SchemaValue.UINT256); // reserveA
+    _schema[4] = uint8(LibTypes.SchemaValue.UINT256); // reserveB
+    _schema[5] = uint8(LibTypes.SchemaValue.UINT256); // totalSupply
     return _schema;
   }
 

--- a/packages/contracts/src/systems/PoolSystem.sol
+++ b/packages/contracts/src/systems/PoolSystem.sol
@@ -42,6 +42,7 @@ contract PoolSystem is System {
       minAmountOut
     );
     LibPool.logSwap(world, components, accID, poolID, indexIn, indexOut, amountIn, amountOut);
+    LibPool.logSync(world, components, poolID, indexIn, indexOut);
 
     // standard logging and tracking
     LibAccount.updateLastTs(components, accID);
@@ -78,6 +79,7 @@ contract PoolSystem is System {
       p
     );
     LibPool.logLiquidity(world, components, accID, poolID, true, amtA, amtB, liquidity);
+    LibPool.logSync(world, components, poolID, p.indexA, p.indexB);
 
     // standard logging and tracking
     LibAccount.updateLastTs(components, accID);
@@ -107,6 +109,7 @@ contract PoolSystem is System {
 
     (uint256 amtA, uint256 amtB) = LibPool.removeLiquidity(components, poolID, accID, p);
     LibPool.logLiquidity(world, components, accID, poolID, false, amtA, amtB, p.shares);
+    LibPool.logSync(world, components, poolID, p.indexA, p.indexB);
 
     // standard logging and tracking
     LibAccount.updateLastTs(components, accID);

--- a/packages/contracts/src/systems/_PoolRegistrySystem.sol
+++ b/packages/contracts/src/systems/_PoolRegistrySystem.sol
@@ -59,6 +59,7 @@ contract _PoolRegistrySystem is System, AuthRoles {
     LibInventory.transferForNoLog(components, seeder, id, indexA, amtA); // reverts if short
     LibInventory.transferForNoLog(components, seeder, id, indexB, amtB);
     LibPool.mintShares(components, id, id, LibPool.calcInitialLiquidity(amtA, amtB));
+    LibPool.logSync(world, components, id, indexA, indexB);
   }
 
   /// @notice deepen reserves (boosts LP value) from the caller's own inventory
@@ -73,6 +74,7 @@ contract _PoolRegistrySystem is System, AuthRoles {
     uint256 seeder = uint256(uint160(msg.sender));
     if (amtA > 0) LibInventory.transferForNoLog(components, seeder, id, indexA, amtA);
     if (amtB > 0) LibInventory.transferForNoLog(components, seeder, id, indexB, amtB);
+    if (amtA > 0 || amtB > 0) LibPool.logSync(world, components, id, indexA, indexB);
   }
 
   function setFee(uint32 indexA, uint32 indexB, uint256 feeBps) public onlyAdmin(components) {
@@ -115,6 +117,9 @@ contract _PoolRegistrySystem is System, AuthRoles {
     if (reserveLo > 0) LibInventory.transferForNoLog(components, id, recipient, lo, reserveLo);
     if (reserveHi > 0) LibInventory.transferForNoLog(components, id, recipient, hi, reserveHi);
 
+    // terminal (0,0,0) row closing the pool's series — reserves and supply are
+    // both drained by here. consumers key on it to detect id reuse on recreate
+    LibPool.logSync(world, components, id, lo, hi);
     LibPoolRegistry.remove(components, id);
   }
 

--- a/packages/contracts/test/systems/Pool.t.sol
+++ b/packages/contracts/test/systems/Pool.t.sol
@@ -626,7 +626,10 @@ contract PoolTest is SetupTemplate {
     uint256 totalSupply;
   }
 
-  function _decodeSync(Vm.Log[] memory logs) internal pure returns (Sync memory s) {
+  // every action under test emits exactly one sync, so assert that here rather
+  // than silently decoding the first of several
+  function _decodeSync(Vm.Log[] memory logs) internal returns (Sync memory s) {
+    assertEq(_countWorldEvents(logs, "POOL_SYNC"), 1);
     (, bytes memory values) = abi.decode(_findWorldEvent(logs, "POOL_SYNC").data, (uint8[], bytes));
     (s.poolID, s.indexA, s.indexB, s.reserveA, s.reserveB, s.totalSupply) = abi.decode(
       values,
@@ -635,9 +638,8 @@ contract PoolTest is SetupTemplate {
   }
 
   // asserts a single sync was emitted and that every field matches live state
-  function _assertSyncMatchesState(Vm.Log[] memory logs, uint256 poolID) internal view {
+  function _assertSyncMatchesState(Vm.Log[] memory logs, uint256 poolID) internal {
     Sync memory s = _decodeSync(logs);
-    assertEq(_countWorldEvents(logs, "POOL_SYNC"), 1);
     assertEq(s.poolID, poolID);
     assertEq(s.indexA, ITEM_A);
     assertEq(s.indexB, ITEM_B);

--- a/packages/contracts/test/systems/Pool.t.sol
+++ b/packages/contracts/test/systems/Pool.t.sol
@@ -3,6 +3,9 @@ pragma solidity >=0.8.28;
 
 import "tests/utils/SetupTemplate.t.sol";
 
+import { Vm } from "forge-std/Vm.sol";
+import { LibTypes } from "solecs/LibTypes.sol";
+
 import { FixedPointMathLib } from "utils/FixedPointMathLib.sol";
 import { LibData } from "libraries/LibData.sol";
 import { LibPool } from "libraries/LibPool.sol";
@@ -574,5 +577,364 @@ contract PoolTest is SetupTemplate {
     _swap(alice, ITEM_A, MUSU_INDEX, 1_000, 0);
     assertGt(_getItemBal(alice.id, MUSU_INDEX), 0); // actually received MUSU
     assertEq(LibData.get(components, alice.id, MUSU_INDEX, "ITEM_TOTAL"), before);
+  }
+
+  /////////////////
+  // POOL_SYNC
+
+  function _worldEventIndex(
+    Vm.Log[] memory logs,
+    string memory identifier
+  ) internal pure returns (uint256) {
+    bytes32 identifierHash = keccak256(bytes(identifier));
+    for (uint256 i; i < logs.length; i++) {
+      if (logs[i].topics.length > 1 && logs[i].topics[1] == identifierHash) return i;
+    }
+    revert("WorldEvent not found");
+  }
+
+  function _findWorldEvent(
+    Vm.Log[] memory logs,
+    string memory identifier
+  ) internal pure returns (Vm.Log memory) {
+    return logs[_worldEventIndex(logs, identifier)];
+  }
+
+  function _hasWorldEvent(
+    Vm.Log[] memory logs,
+    string memory identifier
+  ) internal pure returns (bool) {
+    return _countWorldEvents(logs, identifier) > 0;
+  }
+
+  function _countWorldEvents(
+    Vm.Log[] memory logs,
+    string memory identifier
+  ) internal pure returns (uint256 count) {
+    bytes32 identifierHash = keccak256(bytes(identifier));
+    for (uint256 i; i < logs.length; i++) {
+      if (logs[i].topics.length > 1 && logs[i].topics[1] == identifierHash) count++;
+    }
+  }
+
+  struct Sync {
+    uint256 poolID;
+    uint32 indexA;
+    uint32 indexB;
+    uint256 reserveA;
+    uint256 reserveB;
+    uint256 totalSupply;
+  }
+
+  function _decodeSync(Vm.Log[] memory logs) internal pure returns (Sync memory s) {
+    (, bytes memory values) = abi.decode(_findWorldEvent(logs, "POOL_SYNC").data, (uint8[], bytes));
+    (s.poolID, s.indexA, s.indexB, s.reserveA, s.reserveB, s.totalSupply) = abi.decode(
+      values,
+      (uint256, uint32, uint32, uint256, uint256, uint256)
+    );
+  }
+
+  // asserts a single sync was emitted and that every field matches live state
+  function _assertSyncMatchesState(Vm.Log[] memory logs, uint256 poolID) internal view {
+    Sync memory s = _decodeSync(logs);
+    assertEq(_countWorldEvents(logs, "POOL_SYNC"), 1);
+    assertEq(s.poolID, poolID);
+    assertEq(s.indexA, ITEM_A);
+    assertEq(s.indexB, ITEM_B);
+    assertEq(s.reserveA, _getItemBal(poolID, ITEM_A));
+    assertEq(s.reserveB, _getItemBal(poolID, ITEM_B));
+    assertEq(s.totalSupply, LibPool.getTotalSupply(components, poolID));
+  }
+
+  function testSyncOnSwap() public {
+    uint256 poolID = _createPool();
+    _fundAccount(alice.index, 10_000);
+    _giveItem(alice, ITEM_A, 10_000);
+
+    vm.recordLogs();
+    _swap(alice, ITEM_A, ITEM_B, 1_000, 0);
+    _assertSyncMatchesState(vm.getRecordedLogs(), poolID);
+  }
+
+  // canonical ordering must survive reversed caller arguments
+  function testSyncOnSwapReverseArgs() public {
+    uint256 poolID = _createPool();
+    _fundAccount(alice.index, 10_000);
+    _giveItem(alice, ITEM_B, 10_000);
+
+    vm.recordLogs();
+    _swap(alice, ITEM_B, ITEM_A, 1_000, 0);
+
+    Sync memory s = _decodeSync(vm.getRecordedLogs());
+    assertEq(s.indexA, ITEM_A);
+    assertEq(s.indexB, ITEM_B);
+    assertEq(s.reserveA, _getItemBal(poolID, ITEM_A));
+    assertEq(s.reserveB, _getItemBal(poolID, ITEM_B));
+  }
+
+  // ITEM_A/ITEM_B are already sorted, so they cannot catch an inverted
+  // reserve<->index pairing. MUSU (index 1) against ITEM_A (200) can.
+  function testSyncOrientationInvertedPair() public {
+    if (LibItem.getByIndex(components, MUSU_INDEX) == 0) _createGenericItem(MUSU_INDEX);
+    // deliberately unequal so an inverted reserve<->index pairing is visible
+    uint256 musuSeed = 50_000;
+    uint256 itemSeed = 100_000;
+    _fundSeeder(MUSU_INDEX, musuSeed);
+    _fundSeeder(ITEM_A, itemSeed);
+
+    vm.recordLogs();
+    vm.prank(deployer);
+    uint256 poolID = __PoolRegistrySystem.create(ITEM_A, MUSU_INDEX, itemSeed, musuSeed, FEE_BPS);
+
+    Sync memory s = _decodeSync(vm.getRecordedLogs());
+    assertEq(s.indexA, MUSU_INDEX); // lo, despite being passed second
+    assertEq(s.indexB, ITEM_A);
+    assertEq(s.reserveA, musuSeed); // would be itemSeed if the pairing inverted
+    assertEq(s.reserveB, itemSeed);
+    assertEq(s.reserveA, _getItemBal(poolID, MUSU_INDEX));
+    assertEq(s.reserveB, _getItemBal(poolID, ITEM_A));
+  }
+
+  function testSyncOnAddLiquidity() public {
+    uint256 poolID = _createPool();
+    _giveItem(alice, ITEM_A, 10_000);
+    _giveItem(alice, ITEM_B, 10_000);
+
+    vm.recordLogs();
+    _addLiquidity(alice, 1_000, 1_000);
+    _assertSyncMatchesState(vm.getRecordedLogs(), poolID);
+  }
+
+  function testSyncOnRemoveLiquidity() public {
+    uint256 poolID = _createPool();
+    _giveItem(alice, ITEM_A, 10_000);
+    _giveItem(alice, ITEM_B, 10_000);
+    (, , uint256 shares) = _addLiquidity(alice, 1_000, 1_000);
+
+    uint256 supplyBefore = LibPool.getTotalSupply(components, poolID);
+    vm.recordLogs();
+    _removeLiquidity(alice, shares);
+
+    // getRecordedLogs() drains the buffer, so capture it once
+    Vm.Log[] memory logs = vm.getRecordedLogs();
+    assertEq(_decodeSync(logs).totalSupply, supplyBefore - shares);
+    _assertSyncMatchesState(logs, poolID);
+  }
+
+  function testSyncOnCreate() public {
+    _fundSeeder(ITEM_A, SEED_A);
+    _fundSeeder(ITEM_B, SEED_B);
+
+    vm.recordLogs();
+    vm.prank(deployer);
+    uint256 poolID = __PoolRegistrySystem.create(ITEM_A, ITEM_B, SEED_A, SEED_B, FEE_BPS);
+
+    Sync memory s = _decodeSync(vm.getRecordedLogs());
+    assertEq(s.poolID, poolID);
+    assertEq(s.reserveA, SEED_A);
+    assertEq(s.reserveB, SEED_B);
+    assertEq(s.totalSupply, FixedPointMathLib.sqrt(SEED_A * SEED_B));
+  }
+
+  // the sync must land after the pre-fund sweep, not before it
+  function testSyncOnCreateExcludesPreFund() public {
+    _fundSeeder(ITEM_A, SEED_A + 1_000_000);
+    _fundSeeder(ITEM_B, SEED_B);
+
+    uint256 preID = LibPoolRegistry.genID(ITEM_A, ITEM_B);
+    vm.startPrank(deployer);
+    LibInventory.incFor(components, preID, ITEM_A, 1_000_000); // griefer pre-fund
+    vm.stopPrank();
+
+    vm.recordLogs();
+    vm.prank(deployer);
+    __PoolRegistrySystem.create(ITEM_A, ITEM_B, SEED_A, SEED_B, FEE_BPS);
+
+    Sync memory s = _decodeSync(vm.getRecordedLogs());
+    assertEq(s.reserveA, SEED_A);
+  }
+
+  function testSyncOnDonate() public {
+    uint256 poolID = _createPool();
+    uint256 supplyBefore = LibPool.getTotalSupply(components, poolID);
+    _fundSeeder(ITEM_A, 5_000);
+    _fundSeeder(ITEM_B, 5_000);
+
+    vm.recordLogs();
+    vm.prank(deployer);
+    __PoolRegistrySystem.donate(ITEM_A, ITEM_B, 5_000, 5_000);
+
+    Sync memory s = _decodeSync(vm.getRecordedLogs());
+    assertEq(s.reserveA, SEED_A + 5_000);
+    assertEq(s.reserveB, SEED_B + 5_000);
+    assertEq(s.totalSupply, supplyBefore); // donation mints no shares
+  }
+
+  // teardown must not revert and must emit exactly one terminal row
+  function testSyncOnRemovePool() public {
+    uint256 poolID = _createPool();
+
+    vm.recordLogs();
+    vm.prank(deployer);
+    __PoolRegistrySystem.remove(ITEM_A, ITEM_B);
+
+    Vm.Log[] memory logs = vm.getRecordedLogs();
+    assertEq(_countWorldEvents(logs, "POOL_SYNC"), 1);
+
+    Sync memory s = _decodeSync(logs);
+    assertEq(s.poolID, poolID);
+    assertEq(s.indexA, ITEM_A);
+    assertEq(s.indexB, ITEM_B);
+    assertEq(s.reserveA, 0);
+    assertEq(s.reserveB, 0);
+    assertEq(s.totalSupply, 0);
+  }
+
+  // two LPs staked: a per-iteration emit inside forceExitAll would yield 3
+  function testSyncOnRemovePoolWithLPs() public {
+    _createPool();
+    _giveItem(alice, ITEM_A, 10_000);
+    _giveItem(alice, ITEM_B, 10_000);
+    _giveItem(bob, ITEM_A, 10_000);
+    _giveItem(bob, ITEM_B, 10_000);
+    _addLiquidity(alice, 1_000, 1_000);
+    _addLiquidity(bob, 2_000, 2_000);
+
+    vm.recordLogs();
+    vm.prank(deployer);
+    __PoolRegistrySystem.remove(ITEM_A, ITEM_B);
+
+    Vm.Log[] memory logs = vm.getRecordedLogs();
+    assertEq(_countWorldEvents(logs, "POOL_SYNC"), 1);
+
+    Sync memory s = _decodeSync(logs);
+    assertEq(s.reserveA, 0);
+    assertEq(s.reserveB, 0);
+    assertEq(s.totalSupply, 0);
+  }
+
+  // pool ids are recycled, so the terminator is what separates the two series
+  function testSyncRecycledPoolID() public {
+    uint256 poolID = _createPool();
+
+    vm.recordLogs();
+    vm.prank(deployer);
+    __PoolRegistrySystem.remove(ITEM_A, ITEM_B);
+    Sync memory terminal = _decodeSync(vm.getRecordedLogs());
+    assertEq(terminal.totalSupply, 0);
+
+    vm.recordLogs();
+    uint256 newID = _createPool();
+    Sync memory fresh = _decodeSync(vm.getRecordedLogs());
+
+    assertEq(newID, poolID); // same id, unrelated pool
+    assertGt(fresh.reserveA, 0);
+    assertGt(fresh.totalSupply, 0);
+  }
+
+  function testSyncTotalSupplyAcrossMintAndBurn() public {
+    uint256 poolID = _createPool();
+    _giveItem(alice, ITEM_A, 10_000);
+    _giveItem(alice, ITEM_B, 10_000);
+
+    uint256 seeded = LibPool.getTotalSupply(components, poolID);
+
+    vm.recordLogs();
+    (, , uint256 shares) = _addLiquidity(alice, 1_000, 1_000);
+    assertEq(_decodeSync(vm.getRecordedLogs()).totalSupply, seeded + shares);
+
+    vm.recordLogs();
+    _removeLiquidity(alice, shares);
+    assertEq(_decodeSync(vm.getRecordedLogs()).totalSupply, seeded);
+  }
+
+  function testSyncOnDustExit() public {
+    _fundSeeder(ITEM_A, 1_000_000);
+    _fundSeeder(ITEM_B, 1_000);
+    vm.prank(deployer);
+    uint256 poolID = __PoolRegistrySystem.create(ITEM_A, ITEM_B, 1_000_000, 1_000, FEE_BPS);
+
+    _giveItem(alice, ITEM_A, 10_000);
+    _giveItem(alice, ITEM_B, 10_000);
+    (, , uint256 shares) = _addLiquidity(alice, 1_000, 1);
+
+    vm.recordLogs();
+    _removeLiquidity(alice, shares);
+
+    Sync memory s = _decodeSync(vm.getRecordedLogs());
+    assertEq(s.reserveA, _getItemBal(poolID, ITEM_A));
+    assertEq(s.reserveB, _getItemBal(poolID, ITEM_B));
+  }
+
+  function testSyncSchemaShape() public {
+    _createPool();
+    _fundAccount(alice.index, 10_000);
+    _giveItem(alice, ITEM_A, 10_000);
+
+    vm.recordLogs();
+    _swap(alice, ITEM_A, ITEM_B, 1_000, 0);
+
+    (uint8[] memory schema, ) = abi.decode(
+      _findWorldEvent(vm.getRecordedLogs(), "POOL_SYNC").data,
+      (uint8[], bytes)
+    );
+    assertEq(schema.length, 6);
+    assertEq(schema[0], uint8(LibTypes.SchemaValue.UINT256));
+    assertEq(schema[1], uint8(LibTypes.SchemaValue.UINT32));
+    assertEq(schema[2], uint8(LibTypes.SchemaValue.UINT32));
+    assertEq(schema[3], uint8(LibTypes.SchemaValue.UINT256));
+    assertEq(schema[4], uint8(LibTypes.SchemaValue.UINT256));
+    assertEq(schema[5], uint8(LibTypes.SchemaValue.UINT256));
+  }
+
+  function testSyncFollowsSwapInSameTx() public {
+    _createPool();
+    _fundAccount(alice.index, 10_000);
+    _giveItem(alice, ITEM_A, 10_000);
+
+    vm.recordLogs();
+    _swap(alice, ITEM_A, ITEM_B, 1_000, 0);
+
+    Vm.Log[] memory logs = vm.getRecordedLogs();
+    assertGt(_worldEventIndex(logs, "POOL_SYNC"), _worldEventIndex(logs, "POOL_SWAP"));
+  }
+
+  // reserves can be inflated out of band via ItemTransferSystem. that emits no
+  // POOL_SYNC, but the next pool call must report the true balance
+  function testDonationGapSelfHeals() public {
+    uint256 poolID = _createPool();
+    _fundAccount(alice.index, 10_000); // covers TRANSFER_FEE
+    _giveItem(alice, ITEM_A, 10_000);
+
+    uint32[] memory indices = new uint32[](1);
+    uint256[] memory amts = new uint256[](1);
+    indices[0] = ITEM_A;
+    amts[0] = 5_000;
+
+    vm.recordLogs();
+    vm.prank(alice.owner);
+    _ItemTransferSystem.executeTyped(indices, amts, poolID);
+    assertFalse(_hasWorldEvent(vm.getRecordedLogs(), "POOL_SYNC"));
+    assertEq(_getItemBal(poolID, ITEM_A), SEED_A + 5_000);
+
+    vm.recordLogs();
+    _swap(alice, ITEM_A, ITEM_B, 1_000, 0);
+
+    Sync memory s = _decodeSync(vm.getRecordedLogs());
+    assertEq(s.reserveA, _getItemBal(poolID, ITEM_A)); // includes the donation
+    assertEq(s.reserveA, SEED_A + 5_000 + 1_000);
+  }
+
+  function testNoSyncOnRevertedSwap() public {
+    _createPool();
+    _fundAccount(alice.index, 10_000);
+    _giveItem(alice, ITEM_A, 10_000);
+
+    vm.recordLogs();
+    vm.prank(alice.operator);
+    vm.expectRevert("Pool: slippage exceeded");
+    _PoolSystem.swap(ITEM_A, ITEM_B, 1_000, type(uint256).max);
+
+    assertFalse(_hasWorldEvent(vm.getRecordedLogs(), "POOL_SYNC"));
   }
 }


### PR DESCRIPTION
## Why

Pool events carry only amounts, so **spot price (`reserveB/reserveA`), TVL and LP share value are underivable** from the event stream. Reserves live solely as ECS state, which kamiden cannot observe live (`processEventUpdates := false`).

Four reserve-mutating paths — `create`, `donate`, `remove`, `forceExitAll` — emit nothing at all today, so a chart built on the existing events would show unexplained discontinuities at exactly the moments an operator intervened.

This unblocks the pool price/liquidity charts on the client. Kamiden feed and the chart itself are follow-up PRs.

## What

Adds one event. **The three existing pool events are byte-identical**, so already-indexed rows stay valid.

```
POOL_SYNC  poolID(u256), indexA(u32), indexB(u32),
           reserveA(u256), reserveB(u256), totalSupply(u256)
```

Emitted from a `LibPool.logSync` choke point at 6 sites covering all 7 logical paths:

| Site | File |
|---|---|
| `swap`, `addLiquidity`, `removeLiquidity` | `PoolSystem.sol` |
| `create`, `donate`, `remove` | `_PoolRegistrySystem.sol` |

`forceExitAll` deliberately gets no emit — `remove()`'s sync fires after it and strictly subsumes it, yielding exactly one terminal `(0,0,0)` row per teardown.

### Design notes

**Emits absolute state, never deltas.** `logSync` reads reserves and supply itself rather than accepting them from callers. Reserves can be inflated out of band — both `ItemTransferSystem` (arbitrary `targetID`) and the harvest tax recipient (arbitrary `taxerID`) accept unvalidated entity IDs, and a pool ID is a precomputable hash. Reading state means the next call self-corrects instead of compounding drift. Both gaps are documented as an indexer contract rather than fixed in contracts, since patching generic transfer paths with pool semantics would be the wrong coupling.

**Orientation comes from the pure `sortIndices`, not a `Keys` read.** `poolID != 0` already proves the two agree, so the read was redundant — and it was the only cold account access on the swap path.

**`logSync` is `public`.** `LibPool` is already a linked library, so this gets its own DELEGATECALL frame, avoiding stack-too-deep under `optimizer = false`. A direct CALL to the library reverts at `Emitter.onlySystems`, since `LibPool` is in `deploy.json["libraries"]` and not `["systems"]` — no forgery path.

## Consumer contract

1. `(0,0,0)` is a **series terminator, not a data point.** Pool IDs are recycled — `Pool.t.sol` asserts remove-then-recreate returns the same `poolID`. Splicing across it fabricates a series.
2. **Reserve deltas between syncs do not reconcile.** Never compute volume by differencing reserves; use `POOL_SWAP`.
3. `setFee`/`setDisabled` emit no sync.

## Testing

44/44 `PoolTest` pass (27 pre-existing + 17 new). Two that must not be waived:

- `testSyncOrientationInvertedPair` — `ITEM_A=200 < ITEM_B=201` means sorted and caller order are identical, so no existing-style test could catch an inverted `reserveA`/`indexA` pairing. Uses the `MUSU(1)`/`ITEM_A(200)` pair with unequal seeds.
- `testDonationGapSelfHeals` — proves the self-healing property the "don't fix it in contracts" decision rests on.

Full suite: 414 pass / 16 fail. **All 16 fail identically on `main`** (same tests, same messages, byte-identical gas) — pre-existing, unrelated: TokenPortal ×6, MintTicket ×8, `testTransferBasic`, `testGoalCompleteEventEmission`.

## Gas — reviewer attention

| Function | main (Max) | branch (Max) | Δ |
|---|---|---|---|
| `swap` | 837,090 | 874,770 | **+37,680** |
| `addLiquidity` | 850,531 | 884,206 | +33,675 |
| `removeLiquidity` | 1,078,772 | 1,112,447 | +33,675 |

**~34–38k per sync, roughly double the ~15–20k projected during planning**, with both optimisations already applied. Attributable to `getAddrByID`'s `getEntitiesWithValue` staticcall, the library DELEGATECALL, the emitter CALL, and LOG2 over six words. Flagging explicitly since every mainnet swap pays it.

## Deploy

`deploy.json` needs **no change** (`logSync` makes only `view` calls). But `LibPool` is a linked library, so this requires redeploying `LibPool` → `PoolSystem` → `_PoolRegistrySystem` and re-registering both. `world:verify:*` checks linked libraries by content, which catches a missed relink.

Rollback: the old library and systems remain deployed, so re-registering prior addresses reverts cleanly. `POOL_SWAP`/`POOL_LIQUIDITY_*` consumers are unaffected either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hyY7z5y2BAgb113rQ4vJu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `POOL_SYNC` events after pool creation, swaps, liquidity changes, donations, and pool removal.
  * Events capture pool identifiers, item indices, reserves, and total liquidity supply for accurate state tracking.

* **Tests**
  * Added comprehensive coverage for synchronization events, reserve updates, supply changes, pool lifecycle events, and reverted operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->