### PR TITLE
feat(contracts): embed block.timestamp in all four pool events

### DIFF
--- a/packages/contracts/src/libraries/LibPool.sol
+++ b/packages/contracts/src/libraries/LibPool.sol
@@ -277,7 +277,7 @@ library LibPool {
       world,
       "POOL_SWAP",
       swapEventSchema(),
-      abi.encode(accID, poolID, indexIn, indexOut, amountIn, amountOut)
+      abi.encode(accID, poolID, indexIn, indexOut, amountIn, amountOut, block.timestamp)
     );
   }
 
@@ -296,7 +296,7 @@ library LibPool {
       world,
       isAdd ? "POOL_LIQUIDITY_ADD" : "POOL_LIQUIDITY_REMOVE",
       liquidityEventSchema(),
-      abi.encode(accID, poolID, amtA, amtB, shares)
+      abi.encode(accID, poolID, amtA, amtB, shares, block.timestamp)
     );
   }
 
@@ -336,23 +336,25 @@ library LibPool {
   }
 
   function swapEventSchema() internal pure returns (uint8[] memory) {
-    uint8[] memory _schema = new uint8[](6);
+    uint8[] memory _schema = new uint8[](7);
     _schema[0] = uint8(LibTypes.SchemaValue.UINT256); // accID
     _schema[1] = uint8(LibTypes.SchemaValue.UINT256); // poolID
     _schema[2] = uint8(LibTypes.SchemaValue.UINT32); // itemIn
     _schema[3] = uint8(LibTypes.SchemaValue.UINT32); // itemOut
     _schema[4] = uint8(LibTypes.SchemaValue.UINT256); // amountIn
     _schema[5] = uint8(LibTypes.SchemaValue.UINT256); // amountOut
+    _schema[6] = uint8(LibTypes.SchemaValue.UINT256); // timestamp
     return _schema;
   }
 
   function liquidityEventSchema() internal pure returns (uint8[] memory) {
-    uint8[] memory _schema = new uint8[](5);
+    uint8[] memory _schema = new uint8[](6);
     _schema[0] = uint8(LibTypes.SchemaValue.UINT256); // accID
     _schema[1] = uint8(LibTypes.SchemaValue.UINT256); // poolID
     _schema[2] = uint8(LibTypes.SchemaValue.UINT256); // amtA
     _schema[3] = uint8(LibTypes.SchemaValue.UINT256); // amtB
     _schema[4] = uint8(LibTypes.SchemaValue.UINT256); // shares
+    _schema[5] = uint8(LibTypes.SchemaValue.UINT256); // timestamp
     return _schema;
   }
 

--- a/packages/contracts/src/libraries/LibPool.sol
+++ b/packages/contracts/src/libraries/LibPool.sol
@@ -330,7 +330,8 @@ library LibPool {
         hi,
         valComp.safeGet(LibInventory.genID(poolID, lo)),
         valComp.safeGet(LibInventory.genID(poolID, hi)),
-        valComp.safeGet(poolID)
+        valComp.safeGet(poolID),
+        block.timestamp
       );
   }
 
@@ -356,13 +357,14 @@ library LibPool {
   }
 
   function syncEventSchema() internal pure returns (uint8[] memory) {
-    uint8[] memory _schema = new uint8[](6);
+    uint8[] memory _schema = new uint8[](7);
     _schema[0] = uint8(LibTypes.SchemaValue.UINT256); // poolID
     _schema[1] = uint8(LibTypes.SchemaValue.UINT32); // indexA
     _schema[2] = uint8(LibTypes.SchemaValue.UINT32); // indexB
     _schema[3] = uint8(LibTypes.SchemaValue.UINT256); // reserveA
     _schema[4] = uint8(LibTypes.SchemaValue.UINT256); // reserveB
     _schema[5] = uint8(LibTypes.SchemaValue.UINT256); // totalSupply
+    _schema[6] = uint8(LibTypes.SchemaValue.UINT256); // timestamp
     return _schema;
   }
 

--- a/packages/contracts/test/systems/Pool.t.sol
+++ b/packages/contracts/test/systems/Pool.t.sol
@@ -649,6 +649,46 @@ contract PoolTest is SetupTemplate {
     assertEq(s.totalSupply, LibPool.getTotalSupply(components, poolID));
   }
 
