### PR TITLE
configs: mirror newbie vendor min price to 0.004 ether

### DIFF
--- a/packages/contracts/deployment/world/state/configs/configs.ts
+++ b/packages/contracts/deployment/world/state/configs/configs.ts
@@ -193,7 +193,7 @@ async function initVIP(api: AdminAPI) {
 }
 
 async function initNewbieVendor(api: AdminAPI) {
-  await api.config.set.number('NEWBIE_VENDOR_MIN_PRICE', 5000000000000000); // 0.005 ether
+  await api.config.set.number('NEWBIE_VENDOR_MIN_PRICE', 4000000000000000); // 0.004 ether
   await api.config.set.number('NEWBIE_VENDOR_TWAP_WINDOW', 86400); // 24h
   await api.config.set.bool('NEWBIE_VENDOR_ENABLED', true);
   await api.vendor.setCycleDuration(172800); // 48h


### PR DESCRIPTION
- prod `NEWBIE_VENDOR_MIN_PRICE` was set on-chain to 0.004 ether (via `setMinPrice`, tx `0x08d03fd2...de711e2`)
- this mirrors the seed so a future bulk configs init does not regress the live value back to 0.005
- 0.004 also matches the in-code `DEFAULT_MIN_PRICE` fallback in `NewbieVendorBuySystem`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Reduced the minimum purchase price for the newbie vendor from 0.005 ETH to 0.004 ETH.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->