+  struct Swap {
+    uint256 accID;
+    uint256 poolID;
+    uint32 indexIn;
+    uint32 indexOut;
+    uint256 amountIn;
+    uint256 amountOut;
+    uint256 timestamp;
+  }
+
+  function _decodeSwap(Vm.Log[] memory logs) internal returns (Swap memory s) {
+    assertEq(_countWorldEvents(logs, "POOL_SWAP"), 1);
+    (, bytes memory values) = abi.decode(_findWorldEvent(logs, "POOL_SWAP").data, (uint8[], bytes));
+    (s.accID, s.poolID, s.indexIn, s.indexOut, s.amountIn, s.amountOut, s.timestamp) = abi.decode(
+      values,
+      (uint256, uint256, uint32, uint32, uint256, uint256, uint256)
+    );
+  }
+
+  struct Liquidity {
+    uint256 accID;
+    uint256 poolID;
+    uint256 amtA;
+    uint256 amtB;
+    uint256 shares;
+    uint256 timestamp;
+  }
+
+  function _decodeLiquidity(
+    Vm.Log[] memory logs,
+    string memory identifier
+  ) internal returns (Liquidity memory l) {
+    assertEq(_countWorldEvents(logs, identifier), 1);
+    (, bytes memory values) = abi.decode(_findWorldEvent(logs, identifier).data, (uint8[], bytes));
+    (l.accID, l.poolID, l.amtA, l.amtB, l.shares, l.timestamp) = abi.decode(
+      values,
+      (uint256, uint256, uint256, uint256, uint256, uint256)
+    );
+  }
+
   function testSyncOnSwap() public {
     uint256 poolID = _createPool();
     _fundAccount(alice.index, 10_000);
@@ -903,6 +943,83 @@ contract PoolTest is SetupTemplate {
     _swap(alice, ITEM_A, ITEM_B, 1_000, 0);
 
     assertEq(_decodeSync(vm.getRecordedLogs()).timestamp, warpedTo);
+  }
+
+  function testSwapSchemaShape() public {
+    _createPool();
+    _fundAccount(alice.index, 10_000);
+    _giveItem(alice, ITEM_A, 10_000);
+
+    vm.recordLogs();
+    _swap(alice, ITEM_A, ITEM_B, 1_000, 0);
+
+    (uint8[] memory schema, ) = abi.decode(
+      _findWorldEvent(vm.getRecordedLogs(), "POOL_SWAP").data,
+      (uint8[], bytes)
+    );
+    assertEq(schema.length, 7);
+    assertEq(schema[0], uint8(LibTypes.SchemaValue.UINT256));
+    assertEq(schema[1], uint8(LibTypes.SchemaValue.UINT256));
+    assertEq(schema[2], uint8(LibTypes.SchemaValue.UINT32));
+    assertEq(schema[3], uint8(LibTypes.SchemaValue.UINT32));
+    assertEq(schema[4], uint8(LibTypes.SchemaValue.UINT256));
+    assertEq(schema[5], uint8(LibTypes.SchemaValue.UINT256));
+    assertEq(schema[6], uint8(LibTypes.SchemaValue.UINT256));
+  }
+
+  function testSwapTimestamp() public {
+    _createPool();
+    _fundAccount(alice.index, 10_000);
+    _giveItem(alice, ITEM_A, 10_000);
+
+    uint256 warpedTo = block.timestamp + 12 hours;
+    vm.warp(warpedTo);
+
+    vm.recordLogs();
+    _swap(alice, ITEM_A, ITEM_B, 1_000, 0);
+
+    assertEq(_decodeSwap(vm.getRecordedLogs()).timestamp, warpedTo);
+  }
+
+  function testLiquiditySchemaShape() public {
+    _createPool();
+    _giveItem(alice, ITEM_A, 10_000);
+    _giveItem(alice, ITEM_B, 10_000);
+
+    vm.recordLogs();
+    _addLiquidity(alice, 1_000, 1_000);
+
+    (uint8[] memory schema, ) = abi.decode(
+      _findWorldEvent(vm.getRecordedLogs(), "POOL_LIQUIDITY_ADD").data,
+      (uint8[], bytes)
+    );
+    assertEq(schema.length, 6);
+    assertEq(schema[0], uint8(LibTypes.SchemaValue.UINT256));
+    assertEq(schema[1], uint8(LibTypes.SchemaValue.UINT256));
+    assertEq(schema[2], uint8(LibTypes.SchemaValue.UINT256));
+    assertEq(schema[3], uint8(LibTypes.SchemaValue.UINT256));
+    assertEq(schema[4], uint8(LibTypes.SchemaValue.UINT256));
+    assertEq(schema[5], uint8(LibTypes.SchemaValue.UINT256));
+  }
+
+  function testLiquidityTimestamp() public {
+    _createPool();
+    _giveItem(alice, ITEM_A, 10_000);
+    _giveItem(alice, ITEM_B, 10_000);
+
+    uint256 addedAt = block.timestamp + 12 hours;
+    vm.warp(addedAt);
+
+    vm.recordLogs();
+    (, , uint256 shares) = _addLiquidity(alice, 1_000, 1_000);
+    assertEq(_decodeLiquidity(vm.getRecordedLogs(), "POOL_LIQUIDITY_ADD").timestamp, addedAt);
+
+    uint256 removedAt = addedAt + 3 hours;
+    vm.warp(removedAt);
+
+    vm.recordLogs();
+    _removeLiquidity(alice, shares);
+    assertEq(_decodeLiquidity(vm.getRecordedLogs(), "POOL_LIQUIDITY_REMOVE").timestamp, removedAt);
   }
 
   function testSyncFollowsSwapInSameTx() public {

--- a/packages/contracts/test/systems/Pool.t.sol
+++ b/packages/contracts/test/systems/Pool.t.sol
@@ -624,6 +624,7 @@ contract PoolTest is SetupTemplate {
     uint256 reserveA;
     uint256 reserveB;
     uint256 totalSupply;
+    uint256 timestamp;
   }
 
   // every action under test emits exactly one sync, so assert that here rather
@@ -631,9 +632,9 @@ contract PoolTest is SetupTemplate {
   function _decodeSync(Vm.Log[] memory logs) internal returns (Sync memory s) {
     assertEq(_countWorldEvents(logs, "POOL_SYNC"), 1);
     (, bytes memory values) = abi.decode(_findWorldEvent(logs, "POOL_SYNC").data, (uint8[], bytes));
-    (s.poolID, s.indexA, s.indexB, s.reserveA, s.reserveB, s.totalSupply) = abi.decode(
+    (s.poolID, s.indexA, s.indexB, s.reserveA, s.reserveB, s.totalSupply, s.timestamp) = abi.decode(
       values,
-      (uint256, uint32, uint32, uint256, uint256, uint256)
+      (uint256, uint32, uint32, uint256, uint256, uint256, uint256)
     );
   }
 
@@ -880,13 +881,28 @@ contract PoolTest is SetupTemplate {
       _findWorldEvent(vm.getRecordedLogs(), "POOL_SYNC").data,
       (uint8[], bytes)
     );
-    assertEq(schema.length, 6);
+    assertEq(schema.length, 7);
     assertEq(schema[0], uint8(LibTypes.SchemaValue.UINT256));
     assertEq(schema[1], uint8(LibTypes.SchemaValue.UINT32));
     assertEq(schema[2], uint8(LibTypes.SchemaValue.UINT32));
     assertEq(schema[3], uint8(LibTypes.SchemaValue.UINT256));
     assertEq(schema[4], uint8(LibTypes.SchemaValue.UINT256));
     assertEq(schema[5], uint8(LibTypes.SchemaValue.UINT256));
+    assertEq(schema[6], uint8(LibTypes.SchemaValue.UINT256));
+  }
+
+  function testSyncTimestamp() public {
+    _createPool();
+    _fundAccount(alice.index, 10_000);
+    _giveItem(alice, ITEM_A, 10_000);
+
+    uint256 warpedTo = block.timestamp + 12 hours;
+    vm.warp(warpedTo);
+
+    vm.recordLogs();
+    _swap(alice, ITEM_A, ITEM_B, 1_000, 0);
+
+    assertEq(_decodeSync(vm.getRecordedLogs()).timestamp, warpedTo);
   }
 
   function testSyncFollowsSwapInSameTx() public {


### PR DESCRIPTION
## What

Appends `block.timestamp` (`uint256`, unix seconds) as a **trailing** field to all four pool world events in `LibPool.sol`.

| Event | Fields |
|---|---|
| `POOL_SYNC` | 6 → 7 |
| `POOL_SWAP` | 6 → 7 |
| `POOL_LIQUIDITY_ADD` / `_REMOVE` | 5 → 6 |

## Why

The kamiden price-history endpoint currently derives event time by joining `events.worldevents → evm.transactions → evm.blocks.ts`. That path has three defects an embedded timestamp removes outright:

1. **Timezone skew** — `00025_PROC_ProcessBlocks.sql:41` writes a `timestamptz` into a naive column using the *writer's* session timezone.
2. **NULL timestamps** — `00022:72` inserts bare blocks with no `ts` until `populate.Blocks` runs.
3. **Lag** — the tail trails block population plus replica replication.

All four in one change: price history needs `POOL_SYNC`, deferred volume/OHLC needs the other three, and a second redeploy of a live game costs more than including them now. This also aligns `LibPool` with `LibAuction`, `LibTokenPortal`, and `LibInventory`, which already embed `block.timestamp`.

## Compatibility

Appending preserves every existing 32-byte word offset, so already-emitted events stay decodable and consumers can migrate via `COALESCE(embedded_ts, blocks.ts)`. Nothing off-chain decodes these payloads today (kamigaze drops unknown identifiers at `handler_kamiden.go:275`).

## Tests

`Pool.t.sol` — **49 passed, 0 failed**.

Adds `_decodeSwap` / `_decodeLiquidity` (neither payload had *any* decode coverage before), schema-shape assertions for all three schemas, and `testSyncTimestamp` / `testSwapTimestamp` / `testLiquidityTimestamp`, each `vm.warp`ing to a known value so the assertion isn't tautological. No existing assertions weakened.

Full suite: 435 passed / 24 failed — the same 24 fail on `main` (`Minting/*`, `Traits`, `TokenPortal`); none touch pool paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ADJK1FFkZdmYH9k2RMaAon
