### PR TITLE
Kamiden GetPoolPriceHistory ts pagination + Tisi LP changes

### DIFF
--- a/packages/client/src/app/components/modals/pool/Chart.tsx
+++ b/packages/client/src/app/components/modals/pool/Chart.tsx
@@ -5,12 +5,20 @@ import styled from 'styled-components';
 import { EmptyText, Text } from 'app/components/library';
 import { getKamidenClient } from 'clients/kamiden';
 import { playClick } from 'utils/sounds';
+import {
+  DAY,
+  PricePoint,
+  RANGES,
+  Range,
+  computeNiceAxis,
+  fmtAxisDate,
+  fmtFullDate,
+  fmtValue,
+  isInverted,
+} from './utils';
 
 const KamidenClient = getKamidenClient();
 
-const DAY = 3600 * 24;
-
-const Y_TICKS = 5;
 const X_LABEL_DIVISOR = 5;
 
 const GREEN = '#2F8F46';
@@ -18,13 +26,6 @@ const GRID = '#e8e8e8';
 const CROSSHAIR = '#bbb';
 const TICK = '#999';
 
-const RANGES = {
-  '7d': DAY * 7,
-  '30d': DAY * 30,
-  Max: null,
-} as const;
-
-type Range = keyof typeof RANGES;
 type Status = 'offline' | 'loading' | 'error' | 'ready';
 
 export interface ChartAsset {
@@ -33,87 +34,11 @@ export interface ChartAsset {
   image?: string;
 }
 
-interface PricePoint {
-  ts: number;
-  price: number;
-}
-
 interface Hover {
   index: number;
   x: number;
   y: number;
 }
-
-const isInverted = (
-  points: PricePoint[],
-  reference: number,
-  labels: { baseIsUnit: boolean; quoteIsSubject: boolean }
-) => {
-  const latest = points[points.length - 1]?.price ?? 0;
-  if (reference > 0 && latest > 0) {
-    const asIs = Math.abs(Math.log(latest / reference));
-    const flipped = Math.abs(Math.log(1 / latest / reference));
-    return flipped < asIs;
-  }
-  return labels.baseIsUnit && labels.quoteIsSubject;
-};
-
-const niceNum = (range: number, round: boolean) => {
-  const exponent = Math.floor(Math.log10(range));
-  const fraction = range / Math.pow(10, exponent);
-  let nice: number;
-  if (round) {
-    if (fraction < 1.5) nice = 1;
-    else if (fraction < 3) nice = 2;
-    else if (fraction < 7) nice = 5;
-    else nice = 10;
-  } else {
-    if (fraction <= 1) nice = 1;
-    else if (fraction <= 2) nice = 2;
-    else if (fraction <= 5) nice = 5;
-    else nice = 10;
-  }
-  return nice * Math.pow(10, exponent);
-};
-
-const computeNiceAxis = (dataMin: number, dataMax: number, tickCount = Y_TICKS) => {
-  let low = dataMin;
-  let high = dataMax;
-  if (low === high) {
-    const pad = low === 0 ? 1 : Math.abs(low) * 0.1;
-    low -= pad;
-    high += pad;
-  }
-
-  const step = niceNum(niceNum(high - low, false) / (tickCount - 1), true);
-  const decimals = Math.max(0, -Math.floor(Math.log10(step)) + 1);
-  const round = (value: number) => parseFloat(value.toFixed(decimals));
-
-  const min = Math.floor(low / step) * step;
-  const max = Math.ceil(high / step) * step;
-  const ticks: number[] = [];
-  for (let value = min; value <= max + step * 0.5; value += step) ticks.push(round(value));
-
-  return { min: round(min), max: round(max), ticks, decimals };
-};
-
-const fmtValue = (value: number, decimals: number) =>
-  value.toLocaleString('en-US', {
-    minimumFractionDigits: decimals,
-    maximumFractionDigits: decimals,
-  });
-
-const fmtAxisDate = (ts: number) => {
-  const date = new Date(ts * 1000);
-  return `${date.getUTCMonth() + 1}/${date.getUTCDate()}`;
-};
-
-const fmtFullDate = (ts: number) =>
-  new Date(ts * 1000).toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    timeZone: 'UTC',
-  });
 
 const CrosshairPlugin = {
   id: 'poolCrosshair',

--- a/packages/client/src/app/components/modals/pool/Chart.tsx
+++ b/packages/client/src/app/components/modals/pool/Chart.tsx
@@ -259,7 +259,7 @@ export const Chart = ({
       return (
         <ChartBox>
           <canvas ref={canvasRef} />
-          {hover && (
+          {hover && points[hover.index] && (
             <HoverCard
               point={points[hover.index]}
               subject={subject}

--- a/packages/client/src/app/components/modals/pool/Chart.tsx
+++ b/packages/client/src/app/components/modals/pool/Chart.tsx
@@ -5,13 +5,13 @@ import styled from 'styled-components';
 import { EmptyText, Text } from 'app/components/library';
 import { getKamidenClient } from 'clients/kamiden';
 import { playClick } from 'utils/sounds';
+import { CrosshairPlugin, RightEdgePlugin, buildChartOptions } from './chartOptions';
 import {
   DAY,
   PricePoint,
   RANGES,
   Range,
   computeNiceAxis,
-  fmtAxisDate,
   fmtFullDate,
   fmtValue,
   isInverted,
@@ -22,9 +22,6 @@ const KamidenClient = getKamidenClient();
 const X_LABEL_DIVISOR = 5;
 
 const GREEN = '#2F8F46';
-const GRID = '#e8e8e8';
-const CROSSHAIR = '#bbb';
-const TICK = '#999';
 
 type Status = 'offline' | 'loading' | 'error' | 'ready';
 
@@ -39,42 +36,6 @@ interface Hover {
   x: number;
   y: number;
 }
-
-const CrosshairPlugin = {
-  id: 'poolCrosshair',
-  beforeDatasetsDraw: (chart: any) => {
-    const active = chart.tooltip?.getActiveElements?.();
-    if (!active?.length) return;
-
-    const { ctx } = chart;
-    const { top, bottom } = chart.chartArea;
-    ctx.save();
-    ctx.beginPath();
-    ctx.lineWidth = 1;
-    ctx.strokeStyle = CROSSHAIR;
-    ctx.setLineDash([3, 4]);
-    ctx.moveTo(active[0].element.x, top);
-    ctx.lineTo(active[0].element.x, bottom);
-    ctx.stroke();
-    ctx.restore();
-  },
-};
-
-const RightEdgePlugin = {
-  id: 'poolRightEdge',
-  beforeDatasetsDraw: (chart: any) => {
-    const { ctx, chartArea } = chart;
-    if (!chartArea) return;
-    ctx.save();
-    ctx.beginPath();
-    ctx.lineWidth = 1;
-    ctx.strokeStyle = GRID;
-    ctx.moveTo(chartArea.right, chartArea.top);
-    ctx.lineTo(chartArea.right, chartArea.bottom);
-    ctx.stroke();
-    ctx.restore();
-  },
-};
 
 const RangeSelector = ({
   range,
@@ -244,10 +205,10 @@ export const Chart = ({
     };
 
     chartRef.current = new ChartJS(ctx, {
-      type: 'line',
       data: {
         datasets: [
           {
+            type: 'line',
             label: 'Price',
             data: points.map((point) => ({ x: point.ts, y: point.price })),
             borderColor: GREEN,
@@ -259,50 +220,7 @@ export const Chart = ({
           },
         ],
       },
-      options: {
-        responsive: true,
-        maintainAspectRatio: false,
-        animation: false,
-        interaction: { mode: 'index', intersect: false },
-        scales: {
-          y: {
-            min: bounds.min,
-            max: bounds.max,
-            border: { display: false },
-            grid: { color: GRID, z: -1 },
-            afterBuildTicks: (axis: any) => {
-              axis.ticks = bounds.ticks.map((value) => ({ value }));
-            },
-            ticks: {
-              color: TICK,
-              font: { family: 'Pixel', size: 9 },
-              autoSkip: false,
-              callback: (value: any) => fmtValue(Number(value), bounds.decimals),
-            },
-          },
-          x: {
-            type: 'linear',
-            min: span.min,
-            max: span.max,
-            border: { display: false },
-            grid: { color: GRID, z: -1 },
-            afterBuildTicks: (axis: any) => {
-              axis.ticks = span.ticks.map((value) => ({ value }));
-            },
-            ticks: {
-              color: TICK,
-              font: { family: 'Pixel', size: 9 },
-              maxRotation: 0,
-              autoSkip: false,
-              callback: (value: any) => fmtAxisDate(Number(value)),
-            },
-          },
-        },
-        plugins: {
-          legend: { display: false },
-          tooltip: { enabled: false, external: trackHover },
-        },
-      },
+      options: buildChartOptions(bounds, span, trackHover),
       plugins: [CrosshairPlugin, RightEdgePlugin],
     });
 

--- a/packages/client/src/app/components/modals/pool/Chart.tsx
+++ b/packages/client/src/app/components/modals/pool/Chart.tsx
@@ -1,0 +1,548 @@
+import ChartJS from 'chart.js/auto';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import styled from 'styled-components';
+
+import { EmptyText, Text } from 'app/components/library';
+import { getKamidenClient } from 'clients/kamiden';
+import { playClick } from 'utils/sounds';
+
+const KamidenClient = getKamidenClient();
+
+const DAY = 3600 * 24;
+
+const Y_TICKS = 5;
+const X_LABEL_DIVISOR = 5;
+
+const GREEN = '#2F8F46';
+const GRID = '#e8e8e8';
+const CROSSHAIR = '#bbb';
+const TICK = '#999';
+
+const RANGES = {
+  '7d': DAY * 7,
+  '30d': DAY * 30,
+  Max: null,
+} as const;
+
+type Range = keyof typeof RANGES;
+type Status = 'offline' | 'loading' | 'error' | 'ready';
+
+export interface ChartAsset {
+  index: number;
+  name: string;
+  image?: string;
+}
+
+interface PricePoint {
+  ts: number;
+  price: number;
+}
+
+interface Hover {
+  index: number;
+  x: number;
+  y: number;
+}
+
+const isInverted = (
+  points: PricePoint[],
+  reference: number,
+  labels: { baseIsUnit: boolean; quoteIsSubject: boolean }
+) => {
+  const latest = points[points.length - 1]?.price ?? 0;
+  if (reference > 0 && latest > 0) {
+    const asIs = Math.abs(Math.log(latest / reference));
+    const flipped = Math.abs(Math.log(1 / latest / reference));
+    return flipped < asIs;
+  }
+  return labels.baseIsUnit && labels.quoteIsSubject;
+};
+
+const niceNum = (range: number, round: boolean) => {
+  const exponent = Math.floor(Math.log10(range));
+  const fraction = range / Math.pow(10, exponent);
+  let nice: number;
+  if (round) {
+    if (fraction < 1.5) nice = 1;
+    else if (fraction < 3) nice = 2;
+    else if (fraction < 7) nice = 5;
+    else nice = 10;
+  } else {
+    if (fraction <= 1) nice = 1;
+    else if (fraction <= 2) nice = 2;
+    else if (fraction <= 5) nice = 5;
+    else nice = 10;
+  }
+  return nice * Math.pow(10, exponent);
+};
+
+const computeNiceAxis = (dataMin: number, dataMax: number, tickCount = Y_TICKS) => {
+  let low = dataMin;
+  let high = dataMax;
+  if (low === high) {
+    const pad = low === 0 ? 1 : Math.abs(low) * 0.1;
+    low -= pad;
+    high += pad;
+  }
+
+  const step = niceNum(niceNum(high - low, false) / (tickCount - 1), true);
+  const decimals = Math.max(0, -Math.floor(Math.log10(step)) + 1);
+  const round = (value: number) => parseFloat(value.toFixed(decimals));
+
+  const min = Math.floor(low / step) * step;
+  const max = Math.ceil(high / step) * step;
+  const ticks: number[] = [];
+  for (let value = min; value <= max + step * 0.5; value += step) ticks.push(round(value));
+
+  return { min: round(min), max: round(max), ticks, decimals };
+};
+
+const fmtValue = (value: number, decimals: number) =>
+  value.toLocaleString('en-US', {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+
+const fmtAxisDate = (ts: number) => {
+  const date = new Date(ts * 1000);
+  return `${date.getUTCMonth() + 1}/${date.getUTCDate()}`;
+};
+
+const fmtFullDate = (ts: number) =>
+  new Date(ts * 1000).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+
+const CrosshairPlugin = {
+  id: 'poolCrosshair',
+  beforeDatasetsDraw: (chart: any) => {
+    const active = chart.tooltip?.getActiveElements?.();
+    if (!active?.length) return;
+
+    const { ctx } = chart;
+    const { top, bottom } = chart.chartArea;
+    ctx.save();
+    ctx.beginPath();
+    ctx.lineWidth = 1;
+    ctx.strokeStyle = CROSSHAIR;
+    ctx.setLineDash([3, 4]);
+    ctx.moveTo(active[0].element.x, top);
+    ctx.lineTo(active[0].element.x, bottom);
+    ctx.stroke();
+    ctx.restore();
+  },
+};
+
+const RangeSelector = ({
+  range,
+  onSelect,
+  refreshing,
+}: {
+  range: Range;
+  onSelect: (range: Range) => void;
+  refreshing: boolean;
+}) => (
+  <RangeRow $refreshing={refreshing}>
+    {(Object.keys(RANGES) as Range[]).map((option) => (
+      <RangeButton
+        key={option}
+        $active={range === option}
+        onClick={() => onSelect(option)}
+        disabled={range === option}
+      >
+        {option}
+      </RangeButton>
+    ))}
+  </RangeRow>
+);
+
+const HoverCard = ({
+  point,
+  subject,
+  unit,
+  decimals,
+  flipped,
+  left,
+}: {
+  point: PricePoint;
+  subject: ChartAsset;
+  unit: ChartAsset;
+  decimals: number;
+  flipped: boolean;
+  left: number;
+}) => (
+  <Card style={{ left: `${left}px`, transform: `translateX(${flipped ? -102 : 2}%)` }}>
+    <CardRow>
+      {subject.image && <CardSprite src={subject.image} alt={subject.name} />}
+      <Text size={0.75}>{subject.name}</Text>
+    </CardRow>
+    <CardRow>
+      <Text size={0.65}>Time: {fmtFullDate(point.ts)}</Text>
+    </CardRow>
+    <CardRow>
+      <Text size={0.65} color={GREEN}>
+        Price: {fmtValue(point.price, decimals)}
+      </Text>
+      {unit.image && <UnitSprite src={unit.image} alt={unit.name} />}
+    </CardRow>
+  </Card>
+);
+
+export const Chart = ({
+  subject,
+  unit,
+  referencePrice,
+}: {
+  subject: ChartAsset;
+  unit: ChartAsset;
+  referencePrice: number;
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const chartRef = useRef<ChartJS>();
+  const hoverRef = useRef<Hover | null>(null);
+
+  const [points, setPoints] = useState<PricePoint[]>([]);
+  const [status, setStatus] = useState<Status>(KamidenClient ? 'loading' : 'offline');
+  const [range, setRange] = useState<Range>('30d');
+  const [hover, setHover] = useState<Hover | null>(null);
+
+  const hasReference = referencePrice > 0;
+  const referenceRef = useRef(referencePrice);
+  referenceRef.current = referencePrice;
+
+  useEffect(() => {
+    if (!KamidenClient) return setStatus('offline');
+    let stale = false;
+    setStatus('loading');
+
+    const [indexA, indexB] =
+      subject.index < unit.index ? [subject.index, unit.index] : [unit.index, subject.index];
+    const windowSeconds = RANGES[range];
+    const fromTs =
+      windowSeconds === null ? undefined : Math.floor(Date.now() / 1000) - (windowSeconds - DAY);
+
+    KamidenClient.getPoolPriceHistory({ indexA, indexB, fromTs })
+      .then((response) => {
+        if (stale) return;
+        const parsed = response.points
+          .map((point) => ({ ts: point.bucketTs, price: point.price }))
+          .filter((point) => point.ts > 0 && point.price > 0 && Number.isFinite(point.price))
+          .sort((a, b) => a.ts - b.ts);
+
+        const inverted = isInverted(parsed, referenceRef.current, {
+          baseIsUnit: response.baseIndex === unit.index,
+          quoteIsSubject: response.quoteIndex === subject.index,
+        });
+
+        setPoints(
+          inverted ? parsed.map((point) => ({ ...point, price: 1 / point.price })) : parsed
+        );
+        setStatus('ready');
+      })
+      .catch((error) => {
+        if (stale) return;
+        console.error('[pool chart] price history failed', error);
+        setStatus('error');
+      });
+
+    return () => {
+      stale = true;
+    };
+  }, [subject.index, unit.index, range, hasReference]);
+
+  /////////////////
+  // INTERPRETATION
+
+  const bounds = useMemo(() => {
+    if (!points.length) return { min: 0, max: 1, ticks: [0, 1], decimals: 2 };
+    const prices = points.map((point) => point.price);
+    return computeNiceAxis(Math.min(...prices), Math.max(...prices));
+  }, [points]);
+
+  const span = useMemo(() => {
+    if (!points.length) return { min: 0, max: 1, ticks: [0, 1] };
+
+    const step = Math.max(1, Math.floor(points.length / X_LABEL_DIVISOR));
+    const ticks: number[] = [];
+    for (let i = 0; i < points.length; i += step) ticks.push(points[i].ts);
+
+    return { min: points[0].ts, max: points[points.length - 1].ts, ticks };
+  }, [points]);
+
+  /////////////////
+  // RENDERING
+
+  useEffect(() => {
+    setHover(null);
+    hoverRef.current = null;
+    chartRef.current?.destroy();
+    chartRef.current = undefined;
+    if (points.length < 2) return;
+
+    const ctx = canvasRef.current?.getContext('2d');
+    if (!ctx) return;
+
+    const trackHover = ({ tooltip }: any) => {
+      if (!tooltip.opacity) {
+        if (!hoverRef.current) return;
+        hoverRef.current = null;
+        return setHover(null);
+      }
+
+      const index = tooltip.dataPoints?.[0]?.dataIndex;
+      if (index === undefined) return;
+
+      const next = { index, x: tooltip.caretX, y: tooltip.caretY };
+      const previous = hoverRef.current;
+      if (previous && previous.index === index && previous.x === next.x && previous.y === next.y)
+        return;
+      hoverRef.current = next;
+      setHover(next);
+    };
+
+    chartRef.current = new ChartJS(ctx, {
+      type: 'line',
+      data: {
+        datasets: [
+          {
+            label: 'Price',
+            data: points.map((point) => ({ x: point.ts, y: point.price })),
+            borderColor: GREEN,
+            backgroundColor: GREEN,
+            borderWidth: 1.5,
+            pointRadius: points.length > 120 ? 0 : 2.5,
+            pointHoverRadius: 4,
+            tension: 0.1,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        animation: false,
+        interaction: { mode: 'index', intersect: false },
+        scales: {
+          y: {
+            min: bounds.min,
+            max: bounds.max,
+            border: { display: false },
+            grid: { color: GRID, z: -1 },
+            afterBuildTicks: (axis: any) => {
+              axis.ticks = bounds.ticks.map((value) => ({ value }));
+            },
+            ticks: {
+              color: TICK,
+              font: { family: 'Pixel', size: 9 },
+              autoSkip: false,
+              callback: (value: any) => fmtValue(Number(value), bounds.decimals),
+            },
+          },
+          x: {
+            type: 'linear',
+            min: span.min,
+            max: span.max,
+            border: { display: false },
+            grid: { color: GRID, z: -1 },
+            afterBuildTicks: (axis: any) => {
+              axis.ticks = span.ticks.map((value) => ({ value }));
+            },
+            ticks: {
+              color: TICK,
+              font: { family: 'Pixel', size: 9 },
+              maxRotation: 0,
+              autoSkip: false,
+              callback: (value: any) => fmtAxisDate(Number(value)),
+            },
+          },
+        },
+        plugins: {
+          legend: { display: false },
+          tooltip: { enabled: false, external: trackHover },
+        },
+      },
+      plugins: [CrosshairPlugin],
+    });
+
+    return () => {
+      chartRef.current?.destroy();
+      chartRef.current = undefined;
+    };
+  }, [points, bounds, span]);
+
+  const selectRange = (option: Range) => {
+    playClick();
+    setRange(option);
+  };
+
+  if (status === 'offline') return <EmptyText text={['Price history unavailable.']} size={1} />;
+
+  const chartWidth = canvasRef.current?.clientWidth ?? 0;
+  const refreshing = status === 'loading' && points.length > 0;
+
+  const renderBody = () => {
+    if (status === 'error')
+      return (
+        <EmptyBox>
+          <EmptyText text={['Could not load price history.', 'Try again later!']} size={0.9} />
+        </EmptyBox>
+      );
+
+    if (status === 'loading' && !points.length)
+      return (
+        <EmptyBox>
+          <EmptyText text={['Loading price history...']} size={0.9} />
+        </EmptyBox>
+      );
+
+    if (points.length > 1)
+      return (
+        <ChartBox>
+          <canvas ref={canvasRef} />
+          {hover && (
+            <HoverCard
+              point={points[hover.index]}
+              subject={subject}
+              unit={unit}
+              decimals={bounds.decimals}
+              flipped={hover.x > chartWidth / 2}
+              left={hover.x}
+            />
+          )}
+        </ChartBox>
+      );
+
+    return (
+      <EmptyBox>
+        <EmptyText
+          text={
+            points.length === 1
+              ? ['Only one price point so far.', 'Check back soon!']
+              : ['No trades recorded yet.', 'Be the first!']
+          }
+          size={0.9}
+        />
+      </EmptyBox>
+    );
+  };
+
+  return (
+    <Container>
+      <Header>
+        <HeaderLabel>price history</HeaderLabel>
+        <RangeSelector range={range} onSelect={selectRange} refreshing={refreshing} />
+      </Header>
+      {renderBody()}
+    </Container>
+  );
+};
+
+/////////////////
+// STYLES
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1vh;
+  border: 0.12vw solid #e0e0e0;
+  border-radius: 0.6vw;
+  background: #fafafa;
+  padding: 0.8vw;
+`;
+
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.6vw;
+`;
+
+const HeaderLabel = styled.div`
+  font-family: Pixel;
+  font-size: 0.72vw;
+  color: #aaa;
+  text-transform: uppercase;
+  letter-spacing: 0.12vw;
+`;
+
+const RangeRow = styled.div<{ $refreshing: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 0.3vw;
+  flex-shrink: 0;
+  opacity: ${({ $refreshing }) => ($refreshing ? 0.5 : 1)};
+  transition: opacity 0.12s;
+`;
+
+const RangeButton = styled.button<{ $active: boolean }>`
+  flex-shrink: 0;
+  height: 1.8vw;
+  padding: 0 0.5vw;
+  border: 0.1vw solid ${({ $active }) => ($active ? '#a0c0e8' : '#ccc')};
+  border-radius: 0.4vw;
+  background: ${({ $active }) => ($active ? '#e8f0fe' : '#fff')};
+  color: ${({ $active }) => ($active ? '#333' : '#555')};
+  font-family: Pixel;
+  font-size: 0.65vw;
+  cursor: pointer;
+  pointer-events: auto;
+  transition:
+    background 0.12s,
+    border-color 0.12s;
+  &:hover {
+    background: #e8f0fe;
+    border-color: #a0c0e8;
+  }
+  &:disabled {
+    cursor: default;
+    pointer-events: none;
+  }
+`;
+
+const ChartBox = styled.div`
+  position: relative;
+  width: 100%;
+  height: 15vw;
+`;
+
+const EmptyBox = styled.div`
+  padding: 3vh 0;
+`;
+
+const Card = styled.div`
+  position: absolute;
+  top: 0.6vw;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2vh;
+  border: 0.12vw solid #e0e0e0;
+  border-radius: 0.5vw;
+  background: #fff;
+  padding: 0.6vw;
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 2;
+`;
+
+const CardRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.3vw;
+`;
+
+const CardSprite = styled.img`
+  width: 1.2vw;
+  height: 1.2vw;
+  image-rendering: pixelated;
+  user-drag: none;
+  flex-shrink: 0;
+`;
+
+const UnitSprite = styled.img`
+  width: 0.8vw;
+  height: 0.8vw;
+  image-rendering: pixelated;
+  user-drag: none;
+  flex-shrink: 0;
+`;

--- a/packages/client/src/app/components/modals/pool/Chart.tsx
+++ b/packages/client/src/app/components/modals/pool/Chart.tsx
@@ -60,6 +60,22 @@ const CrosshairPlugin = {
   },
 };
 
+const RightEdgePlugin = {
+  id: 'poolRightEdge',
+  beforeDatasetsDraw: (chart: any) => {
+    const { ctx, chartArea } = chart;
+    if (!chartArea) return;
+    ctx.save();
+    ctx.beginPath();
+    ctx.lineWidth = 1;
+    ctx.strokeStyle = GRID;
+    ctx.moveTo(chartArea.right, chartArea.top);
+    ctx.lineTo(chartArea.right, chartArea.bottom);
+    ctx.stroke();
+    ctx.restore();
+  },
+};
+
 const RangeSelector = ({
   range,
   onSelect,
@@ -236,7 +252,7 @@ export const Chart = ({
             data: points.map((point) => ({ x: point.ts, y: point.price })),
             borderColor: GREEN,
             backgroundColor: GREEN,
-            borderWidth: 1.5,
+            borderWidth: 2.5,
             pointRadius: points.length > 120 ? 0 : 2.5,
             pointHoverRadius: 4,
             tension: 0.1,
@@ -287,7 +303,7 @@ export const Chart = ({
           tooltip: { enabled: false, external: trackHover },
         },
       },
-      plugins: [CrosshairPlugin],
+      plugins: [CrosshairPlugin, RightEdgePlugin],
     });
 
     return () => {

--- a/packages/client/src/app/components/modals/pool/Pool.tsx
+++ b/packages/client/src/app/components/modals/pool/Pool.tsx
@@ -31,6 +31,7 @@ import {
   quote,
 } from 'network/shapes/Pool';
 import { playClick, playFund } from 'utils/sounds';
+import { Chart } from './Chart';
 import { PoolPosition, Positions } from './Positions';
 import { fmtPrice } from './utils';
 
@@ -43,9 +44,10 @@ const RED = '#F8D6D6';
 // pastel tab colors, shared with the Token Portal tabs
 const TAB_BLUE = '#E0EEFF';
 const TAB_ORANGE = '#FFF0E0';
+const TAB_GREEN = '#E4F5E0';
 
 type View = 'world' | 'positions';
-type Tab = 'swap' | 'liquidity';
+type Tab = 'swap' | 'liquidity' | 'chart';
 
 // floor to a safe non-negative integer. guards negatives / non-finite so a bad
 // amount ("1e999" -> Infinity) can never reach BigInt() downstream
@@ -490,6 +492,24 @@ export const PoolModal: UIComponent = {
       );
     };
 
+    const renderChart = () => {
+      if (!pool || !priceInfo)
+        return <EmptyText text={['No pools available.', 'Check back later!']} size={1} />;
+      const unitIndex =
+        pool.itemA.index === priceInfo.item.index ? pool.itemB.index : pool.itemA.index;
+      return (
+        <Chart
+          subject={{
+            index: priceInfo.item.index,
+            name: priceInfo.item.name,
+            image: priceInfo.item.image,
+          }}
+          unit={{ index: unitIndex, name: priceInfo.unitName, image: priceInfo.unitImage }}
+          referencePrice={priceInfo.price}
+        />
+      );
+    };
+
     const renderLiquidity = () => {
       if (!pool) return <EmptyText text={['No pools available.', 'Check back later!']} size={1} />;
       const sharePct =
@@ -670,12 +690,22 @@ export const PoolModal: UIComponent = {
                   $active={tab === 'liquidity'}
                   onClick={() => switchTab('liquidity')}
                   disabled={tab === 'liquidity'}
-                  style={{ borderRight: 'none' }}
                 >
                   Liquidity
                 </TabButton>
+                <TabButton
+                  $color={TAB_GREEN}
+                  $active={tab === 'chart'}
+                  onClick={() => switchTab('chart')}
+                  disabled={tab === 'chart'}
+                  style={{ borderRight: 'none' }}
+                >
+                  Chart
+                </TabButton>
               </Tabs>
-              {tab === 'swap' ? renderSwap() : renderLiquidity()}
+              {tab === 'swap' && renderSwap()}
+              {tab === 'liquidity' && renderLiquidity()}
+              {tab === 'chart' && renderChart()}
             </>
           )}
         </Container>

--- a/packages/client/src/app/components/modals/pool/chartOptions.ts
+++ b/packages/client/src/app/components/modals/pool/chartOptions.ts
@@ -1,0 +1,89 @@
+import { fmtAxisDate, fmtValue } from './utils';
+
+const GRID = '#e8e8e8';
+const CROSSHAIR = '#bbb';
+const TICK = '#999';
+
+type Axis = { min: number; max: number; ticks: number[]; decimals: number };
+type Span = { min: number; max: number; ticks: number[] };
+
+export const CrosshairPlugin = {
+  id: 'poolCrosshair',
+  beforeDatasetsDraw: (chart: any) => {
+    const active = chart.tooltip?.getActiveElements?.();
+    if (!active?.length) return;
+
+    const { ctx } = chart;
+    const { top, bottom } = chart.chartArea;
+    ctx.save();
+    ctx.beginPath();
+    ctx.lineWidth = 1;
+    ctx.strokeStyle = CROSSHAIR;
+    ctx.setLineDash([3, 4]);
+    ctx.moveTo(active[0].element.x, top);
+    ctx.lineTo(active[0].element.x, bottom);
+    ctx.stroke();
+    ctx.restore();
+  },
+};
+
+export const RightEdgePlugin = {
+  id: 'poolRightEdge',
+  beforeDatasetsDraw: (chart: any) => {
+    const { ctx, chartArea } = chart;
+    if (!chartArea) return;
+    ctx.save();
+    ctx.beginPath();
+    ctx.lineWidth = 1;
+    ctx.strokeStyle = GRID;
+    ctx.moveTo(chartArea.right, chartArea.top);
+    ctx.lineTo(chartArea.right, chartArea.bottom);
+    ctx.stroke();
+    ctx.restore();
+  },
+};
+
+export const buildChartOptions = (bounds: Axis, span: Span, trackHover: (args: any) => void) => ({
+  responsive: true,
+  maintainAspectRatio: false,
+  animation: false,
+  interaction: { mode: 'index', intersect: false },
+  scales: {
+    y: {
+      min: bounds.min,
+      max: bounds.max,
+      border: { display: false },
+      grid: { color: GRID, z: -1 },
+      afterBuildTicks: (axis: any) => {
+        axis.ticks = bounds.ticks.map((value) => ({ value }));
+      },
+      ticks: {
+        color: TICK,
+        font: { family: 'Pixel', size: 9 },
+        autoSkip: false,
+        callback: (value: any) => fmtValue(Number(value), bounds.decimals),
+      },
+    },
+    x: {
+      type: 'linear',
+      min: span.min,
+      max: span.max,
+      border: { display: false },
+      grid: { color: GRID, z: -1 },
+      afterBuildTicks: (axis: any) => {
+        axis.ticks = span.ticks.map((value) => ({ value }));
+      },
+      ticks: {
+        color: TICK,
+        font: { family: 'Pixel', size: 9 },
+        maxRotation: 0,
+        autoSkip: false,
+        callback: (value: any) => fmtAxisDate(Number(value)),
+      },
+    },
+  },
+  plugins: {
+    legend: { display: false },
+    tooltip: { enabled: false, external: trackHover },
+  },
+});

--- a/packages/client/src/app/components/modals/pool/utils.ts
+++ b/packages/client/src/app/components/modals/pool/utils.ts
@@ -8,3 +8,94 @@ export const fmtPrice = (n: number) => {
   const rounded = Number(n.toFixed(2));
   return rounded === 0 ? '<0.01' : rounded.toString();
 };
+
+/////////////////
+// PRICE CHART
+
+export const DAY = 3600 * 24;
+
+const Y_TICKS = 5;
+
+export const RANGES = {
+  '7d': DAY * 7,
+  '30d': DAY * 30,
+  Max: null,
+} as const;
+
+export type Range = keyof typeof RANGES;
+
+export interface PricePoint {
+  ts: number;
+  price: number;
+}
+
+export const isInverted = (
+  points: PricePoint[],
+  reference: number,
+  labels: { baseIsUnit: boolean; quoteIsSubject: boolean }
+) => {
+  const latest = points[points.length - 1]?.price ?? 0;
+  if (reference > 0 && latest > 0) {
+    const asIs = Math.abs(Math.log(latest / reference));
+    const flipped = Math.abs(Math.log(1 / latest / reference));
+    return flipped < asIs;
+  }
+  return labels.baseIsUnit && labels.quoteIsSubject;
+};
+
+const niceNum = (range: number, round: boolean) => {
+  const exponent = Math.floor(Math.log10(range));
+  const fraction = range / Math.pow(10, exponent);
+  let nice: number;
+  if (round) {
+    if (fraction < 1.5) nice = 1;
+    else if (fraction < 3) nice = 2;
+    else if (fraction < 7) nice = 5;
+    else nice = 10;
+  } else {
+    if (fraction <= 1) nice = 1;
+    else if (fraction <= 2) nice = 2;
+    else if (fraction <= 5) nice = 5;
+    else nice = 10;
+  }
+  return nice * Math.pow(10, exponent);
+};
+
+export const computeNiceAxis = (dataMin: number, dataMax: number, tickCount = Y_TICKS) => {
+  let low = dataMin;
+  let high = dataMax;
+  if (low === high) {
+    const pad = low === 0 ? 1 : Math.abs(low) * 0.1;
+    low -= pad;
+    high += pad;
+  }
+
+  const step = niceNum(niceNum(high - low, false) / (tickCount - 1), true);
+  const decimals = Math.max(0, -Math.floor(Math.log10(step)) + 1);
+  const round = (value: number) => parseFloat(value.toFixed(decimals));
+
+  const min = Math.floor(low / step) * step;
+  const max = Math.ceil(high / step) * step;
+  const ticks: number[] = [];
+  for (let value = min; value <= max + step * 0.5; value += step) ticks.push(round(value));
+
+  return { min: round(min), max: round(max), ticks, decimals };
+};
+
+export const fmtValue = (value: number, decimals: number) =>
+  value.toLocaleString('en-US', {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+
+export const fmtAxisDate = (ts: number) => {
+  const date = new Date(ts * 1000);
+  return `${date.getUTCMonth() + 1}/${date.getUTCDate()}`;
+};
+
+export const fmtFullDate = (ts: number) =>
+  new Date(ts * 1000).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });

--- a/packages/client/src/clients/kamiden/proto.ts
+++ b/packages/client/src/clients/kamiden/proto.ts
@@ -5,10 +5,10 @@
 // source: kamiden.proto
 
 /* eslint-disable */
-import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
-import type { CallContext, CallOptions } from "nice-grpc-common";
+import { BinaryReader, BinaryWriter } from '@bufbuild/protobuf/wire';
+import type { CallContext, CallOptions } from 'nice-grpc-common';
 
-export const protobufPackage = "kamiden";
+export const protobufPackage = 'kamiden';
 
 export enum KamiMarketBidType {
   KAMI_MARKET_BID_TYPE_UNSPECIFIED = 0,
@@ -293,8 +293,7 @@ export interface KamiMarketHistoryRequest {
   Size?: number | undefined;
 }
 
-export interface LeaderboardRequest {
-}
+export interface LeaderboardRequest {}
 
 export interface SetLogLevelRequest {
   level: string;
@@ -380,7 +379,7 @@ export interface LeaderboardRow {
 }
 
 function createBaseMessage(): Message {
-  return { RoomIndex: 0, AccountId: "", Message: "", Timestamp: 0 };
+  return { RoomIndex: 0, AccountId: '', Message: '', Timestamp: 0 };
 }
 
 export const Message: MessageFns<Message> = {
@@ -388,10 +387,10 @@ export const Message: MessageFns<Message> = {
     if (message.RoomIndex !== 0) {
       writer.uint32(8).uint32(message.RoomIndex);
     }
-    if (message.AccountId !== "") {
+    if (message.AccountId !== '') {
       writer.uint32(18).string(message.AccountId);
     }
-    if (message.Message !== "") {
+    if (message.Message !== '') {
       writer.uint32(26).string(message.Message);
     }
     if (message.Timestamp !== 0) {
@@ -454,15 +453,15 @@ export const Message: MessageFns<Message> = {
   fromPartial(object: DeepPartial<Message>): Message {
     const message = createBaseMessage();
     message.RoomIndex = object.RoomIndex ?? 0;
-    message.AccountId = object.AccountId ?? "";
-    message.Message = object.Message ?? "";
+    message.AccountId = object.AccountId ?? '';
+    message.Message = object.Message ?? '';
     message.Timestamp = object.Timestamp ?? 0;
     return message;
   },
 };
 
 function createBaseMovement(): Movement {
-  return { RoomIndex: 0, AccountId: "", Timestamp: 0 };
+  return { RoomIndex: 0, AccountId: '', Timestamp: 0 };
 }
 
 export const Movement: MessageFns<Movement> = {
@@ -470,7 +469,7 @@ export const Movement: MessageFns<Movement> = {
     if (message.RoomIndex !== 0) {
       writer.uint32(8).uint32(message.RoomIndex);
     }
-    if (message.AccountId !== "") {
+    if (message.AccountId !== '') {
       writer.uint32(18).string(message.AccountId);
     }
     if (message.Timestamp !== 0) {
@@ -525,14 +524,14 @@ export const Movement: MessageFns<Movement> = {
   fromPartial(object: DeepPartial<Movement>): Movement {
     const message = createBaseMovement();
     message.RoomIndex = object.RoomIndex ?? 0;
-    message.AccountId = object.AccountId ?? "";
+    message.AccountId = object.AccountId ?? '';
     message.Timestamp = object.Timestamp ?? 0;
     return message;
   },
 };
 
 function createBaseHarvestEnd(): HarvestEnd {
-  return { RoomIndex: 0, KamiId: "", Timestamp: 0 };
+  return { RoomIndex: 0, KamiId: '', Timestamp: 0 };
 }
 
 export const HarvestEnd: MessageFns<HarvestEnd> = {
@@ -540,7 +539,7 @@ export const HarvestEnd: MessageFns<HarvestEnd> = {
     if (message.RoomIndex !== 0) {
       writer.uint32(8).uint32(message.RoomIndex);
     }
-    if (message.KamiId !== "") {
+    if (message.KamiId !== '') {
       writer.uint32(18).string(message.KamiId);
     }
     if (message.Timestamp !== 0) {
@@ -595,7 +594,7 @@ export const HarvestEnd: MessageFns<HarvestEnd> = {
   fromPartial(object: DeepPartial<HarvestEnd>): HarvestEnd {
     const message = createBaseHarvestEnd();
     message.RoomIndex = object.RoomIndex ?? 0;
-    message.KamiId = object.KamiId ?? "";
+    message.KamiId = object.KamiId ?? '';
     message.Timestamp = object.Timestamp ?? 0;
     return message;
   },
@@ -603,18 +602,18 @@ export const HarvestEnd: MessageFns<HarvestEnd> = {
 
 function createBaseKill(): Kill {
   return {
-    AccountID: "",
+    AccountID: '',
     Timestamp: 0,
     RoomIndex: 0,
-    KillerId: "",
+    KillerId: '',
     KillerHealthSync: 0,
     KillerHealthTotal: 0,
-    VictimId: "",
+    VictimId: '',
     VictimHealthSync: 0,
     VictimHealthTotal: 0,
-    Bounty: "",
-    Salvage: "",
-    Spoils: "",
+    Bounty: '',
+    Salvage: '',
+    Spoils: '',
     IsDeath: false,
     BlockNumber: undefined,
   };
@@ -622,7 +621,7 @@ function createBaseKill(): Kill {
 
 export const Kill: MessageFns<Kill> = {
   encode(message: Kill, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.AccountID !== "") {
+    if (message.AccountID !== '') {
       writer.uint32(10).string(message.AccountID);
     }
     if (message.Timestamp !== 0) {
@@ -631,7 +630,7 @@ export const Kill: MessageFns<Kill> = {
     if (message.RoomIndex !== 0) {
       writer.uint32(24).uint32(message.RoomIndex);
     }
-    if (message.KillerId !== "") {
+    if (message.KillerId !== '') {
       writer.uint32(34).string(message.KillerId);
     }
     if (message.KillerHealthSync !== 0) {
@@ -640,7 +639,7 @@ export const Kill: MessageFns<Kill> = {
     if (message.KillerHealthTotal !== 0) {
       writer.uint32(48).int32(message.KillerHealthTotal);
     }
-    if (message.VictimId !== "") {
+    if (message.VictimId !== '') {
       writer.uint32(58).string(message.VictimId);
     }
     if (message.VictimHealthSync !== 0) {
@@ -649,13 +648,13 @@ export const Kill: MessageFns<Kill> = {
     if (message.VictimHealthTotal !== 0) {
       writer.uint32(72).int32(message.VictimHealthTotal);
     }
-    if (message.Bounty !== "") {
+    if (message.Bounty !== '') {
       writer.uint32(82).string(message.Bounty);
     }
-    if (message.Salvage !== "") {
+    if (message.Salvage !== '') {
       writer.uint32(90).string(message.Salvage);
     }
-    if (message.Spoils !== "") {
+    if (message.Spoils !== '') {
       writer.uint32(98).string(message.Spoils);
     }
     if (message.IsDeath !== false) {
@@ -800,18 +799,18 @@ export const Kill: MessageFns<Kill> = {
   },
   fromPartial(object: DeepPartial<Kill>): Kill {
     const message = createBaseKill();
-    message.AccountID = object.AccountID ?? "";
+    message.AccountID = object.AccountID ?? '';
     message.Timestamp = object.Timestamp ?? 0;
     message.RoomIndex = object.RoomIndex ?? 0;
-    message.KillerId = object.KillerId ?? "";
+    message.KillerId = object.KillerId ?? '';
     message.KillerHealthSync = object.KillerHealthSync ?? 0;
     message.KillerHealthTotal = object.KillerHealthTotal ?? 0;
-    message.VictimId = object.VictimId ?? "";
+    message.VictimId = object.VictimId ?? '';
     message.VictimHealthSync = object.VictimHealthSync ?? 0;
     message.VictimHealthTotal = object.VictimHealthTotal ?? 0;
-    message.Bounty = object.Bounty ?? "";
-    message.Salvage = object.Salvage ?? "";
-    message.Spoils = object.Spoils ?? "";
+    message.Bounty = object.Bounty ?? '';
+    message.Salvage = object.Salvage ?? '';
+    message.Spoils = object.Spoils ?? '';
     message.IsDeath = object.IsDeath ?? false;
     message.BlockNumber = object.BlockNumber ?? undefined;
     return message;
@@ -1068,24 +1067,30 @@ export const Feed: MessageFns<Feed> = {
     message.Kills = object.Kills?.map((e) => Kill.fromPartial(e)) || [];
     message.Trades = object.Trades?.map((e) => Trade.fromPartial(e)) || [];
     message.KamiCasts = object.KamiCasts?.map((e) => KamiCast.fromPartial(e)) || [];
-    message.DroptableReveals = object.DroptableReveals?.map((e) => DroptableReveal.fromPartial(e)) || [];
-    message.SacrificeReveals = object.SacrificeReveals?.map((e) => SacrificeReveal.fromPartial(e)) || [];
-    message.KamiMarketLists = object.KamiMarketLists?.map((e) => KamiMarketList.fromPartial(e)) || [];
+    message.DroptableReveals =
+      object.DroptableReveals?.map((e) => DroptableReveal.fromPartial(e)) || [];
+    message.SacrificeReveals =
+      object.SacrificeReveals?.map((e) => SacrificeReveal.fromPartial(e)) || [];
+    message.KamiMarketLists =
+      object.KamiMarketLists?.map((e) => KamiMarketList.fromPartial(e)) || [];
     message.KamiMarketBuys = object.KamiMarketBuys?.map((e) => KamiMarketBuy.fromPartial(e)) || [];
-    message.KamiMarketOffers = object.KamiMarketOffers?.map((e) => KamiMarketOffer.fromPartial(e)) || [];
-    message.KamiMarketAccepts = object.KamiMarketAccepts?.map((e) => KamiMarketAccept.fromPartial(e)) || [];
-    message.KamiMarketCancels = object.KamiMarketCancels?.map((e) => KamiMarketCancel.fromPartial(e)) || [];
+    message.KamiMarketOffers =
+      object.KamiMarketOffers?.map((e) => KamiMarketOffer.fromPartial(e)) || [];
+    message.KamiMarketAccepts =
+      object.KamiMarketAccepts?.map((e) => KamiMarketAccept.fromPartial(e)) || [];
+    message.KamiMarketCancels =
+      object.KamiMarketCancels?.map((e) => KamiMarketCancel.fromPartial(e)) || [];
     return message;
   },
 };
 
 function createBaseAuctionBuy(): AuctionBuy {
-  return { AccountIndex: "", ItemIndex: 0, Amount: 0, Currency: 0, Cost: 0, Timestamp: 0 };
+  return { AccountIndex: '', ItemIndex: 0, Amount: 0, Currency: 0, Cost: 0, Timestamp: 0 };
 }
 
 export const AuctionBuy: MessageFns<AuctionBuy> = {
   encode(message: AuctionBuy, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.AccountIndex !== "") {
+    if (message.AccountIndex !== '') {
       writer.uint32(10).string(message.AccountIndex);
     }
     if (message.ItemIndex !== 0) {
@@ -1175,7 +1180,7 @@ export const AuctionBuy: MessageFns<AuctionBuy> = {
   },
   fromPartial(object: DeepPartial<AuctionBuy>): AuctionBuy {
     const message = createBaseAuctionBuy();
-    message.AccountIndex = object.AccountIndex ?? "";
+    message.AccountIndex = object.AccountIndex ?? '';
     message.ItemIndex = object.ItemIndex ?? 0;
     message.Amount = object.Amount ?? 0;
     message.Currency = object.Currency ?? 0;
@@ -1186,18 +1191,18 @@ export const AuctionBuy: MessageFns<AuctionBuy> = {
 };
 
 function createBaseRankRow(): RankRow {
-  return { KamiName: "", OwnerName: "", OwnerAddress: "", KamiIndex: 0, Amount: 0 };
+  return { KamiName: '', OwnerName: '', OwnerAddress: '', KamiIndex: 0, Amount: 0 };
 }
 
 export const RankRow: MessageFns<RankRow> = {
   encode(message: RankRow, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.KamiName !== "") {
+    if (message.KamiName !== '') {
       writer.uint32(10).string(message.KamiName);
     }
-    if (message.OwnerName !== "") {
+    if (message.OwnerName !== '') {
       writer.uint32(18).string(message.OwnerName);
     }
-    if (message.OwnerAddress !== "") {
+    if (message.OwnerAddress !== '') {
       writer.uint32(26).string(message.OwnerAddress);
     }
     if (message.KamiIndex !== 0) {
@@ -1270,9 +1275,9 @@ export const RankRow: MessageFns<RankRow> = {
   },
   fromPartial(object: DeepPartial<RankRow>): RankRow {
     const message = createBaseRankRow();
-    message.KamiName = object.KamiName ?? "";
-    message.OwnerName = object.OwnerName ?? "";
-    message.OwnerAddress = object.OwnerAddress ?? "";
+    message.KamiName = object.KamiName ?? '';
+    message.OwnerName = object.OwnerName ?? '';
+    message.OwnerAddress = object.OwnerAddress ?? '';
     message.KamiIndex = object.KamiIndex ?? 0;
     message.Amount = object.Amount ?? 0;
     return message;
@@ -1281,29 +1286,29 @@ export const RankRow: MessageFns<RankRow> = {
 
 function createBaseTrade(): Trade {
   return {
-    TradeId: "",
-    MakerId: "",
-    TakerId: "",
+    TradeId: '',
+    MakerId: '',
+    TakerId: '',
     BuyOrderIndices: [],
     BuyOrderAmounts: [],
     SellOrderIndices: [],
     SellOrderAmounts: [],
-    CreateTimestamp: "",
-    CancelTimestamp: "",
-    ExecuteTimestamp: "",
-    CompleteTimestamp: "",
+    CreateTimestamp: '',
+    CancelTimestamp: '',
+    ExecuteTimestamp: '',
+    CompleteTimestamp: '',
   };
 }
 
 export const Trade: MessageFns<Trade> = {
   encode(message: Trade, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.TradeId !== "") {
+    if (message.TradeId !== '') {
       writer.uint32(10).string(message.TradeId);
     }
-    if (message.MakerId !== "") {
+    if (message.MakerId !== '') {
       writer.uint32(18).string(message.MakerId);
     }
-    if (message.TakerId !== "") {
+    if (message.TakerId !== '') {
       writer.uint32(26).string(message.TakerId);
     }
     writer.uint32(34).fork();
@@ -1322,16 +1327,16 @@ export const Trade: MessageFns<Trade> = {
     for (const v of message.SellOrderAmounts) {
       writer.uint32(58).string(v!);
     }
-    if (message.CreateTimestamp !== "") {
+    if (message.CreateTimestamp !== '') {
       writer.uint32(66).string(message.CreateTimestamp);
     }
-    if (message.CancelTimestamp !== "") {
+    if (message.CancelTimestamp !== '') {
       writer.uint32(74).string(message.CancelTimestamp);
     }
-    if (message.ExecuteTimestamp !== "") {
+    if (message.ExecuteTimestamp !== '') {
       writer.uint32(82).string(message.ExecuteTimestamp);
     }
-    if (message.CompleteTimestamp !== "") {
+    if (message.CompleteTimestamp !== '') {
       writer.uint32(90).string(message.CompleteTimestamp);
     }
     return writer;
@@ -1466,37 +1471,37 @@ export const Trade: MessageFns<Trade> = {
   },
   fromPartial(object: DeepPartial<Trade>): Trade {
     const message = createBaseTrade();
-    message.TradeId = object.TradeId ?? "";
-    message.MakerId = object.MakerId ?? "";
-    message.TakerId = object.TakerId ?? "";
+    message.TradeId = object.TradeId ?? '';
+    message.MakerId = object.MakerId ?? '';
+    message.TakerId = object.TakerId ?? '';
     message.BuyOrderIndices = object.BuyOrderIndices?.map((e) => e) || [];
     message.BuyOrderAmounts = object.BuyOrderAmounts?.map((e) => e) || [];
     message.SellOrderIndices = object.SellOrderIndices?.map((e) => e) || [];
     message.SellOrderAmounts = object.SellOrderAmounts?.map((e) => e) || [];
-    message.CreateTimestamp = object.CreateTimestamp ?? "";
-    message.CancelTimestamp = object.CancelTimestamp ?? "";
-    message.ExecuteTimestamp = object.ExecuteTimestamp ?? "";
-    message.CompleteTimestamp = object.CompleteTimestamp ?? "";
+    message.CreateTimestamp = object.CreateTimestamp ?? '';
+    message.CancelTimestamp = object.CancelTimestamp ?? '';
+    message.ExecuteTimestamp = object.ExecuteTimestamp ?? '';
+    message.CompleteTimestamp = object.CompleteTimestamp ?? '';
     return message;
   },
 };
 
 function createBaseItemTransfer(): ItemTransfer {
-  return { SenderAccountID: "", RecvAccountID: "", ItemIndex: 0, Amount: "" };
+  return { SenderAccountID: '', RecvAccountID: '', ItemIndex: 0, Amount: '' };
 }
 
 export const ItemTransfer: MessageFns<ItemTransfer> = {
   encode(message: ItemTransfer, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.SenderAccountID !== "") {
+    if (message.SenderAccountID !== '') {
       writer.uint32(10).string(message.SenderAccountID);
     }
-    if (message.RecvAccountID !== "") {
+    if (message.RecvAccountID !== '') {
       writer.uint32(18).string(message.RecvAccountID);
     }
     if (message.ItemIndex !== 0) {
       writer.uint32(24).uint32(message.ItemIndex);
     }
-    if (message.Amount !== "") {
+    if (message.Amount !== '') {
       writer.uint32(34).string(message.Amount);
     }
     return writer;
@@ -1555,27 +1560,27 @@ export const ItemTransfer: MessageFns<ItemTransfer> = {
   },
   fromPartial(object: DeepPartial<ItemTransfer>): ItemTransfer {
     const message = createBaseItemTransfer();
-    message.SenderAccountID = object.SenderAccountID ?? "";
-    message.RecvAccountID = object.RecvAccountID ?? "";
+    message.SenderAccountID = object.SenderAccountID ?? '';
+    message.RecvAccountID = object.RecvAccountID ?? '';
     message.ItemIndex = object.ItemIndex ?? 0;
-    message.Amount = object.Amount ?? "";
+    message.Amount = object.Amount ?? '';
     return message;
   },
 };
 
 function createBaseKamiCast(): KamiCast {
-  return { AccountID: "", Timestamp: 0, TargetID: "", itemIndex: 0, nodeIndex: 0 };
+  return { AccountID: '', Timestamp: 0, TargetID: '', itemIndex: 0, nodeIndex: 0 };
 }
 
 export const KamiCast: MessageFns<KamiCast> = {
   encode(message: KamiCast, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.AccountID !== "") {
+    if (message.AccountID !== '') {
       writer.uint32(10).string(message.AccountID);
     }
     if (message.Timestamp !== 0) {
       writer.uint32(16).uint64(message.Timestamp);
     }
-    if (message.TargetID !== "") {
+    if (message.TargetID !== '') {
       writer.uint32(26).string(message.TargetID);
     }
     if (message.itemIndex !== 0) {
@@ -1648,9 +1653,9 @@ export const KamiCast: MessageFns<KamiCast> = {
   },
   fromPartial(object: DeepPartial<KamiCast>): KamiCast {
     const message = createBaseKamiCast();
-    message.AccountID = object.AccountID ?? "";
+    message.AccountID = object.AccountID ?? '';
     message.Timestamp = object.Timestamp ?? 0;
-    message.TargetID = object.TargetID ?? "";
+    message.TargetID = object.TargetID ?? '';
     message.itemIndex = object.itemIndex ?? 0;
     message.nodeIndex = object.nodeIndex ?? 0;
     return message;
@@ -1658,18 +1663,18 @@ export const KamiCast: MessageFns<KamiCast> = {
 };
 
 function createBaseDroptableReveal(): DroptableReveal {
-  return { CommitID: "", HolderID: "", DtID: "", Timestamp: 0, ItemIndices: [], ItemAmounts: [] };
+  return { CommitID: '', HolderID: '', DtID: '', Timestamp: 0, ItemIndices: [], ItemAmounts: [] };
 }
 
 export const DroptableReveal: MessageFns<DroptableReveal> = {
   encode(message: DroptableReveal, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.CommitID !== "") {
+    if (message.CommitID !== '') {
       writer.uint32(10).string(message.CommitID);
     }
-    if (message.HolderID !== "") {
+    if (message.HolderID !== '') {
       writer.uint32(18).string(message.HolderID);
     }
-    if (message.DtID !== "") {
+    if (message.DtID !== '') {
       writer.uint32(26).string(message.DtID);
     }
     if (message.Timestamp !== 0) {
@@ -1765,9 +1770,9 @@ export const DroptableReveal: MessageFns<DroptableReveal> = {
   },
   fromPartial(object: DeepPartial<DroptableReveal>): DroptableReveal {
     const message = createBaseDroptableReveal();
-    message.CommitID = object.CommitID ?? "";
-    message.HolderID = object.HolderID ?? "";
-    message.DtID = object.DtID ?? "";
+    message.CommitID = object.CommitID ?? '';
+    message.HolderID = object.HolderID ?? '';
+    message.DtID = object.DtID ?? '';
     message.Timestamp = object.Timestamp ?? 0;
     message.ItemIndices = object.ItemIndices?.map((e) => e) || [];
     message.ItemAmounts = object.ItemAmounts?.map((e) => e) || [];
@@ -1776,21 +1781,29 @@ export const DroptableReveal: MessageFns<DroptableReveal> = {
 };
 
 function createBaseSacrificeReveal(): SacrificeReveal {
-  return { CommitID: "", HolderID: "", KamiID: "", DtID: "", Timestamp: 0, ItemIndices: [], ItemAmounts: [] };
+  return {
+    CommitID: '',
+    HolderID: '',
+    KamiID: '',
+    DtID: '',
+    Timestamp: 0,
+    ItemIndices: [],
+    ItemAmounts: [],
+  };
 }
 
 export const SacrificeReveal: MessageFns<SacrificeReveal> = {
   encode(message: SacrificeReveal, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.CommitID !== "") {
+    if (message.CommitID !== '') {
       writer.uint32(10).string(message.CommitID);
     }
-    if (message.HolderID !== "") {
+    if (message.HolderID !== '') {
       writer.uint32(18).string(message.HolderID);
     }
-    if (message.KamiID !== "") {
+    if (message.KamiID !== '') {
       writer.uint32(26).string(message.KamiID);
     }
-    if (message.DtID !== "") {
+    if (message.DtID !== '') {
       writer.uint32(34).string(message.DtID);
     }
     if (message.Timestamp !== 0) {
@@ -1894,10 +1907,10 @@ export const SacrificeReveal: MessageFns<SacrificeReveal> = {
   },
   fromPartial(object: DeepPartial<SacrificeReveal>): SacrificeReveal {
     const message = createBaseSacrificeReveal();
-    message.CommitID = object.CommitID ?? "";
-    message.HolderID = object.HolderID ?? "";
-    message.KamiID = object.KamiID ?? "";
-    message.DtID = object.DtID ?? "";
+    message.CommitID = object.CommitID ?? '';
+    message.HolderID = object.HolderID ?? '';
+    message.KamiID = object.KamiID ?? '';
+    message.DtID = object.DtID ?? '';
     message.Timestamp = object.Timestamp ?? 0;
     message.ItemIndices = object.ItemIndices?.map((e) => e) || [];
     message.ItemAmounts = object.ItemAmounts?.map((e) => e) || [];
@@ -1907,14 +1920,14 @@ export const SacrificeReveal: MessageFns<SacrificeReveal> = {
 
 function createBasePortalReceipt(): PortalReceipt {
   return {
-    Timestamp: "",
-    AccountID: "",
-    ReceiptID: "",
+    Timestamp: '',
+    AccountID: '',
+    ReceiptID: '',
     ItemIndex: 0,
-    ItemAmt: "",
-    TaxAmt: "",
-    TokenAddress: "",
-    TokenAmt: "",
+    ItemAmt: '',
+    TaxAmt: '',
+    TokenAddress: '',
+    TokenAmt: '',
     IsWithdrawal: false,
     IsCanceled: false,
     IsClaimed: false,
@@ -1923,28 +1936,28 @@ function createBasePortalReceipt(): PortalReceipt {
 
 export const PortalReceipt: MessageFns<PortalReceipt> = {
   encode(message: PortalReceipt, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.Timestamp !== "") {
+    if (message.Timestamp !== '') {
       writer.uint32(10).string(message.Timestamp);
     }
-    if (message.AccountID !== "") {
+    if (message.AccountID !== '') {
       writer.uint32(18).string(message.AccountID);
     }
-    if (message.ReceiptID !== "") {
+    if (message.ReceiptID !== '') {
       writer.uint32(26).string(message.ReceiptID);
     }
     if (message.ItemIndex !== 0) {
       writer.uint32(32).uint32(message.ItemIndex);
     }
-    if (message.ItemAmt !== "") {
+    if (message.ItemAmt !== '') {
       writer.uint32(42).string(message.ItemAmt);
     }
-    if (message.TaxAmt !== "") {
+    if (message.TaxAmt !== '') {
       writer.uint32(50).string(message.TaxAmt);
     }
-    if (message.TokenAddress !== "") {
+    if (message.TokenAddress !== '') {
       writer.uint32(58).string(message.TokenAddress);
     }
-    if (message.TokenAmt !== "") {
+    if (message.TokenAmt !== '') {
       writer.uint32(66).string(message.TokenAmt);
     }
     if (message.IsWithdrawal !== false) {
@@ -2068,14 +2081,14 @@ export const PortalReceipt: MessageFns<PortalReceipt> = {
   },
   fromPartial(object: DeepPartial<PortalReceipt>): PortalReceipt {
     const message = createBasePortalReceipt();
-    message.Timestamp = object.Timestamp ?? "";
-    message.AccountID = object.AccountID ?? "";
-    message.ReceiptID = object.ReceiptID ?? "";
+    message.Timestamp = object.Timestamp ?? '';
+    message.AccountID = object.AccountID ?? '';
+    message.ReceiptID = object.ReceiptID ?? '';
     message.ItemIndex = object.ItemIndex ?? 0;
-    message.ItemAmt = object.ItemAmt ?? "";
-    message.TaxAmt = object.TaxAmt ?? "";
-    message.TokenAddress = object.TokenAddress ?? "";
-    message.TokenAmt = object.TokenAmt ?? "";
+    message.ItemAmt = object.ItemAmt ?? '';
+    message.TaxAmt = object.TaxAmt ?? '';
+    message.TokenAddress = object.TokenAddress ?? '';
+    message.TokenAmt = object.TokenAmt ?? '';
     message.IsWithdrawal = object.IsWithdrawal ?? false;
     message.IsCanceled = object.IsCanceled ?? false;
     message.IsClaimed = object.IsClaimed ?? false;
@@ -2084,24 +2097,24 @@ export const PortalReceipt: MessageFns<PortalReceipt> = {
 };
 
 function createBaseKamiMarketList(): KamiMarketList {
-  return { OrderID: "", AccountID: "", KamiIndex: 0, Price: "", Expiry: "", Timestamp: 0 };
+  return { OrderID: '', AccountID: '', KamiIndex: 0, Price: '', Expiry: '', Timestamp: 0 };
 }
 
 export const KamiMarketList: MessageFns<KamiMarketList> = {
   encode(message: KamiMarketList, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.OrderID !== "") {
+    if (message.OrderID !== '') {
       writer.uint32(10).string(message.OrderID);
     }
-    if (message.AccountID !== "") {
+    if (message.AccountID !== '') {
       writer.uint32(18).string(message.AccountID);
     }
     if (message.KamiIndex !== 0) {
       writer.uint32(24).uint32(message.KamiIndex);
     }
-    if (message.Price !== "") {
+    if (message.Price !== '') {
       writer.uint32(34).string(message.Price);
     }
-    if (message.Expiry !== "") {
+    if (message.Expiry !== '') {
       writer.uint32(42).string(message.Expiry);
     }
     if (message.Timestamp !== 0) {
@@ -2179,35 +2192,42 @@ export const KamiMarketList: MessageFns<KamiMarketList> = {
   },
   fromPartial(object: DeepPartial<KamiMarketList>): KamiMarketList {
     const message = createBaseKamiMarketList();
-    message.OrderID = object.OrderID ?? "";
-    message.AccountID = object.AccountID ?? "";
+    message.OrderID = object.OrderID ?? '';
+    message.AccountID = object.AccountID ?? '';
     message.KamiIndex = object.KamiIndex ?? 0;
-    message.Price = object.Price ?? "";
-    message.Expiry = object.Expiry ?? "";
+    message.Price = object.Price ?? '';
+    message.Expiry = object.Expiry ?? '';
     message.Timestamp = object.Timestamp ?? 0;
     return message;
   },
 };
 
 function createBaseKamiMarketBuy(): KamiMarketBuy {
-  return { OrderID: "", BuyerAccountID: "", SellerAccountID: "", KamiIndex: 0, Price: "", Timestamp: 0 };
+  return {
+    OrderID: '',
+    BuyerAccountID: '',
+    SellerAccountID: '',
+    KamiIndex: 0,
+    Price: '',
+    Timestamp: 0,
+  };
 }
 
 export const KamiMarketBuy: MessageFns<KamiMarketBuy> = {
   encode(message: KamiMarketBuy, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.OrderID !== "") {
+    if (message.OrderID !== '') {
       writer.uint32(10).string(message.OrderID);
     }
-    if (message.BuyerAccountID !== "") {
+    if (message.BuyerAccountID !== '') {
       writer.uint32(18).string(message.BuyerAccountID);
     }
-    if (message.SellerAccountID !== "") {
+    if (message.SellerAccountID !== '') {
       writer.uint32(26).string(message.SellerAccountID);
     }
     if (message.KamiIndex !== 0) {
       writer.uint32(32).uint32(message.KamiIndex);
     }
-    if (message.Price !== "") {
+    if (message.Price !== '') {
       writer.uint32(42).string(message.Price);
     }
     if (message.Timestamp !== 0) {
@@ -2285,26 +2305,34 @@ export const KamiMarketBuy: MessageFns<KamiMarketBuy> = {
   },
   fromPartial(object: DeepPartial<KamiMarketBuy>): KamiMarketBuy {
     const message = createBaseKamiMarketBuy();
-    message.OrderID = object.OrderID ?? "";
-    message.BuyerAccountID = object.BuyerAccountID ?? "";
-    message.SellerAccountID = object.SellerAccountID ?? "";
+    message.OrderID = object.OrderID ?? '';
+    message.BuyerAccountID = object.BuyerAccountID ?? '';
+    message.SellerAccountID = object.SellerAccountID ?? '';
     message.KamiIndex = object.KamiIndex ?? 0;
-    message.Price = object.Price ?? "";
+    message.Price = object.Price ?? '';
     message.Timestamp = object.Timestamp ?? 0;
     return message;
   },
 };
 
 function createBaseKamiMarketOffer(): KamiMarketOffer {
-  return { OrderID: "", AccountID: "", KamiIndex: 0, Quantity: 0, Price: "", Expiry: "", Timestamp: 0 };
+  return {
+    OrderID: '',
+    AccountID: '',
+    KamiIndex: 0,
+    Quantity: 0,
+    Price: '',
+    Expiry: '',
+    Timestamp: 0,
+  };
 }
 
 export const KamiMarketOffer: MessageFns<KamiMarketOffer> = {
   encode(message: KamiMarketOffer, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.OrderID !== "") {
+    if (message.OrderID !== '') {
       writer.uint32(10).string(message.OrderID);
     }
-    if (message.AccountID !== "") {
+    if (message.AccountID !== '') {
       writer.uint32(18).string(message.AccountID);
     }
     if (message.KamiIndex !== 0) {
@@ -2313,10 +2341,10 @@ export const KamiMarketOffer: MessageFns<KamiMarketOffer> = {
     if (message.Quantity !== 0) {
       writer.uint32(32).uint32(message.Quantity);
     }
-    if (message.Price !== "") {
+    if (message.Price !== '') {
       writer.uint32(42).string(message.Price);
     }
-    if (message.Expiry !== "") {
+    if (message.Expiry !== '') {
       writer.uint32(50).string(message.Expiry);
     }
     if (message.Timestamp !== 0) {
@@ -2402,36 +2430,43 @@ export const KamiMarketOffer: MessageFns<KamiMarketOffer> = {
   },
   fromPartial(object: DeepPartial<KamiMarketOffer>): KamiMarketOffer {
     const message = createBaseKamiMarketOffer();
-    message.OrderID = object.OrderID ?? "";
-    message.AccountID = object.AccountID ?? "";
+    message.OrderID = object.OrderID ?? '';
+    message.AccountID = object.AccountID ?? '';
     message.KamiIndex = object.KamiIndex ?? 0;
     message.Quantity = object.Quantity ?? 0;
-    message.Price = object.Price ?? "";
-    message.Expiry = object.Expiry ?? "";
+    message.Price = object.Price ?? '';
+    message.Expiry = object.Expiry ?? '';
     message.Timestamp = object.Timestamp ?? 0;
     return message;
   },
 };
 
 function createBaseKamiMarketAccept(): KamiMarketAccept {
-  return { OrderID: "", SellerAccountID: "", BuyerAccountID: "", KamiIndex: 0, Price: "", Timestamp: 0 };
+  return {
+    OrderID: '',
+    SellerAccountID: '',
+    BuyerAccountID: '',
+    KamiIndex: 0,
+    Price: '',
+    Timestamp: 0,
+  };
 }
 
 export const KamiMarketAccept: MessageFns<KamiMarketAccept> = {
   encode(message: KamiMarketAccept, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.OrderID !== "") {
+    if (message.OrderID !== '') {
       writer.uint32(10).string(message.OrderID);
     }
-    if (message.SellerAccountID !== "") {
+    if (message.SellerAccountID !== '') {
       writer.uint32(18).string(message.SellerAccountID);
     }
-    if (message.BuyerAccountID !== "") {
+    if (message.BuyerAccountID !== '') {
       writer.uint32(26).string(message.BuyerAccountID);
     }
     if (message.KamiIndex !== 0) {
       writer.uint32(32).uint32(message.KamiIndex);
     }
-    if (message.Price !== "") {
+    if (message.Price !== '') {
       writer.uint32(42).string(message.Price);
     }
     if (message.Timestamp !== 0) {
@@ -2509,26 +2544,26 @@ export const KamiMarketAccept: MessageFns<KamiMarketAccept> = {
   },
   fromPartial(object: DeepPartial<KamiMarketAccept>): KamiMarketAccept {
     const message = createBaseKamiMarketAccept();
-    message.OrderID = object.OrderID ?? "";
-    message.SellerAccountID = object.SellerAccountID ?? "";
-    message.BuyerAccountID = object.BuyerAccountID ?? "";
+    message.OrderID = object.OrderID ?? '';
+    message.SellerAccountID = object.SellerAccountID ?? '';
+    message.BuyerAccountID = object.BuyerAccountID ?? '';
     message.KamiIndex = object.KamiIndex ?? 0;
-    message.Price = object.Price ?? "";
+    message.Price = object.Price ?? '';
     message.Timestamp = object.Timestamp ?? 0;
     return message;
   },
 };
 
 function createBaseKamiMarketCancel(): KamiMarketCancel {
-  return { OrderID: "", AccountID: "", Timestamp: 0 };
+  return { OrderID: '', AccountID: '', Timestamp: 0 };
 }
 
 export const KamiMarketCancel: MessageFns<KamiMarketCancel> = {
   encode(message: KamiMarketCancel, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.OrderID !== "") {
+    if (message.OrderID !== '') {
       writer.uint32(10).string(message.OrderID);
     }
-    if (message.AccountID !== "") {
+    if (message.AccountID !== '') {
       writer.uint32(18).string(message.AccountID);
     }
     if (message.Timestamp !== 0) {
@@ -2582,38 +2617,46 @@ export const KamiMarketCancel: MessageFns<KamiMarketCancel> = {
   },
   fromPartial(object: DeepPartial<KamiMarketCancel>): KamiMarketCancel {
     const message = createBaseKamiMarketCancel();
-    message.OrderID = object.OrderID ?? "";
-    message.AccountID = object.AccountID ?? "";
+    message.OrderID = object.OrderID ?? '';
+    message.AccountID = object.AccountID ?? '';
     message.Timestamp = object.Timestamp ?? 0;
     return message;
   },
 };
 
 function createBaseKamiMarketListing(): KamiMarketListing {
-  return { OrderID: "", SellerAccountID: "", KamiIndex: 0, Price: "", Expiry: "", Timestamp: 0, BuyerAccountID: "" };
+  return {
+    OrderID: '',
+    SellerAccountID: '',
+    KamiIndex: 0,
+    Price: '',
+    Expiry: '',
+    Timestamp: 0,
+    BuyerAccountID: '',
+  };
 }
 
 export const KamiMarketListing: MessageFns<KamiMarketListing> = {
   encode(message: KamiMarketListing, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.OrderID !== "") {
+    if (message.OrderID !== '') {
       writer.uint32(10).string(message.OrderID);
     }
-    if (message.SellerAccountID !== "") {
+    if (message.SellerAccountID !== '') {
       writer.uint32(18).string(message.SellerAccountID);
     }
     if (message.KamiIndex !== 0) {
       writer.uint32(24).uint32(message.KamiIndex);
     }
-    if (message.Price !== "") {
+    if (message.Price !== '') {
       writer.uint32(34).string(message.Price);
     }
-    if (message.Expiry !== "") {
+    if (message.Expiry !== '') {
       writer.uint32(42).string(message.Expiry);
     }
     if (message.Timestamp !== 0) {
       writer.uint32(48).uint64(message.Timestamp);
     }
-    if (message.BuyerAccountID !== "") {
+    if (message.BuyerAccountID !== '') {
       writer.uint32(58).string(message.BuyerAccountID);
     }
     return writer;
@@ -2696,25 +2739,25 @@ export const KamiMarketListing: MessageFns<KamiMarketListing> = {
   },
   fromPartial(object: DeepPartial<KamiMarketListing>): KamiMarketListing {
     const message = createBaseKamiMarketListing();
-    message.OrderID = object.OrderID ?? "";
-    message.SellerAccountID = object.SellerAccountID ?? "";
+    message.OrderID = object.OrderID ?? '';
+    message.SellerAccountID = object.SellerAccountID ?? '';
     message.KamiIndex = object.KamiIndex ?? 0;
-    message.Price = object.Price ?? "";
-    message.Expiry = object.Expiry ?? "";
+    message.Price = object.Price ?? '';
+    message.Expiry = object.Expiry ?? '';
     message.Timestamp = object.Timestamp ?? 0;
-    message.BuyerAccountID = object.BuyerAccountID ?? "";
+    message.BuyerAccountID = object.BuyerAccountID ?? '';
     return message;
   },
 };
 
 function createBaseKamiMarketBid(): KamiMarketBid {
   return {
-    OrderID: "",
-    BuyerAccountID: "",
+    OrderID: '',
+    BuyerAccountID: '',
     KamiIndex: 0,
     Total: 0,
-    Price: "",
-    Expiry: "",
+    Price: '',
+    Expiry: '',
     Timestamp: 0,
     BidType: 0,
     Quantity: 0,
@@ -2724,10 +2767,10 @@ function createBaseKamiMarketBid(): KamiMarketBid {
 
 export const KamiMarketBid: MessageFns<KamiMarketBid> = {
   encode(message: KamiMarketBid, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.OrderID !== "") {
+    if (message.OrderID !== '') {
       writer.uint32(10).string(message.OrderID);
     }
-    if (message.BuyerAccountID !== "") {
+    if (message.BuyerAccountID !== '') {
       writer.uint32(18).string(message.BuyerAccountID);
     }
     if (message.KamiIndex !== 0) {
@@ -2736,10 +2779,10 @@ export const KamiMarketBid: MessageFns<KamiMarketBid> = {
     if (message.Total !== 0) {
       writer.uint32(32).uint32(message.Total);
     }
-    if (message.Price !== "") {
+    if (message.Price !== '') {
       writer.uint32(42).string(message.Price);
     }
-    if (message.Expiry !== "") {
+    if (message.Expiry !== '') {
       writer.uint32(50).string(message.Expiry);
     }
     if (message.Timestamp !== 0) {
@@ -2870,12 +2913,12 @@ export const KamiMarketBid: MessageFns<KamiMarketBid> = {
   },
   fromPartial(object: DeepPartial<KamiMarketBid>): KamiMarketBid {
     const message = createBaseKamiMarketBid();
-    message.OrderID = object.OrderID ?? "";
-    message.BuyerAccountID = object.BuyerAccountID ?? "";
+    message.OrderID = object.OrderID ?? '';
+    message.BuyerAccountID = object.BuyerAccountID ?? '';
     message.KamiIndex = object.KamiIndex ?? 0;
     message.Total = object.Total ?? 0;
-    message.Price = object.Price ?? "";
-    message.Expiry = object.Expiry ?? "";
+    message.Price = object.Price ?? '';
+    message.Expiry = object.Expiry ?? '';
     message.Timestamp = object.Timestamp ?? 0;
     message.BidType = object.BidType ?? 0;
     message.Quantity = object.Quantity ?? 0;
@@ -2885,7 +2928,14 @@ export const KamiMarketBid: MessageFns<KamiMarketBid> = {
 };
 
 function createBaseKamiMarketOrder(): KamiMarketOrder {
-  return { Timestamp: 0, OrderID: "", IsCanceled: false, IsComplete: false, Listing: undefined, Bid: undefined };
+  return {
+    Timestamp: 0,
+    OrderID: '',
+    IsCanceled: false,
+    IsComplete: false,
+    Listing: undefined,
+    Bid: undefined,
+  };
 }
 
 export const KamiMarketOrder: MessageFns<KamiMarketOrder> = {
@@ -2893,7 +2943,7 @@ export const KamiMarketOrder: MessageFns<KamiMarketOrder> = {
     if (message.Timestamp !== 0) {
       writer.uint32(8).uint64(message.Timestamp);
     }
-    if (message.OrderID !== "") {
+    if (message.OrderID !== '') {
       writer.uint32(18).string(message.OrderID);
     }
     if (message.IsCanceled !== false) {
@@ -2981,13 +3031,17 @@ export const KamiMarketOrder: MessageFns<KamiMarketOrder> = {
   fromPartial(object: DeepPartial<KamiMarketOrder>): KamiMarketOrder {
     const message = createBaseKamiMarketOrder();
     message.Timestamp = object.Timestamp ?? 0;
-    message.OrderID = object.OrderID ?? "";
+    message.OrderID = object.OrderID ?? '';
     message.IsCanceled = object.IsCanceled ?? false;
     message.IsComplete = object.IsComplete ?? false;
-    message.Listing = (object.Listing !== undefined && object.Listing !== null)
-      ? KamiMarketListing.fromPartial(object.Listing)
-      : undefined;
-    message.Bid = (object.Bid !== undefined && object.Bid !== null) ? KamiMarketBid.fromPartial(object.Bid) : undefined;
+    message.Listing =
+      object.Listing !== undefined && object.Listing !== null
+        ? KamiMarketListing.fromPartial(object.Listing)
+        : undefined;
+    message.Bid =
+      object.Bid !== undefined && object.Bid !== null
+        ? KamiMarketBid.fromPartial(object.Bid)
+        : undefined;
     return message;
   },
 };
@@ -3271,7 +3325,7 @@ export const BattleStatsRequest: MessageFns<BattleStatsRequest> = {
 };
 
 function createBaseRankingRequest(): RankingRequest {
-  return { StartBlock: 0, EndBlock: 0, ApiKey: "", IsVip: undefined, ByCount: undefined };
+  return { StartBlock: 0, EndBlock: 0, ApiKey: '', IsVip: undefined, ByCount: undefined };
 }
 
 export const RankingRequest: MessageFns<RankingRequest> = {
@@ -3282,7 +3336,7 @@ export const RankingRequest: MessageFns<RankingRequest> = {
     if (message.EndBlock !== 0) {
       writer.uint32(16).uint64(message.EndBlock);
     }
-    if (message.ApiKey !== "") {
+    if (message.ApiKey !== '') {
       writer.uint32(26).string(message.ApiKey);
     }
     if (message.IsVip !== undefined) {
@@ -3357,7 +3411,7 @@ export const RankingRequest: MessageFns<RankingRequest> = {
     const message = createBaseRankingRequest();
     message.StartBlock = object.StartBlock ?? 0;
     message.EndBlock = object.EndBlock ?? 0;
-    message.ApiKey = object.ApiKey ?? "";
+    message.ApiKey = object.ApiKey ?? '';
     message.IsVip = object.IsVip ?? undefined;
     message.ByCount = object.ByCount ?? undefined;
     return message;
@@ -3365,15 +3419,15 @@ export const RankingRequest: MessageFns<RankingRequest> = {
 };
 
 function createBaseTradesRequest(): TradesRequest {
-  return { AccountId: "", Timestamp: "" };
+  return { AccountId: '', Timestamp: '' };
 }
 
 export const TradesRequest: MessageFns<TradesRequest> = {
   encode(message: TradesRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.AccountId !== "") {
+    if (message.AccountId !== '') {
       writer.uint32(10).string(message.AccountId);
     }
-    if (message.Timestamp !== "") {
+    if (message.Timestamp !== '') {
       writer.uint32(18).string(message.Timestamp);
     }
     return writer;
@@ -3416,19 +3470,19 @@ export const TradesRequest: MessageFns<TradesRequest> = {
   },
   fromPartial(object: DeepPartial<TradesRequest>): TradesRequest {
     const message = createBaseTradesRequest();
-    message.AccountId = object.AccountId ?? "";
-    message.Timestamp = object.Timestamp ?? "";
+    message.AccountId = object.AccountId ?? '';
+    message.Timestamp = object.Timestamp ?? '';
     return message;
   },
 };
 
 function createBaseItemTransferRequest(): ItemTransferRequest {
-  return { AccountID: "" };
+  return { AccountID: '' };
 }
 
 export const ItemTransferRequest: MessageFns<ItemTransferRequest> = {
   encode(message: ItemTransferRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.AccountID !== "") {
+    if (message.AccountID !== '') {
       writer.uint32(10).string(message.AccountID);
     }
     return writer;
@@ -3463,18 +3517,18 @@ export const ItemTransferRequest: MessageFns<ItemTransferRequest> = {
   },
   fromPartial(object: DeepPartial<ItemTransferRequest>): ItemTransferRequest {
     const message = createBaseItemTransferRequest();
-    message.AccountID = object.AccountID ?? "";
+    message.AccountID = object.AccountID ?? '';
     return message;
   },
 };
 
 function createBaseTokenPortalRequest(): TokenPortalRequest {
-  return { AccountID: "" };
+  return { AccountID: '' };
 }
 
 export const TokenPortalRequest: MessageFns<TokenPortalRequest> = {
   encode(message: TokenPortalRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.AccountID !== "") {
+    if (message.AccountID !== '') {
       writer.uint32(10).string(message.AccountID);
     }
     return writer;
@@ -3509,7 +3563,7 @@ export const TokenPortalRequest: MessageFns<TokenPortalRequest> = {
   },
   fromPartial(object: DeepPartial<TokenPortalRequest>): TokenPortalRequest {
     const message = createBaseTokenPortalRequest();
-    message.AccountID = object.AccountID ?? "";
+    message.AccountID = object.AccountID ?? '';
     return message;
   },
 };
@@ -3519,7 +3573,10 @@ function createBaseKamiMarketListingsRequest(): KamiMarketListingsRequest {
 }
 
 export const KamiMarketListingsRequest: MessageFns<KamiMarketListingsRequest> = {
-  encode(message: KamiMarketListingsRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: KamiMarketListingsRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
     if (message.Timestamp !== undefined) {
       writer.uint32(8).uint64(message.Timestamp);
     }
@@ -3631,12 +3688,15 @@ export const KamiMarketBidsRequest: MessageFns<KamiMarketBidsRequest> = {
 };
 
 function createBaseKamiMarketHistoryRequest(): KamiMarketHistoryRequest {
-  return { AccountId: "", Timestamp: undefined, Size: undefined };
+  return { AccountId: '', Timestamp: undefined, Size: undefined };
 }
 
 export const KamiMarketHistoryRequest: MessageFns<KamiMarketHistoryRequest> = {
-  encode(message: KamiMarketHistoryRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.AccountId !== "") {
+  encode(
+    message: KamiMarketHistoryRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.AccountId !== '') {
       writer.uint32(10).string(message.AccountId);
     }
     if (message.Timestamp !== undefined) {
@@ -3693,7 +3753,7 @@ export const KamiMarketHistoryRequest: MessageFns<KamiMarketHistoryRequest> = {
   },
   fromPartial(object: DeepPartial<KamiMarketHistoryRequest>): KamiMarketHistoryRequest {
     const message = createBaseKamiMarketHistoryRequest();
-    message.AccountId = object.AccountId ?? "";
+    message.AccountId = object.AccountId ?? '';
     message.Timestamp = object.Timestamp ?? undefined;
     message.Size = object.Size ?? undefined;
     return message;
@@ -3735,15 +3795,15 @@ export const LeaderboardRequest: MessageFns<LeaderboardRequest> = {
 };
 
 function createBaseSetLogLevelRequest(): SetLogLevelRequest {
-  return { level: "", apiKey: "" };
+  return { level: '', apiKey: '' };
 }
 
 export const SetLogLevelRequest: MessageFns<SetLogLevelRequest> = {
   encode(message: SetLogLevelRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.level !== "") {
+    if (message.level !== '') {
       writer.uint32(10).string(message.level);
     }
-    if (message.apiKey !== "") {
+    if (message.apiKey !== '') {
       writer.uint32(18).string(message.apiKey);
     }
     return writer;
@@ -3786,8 +3846,8 @@ export const SetLogLevelRequest: MessageFns<SetLogLevelRequest> = {
   },
   fromPartial(object: DeepPartial<SetLogLevelRequest>): SetLogLevelRequest {
     const message = createBaseSetLogLevelRequest();
-    message.level = object.level ?? "";
-    message.apiKey = object.apiKey ?? "";
+    message.level = object.level ?? '';
+    message.apiKey = object.apiKey ?? '';
     return message;
   },
 };
@@ -3903,7 +3963,8 @@ export const StreamResponse: MessageFns<StreamResponse> = {
   fromPartial(object: DeepPartial<StreamResponse>): StreamResponse {
     const message = createBaseStreamResponse();
     message.Messages = object.Messages?.map((e) => Message.fromPartial(e)) || [];
-    message.Feed = (object.Feed !== undefined && object.Feed !== null) ? Feed.fromPartial(object.Feed) : undefined;
+    message.Feed =
+      object.Feed !== undefined && object.Feed !== null ? Feed.fromPartial(object.Feed) : undefined;
     return message;
   },
 };
@@ -4041,9 +4102,10 @@ export const BattleStatsResponse: MessageFns<BattleStatsResponse> = {
   },
   fromPartial(object: DeepPartial<BattleStatsResponse>): BattleStatsResponse {
     const message = createBaseBattleStatsResponse();
-    message.BattleStats = (object.BattleStats !== undefined && object.BattleStats !== null)
-      ? BattleStats.fromPartial(object.BattleStats)
-      : undefined;
+    message.BattleStats =
+      object.BattleStats !== undefined && object.BattleStats !== null
+        ? BattleStats.fromPartial(object.BattleStats)
+        : undefined;
     return message;
   },
 };
@@ -4237,7 +4299,10 @@ function createBaseKamiMarketListingsResponse(): KamiMarketListingsResponse {
 }
 
 export const KamiMarketListingsResponse: MessageFns<KamiMarketListingsResponse> = {
-  encode(message: KamiMarketListingsResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: KamiMarketListingsResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
     for (const v of message.Listings) {
       KamiMarketListing.encode(v!, writer.uint32(10).fork()).join();
     }
@@ -4329,7 +4394,10 @@ function createBaseKamiMarketHistoryResponse(): KamiMarketHistoryResponse {
 }
 
 export const KamiMarketHistoryResponse: MessageFns<KamiMarketHistoryResponse> = {
-  encode(message: KamiMarketHistoryResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: KamiMarketHistoryResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
     for (const v of message.Orders) {
       KamiMarketOrder.encode(v!, writer.uint32(10).fork()).join();
     }
@@ -4371,12 +4439,12 @@ export const KamiMarketHistoryResponse: MessageFns<KamiMarketHistoryResponse> = 
 };
 
 function createBaseSetLogLevelResponse(): SetLogLevelResponse {
-  return { level: "" };
+  return { level: '' };
 }
 
 export const SetLogLevelResponse: MessageFns<SetLogLevelResponse> = {
   encode(message: SetLogLevelResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.level !== "") {
+    if (message.level !== '') {
       writer.uint32(10).string(message.level);
     }
     return writer;
@@ -4411,7 +4479,7 @@ export const SetLogLevelResponse: MessageFns<SetLogLevelResponse> = {
   },
   fromPartial(object: DeepPartial<SetLogLevelResponse>): SetLogLevelResponse {
     const message = createBaseSetLogLevelResponse();
-    message.level = object.level ?? "";
+    message.level = object.level ?? '';
     return message;
   },
 };
@@ -4627,15 +4695,15 @@ export const PoolPriceHistory: MessageFns<PoolPriceHistory> = {
 };
 
 function createBaseLeaderboardRow(): LeaderboardRow {
-  return { Name: "", Value: "" };
+  return { Name: '', Value: '' };
 }
 
 export const LeaderboardRow: MessageFns<LeaderboardRow> = {
   encode(message: LeaderboardRow, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.Name !== "") {
+    if (message.Name !== '') {
       writer.uint32(10).string(message.Name);
     }
-    if (message.Value !== "") {
+    if (message.Value !== '') {
       writer.uint32(18).string(message.Value);
     }
     return writer;
@@ -4678,8 +4746,8 @@ export const LeaderboardRow: MessageFns<LeaderboardRow> = {
   },
   fromPartial(object: DeepPartial<LeaderboardRow>): LeaderboardRow {
     const message = createBaseLeaderboardRow();
-    message.Name = object.Name ?? "";
-    message.Value = object.Value ?? "";
+    message.Name = object.Name ?? '';
+    message.Value = object.Value ?? '';
     return message;
   },
 };
@@ -4687,12 +4755,12 @@ export const LeaderboardRow: MessageFns<LeaderboardRow> = {
 /** Replies */
 export type KamidenServiceDefinition = typeof KamidenServiceDefinition;
 export const KamidenServiceDefinition = {
-  name: "KamidenService",
-  fullName: "kamiden.KamidenService",
+  name: 'KamidenService',
+  fullName: 'kamiden.KamidenService',
   methods: {
     /** Requests the latest block number based on the latest ECS state. */
     getRoomMessages: {
-      name: "GetRoomMessages",
+      name: 'GetRoomMessages',
       requestType: RoomRequest,
       requestStream: false,
       responseType: RoomResponse,
@@ -4700,7 +4768,7 @@ export const KamidenServiceDefinition = {
       options: {},
     },
     getAuctionBuys: {
-      name: "GetAuctionBuys",
+      name: 'GetAuctionBuys',
       requestType: AuctionBuysRequest,
       requestStream: false,
       responseType: AuctionBuysResponse,
@@ -4708,7 +4776,7 @@ export const KamidenServiceDefinition = {
       options: {},
     },
     getBattles: {
-      name: "GetBattles",
+      name: 'GetBattles',
       requestType: BattlesRequest,
       requestStream: false,
       responseType: BattlesResponse,
@@ -4716,7 +4784,7 @@ export const KamidenServiceDefinition = {
       options: {},
     },
     getBattleStats: {
-      name: "GetBattleStats",
+      name: 'GetBattleStats',
       requestType: BattleStatsRequest,
       requestStream: false,
       responseType: BattleStatsResponse,
@@ -4724,7 +4792,7 @@ export const KamidenServiceDefinition = {
       options: {},
     },
     getHarvestRanking: {
-      name: "GetHarvestRanking",
+      name: 'GetHarvestRanking',
       requestType: RankingRequest,
       requestStream: false,
       responseType: LeaderboardResponse,
@@ -4732,7 +4800,7 @@ export const KamidenServiceDefinition = {
       options: {},
     },
     getKillerRanking: {
-      name: "GetKillerRanking",
+      name: 'GetKillerRanking',
       requestType: RankingRequest,
       requestStream: false,
       responseType: LeaderboardResponse,
@@ -4740,7 +4808,7 @@ export const KamidenServiceDefinition = {
       options: {},
     },
     getTradeHistory: {
-      name: "GetTradeHistory",
+      name: 'GetTradeHistory',
       requestType: TradesRequest,
       requestStream: false,
       responseType: TradesResponse,
@@ -4748,7 +4816,7 @@ export const KamidenServiceDefinition = {
       options: {},
     },
     getOpenOffers: {
-      name: "GetOpenOffers",
+      name: 'GetOpenOffers',
       requestType: TradesRequest,
       requestStream: false,
       responseType: TradesResponse,
@@ -4756,7 +4824,7 @@ export const KamidenServiceDefinition = {
       options: {},
     },
     getItemTransfers: {
-      name: "GetItemTransfers",
+      name: 'GetItemTransfers',
       requestType: ItemTransferRequest,
       requestStream: false,
       responseType: ItemTransferResponse,
@@ -4764,7 +4832,7 @@ export const KamidenServiceDefinition = {
       options: {},
     },
     getTokenWithdrawals: {
-      name: "GetTokenWithdrawals",
+      name: 'GetTokenWithdrawals',
       requestType: TokenPortalRequest,
       requestStream: false,
       responseType: TokenPortalResponse,
@@ -4772,7 +4840,7 @@ export const KamidenServiceDefinition = {
       options: {},
     },
     getTokenDeposits: {
-      name: "GetTokenDeposits",
+      name: 'GetTokenDeposits',
       requestType: TokenPortalRequest,
       requestStream: false,
       responseType: TokenPortalResponse,
@@ -4780,7 +4848,7 @@ export const KamidenServiceDefinition = {
       options: {},
     },
     getOpenWithdrawals: {
-      name: "GetOpenWithdrawals",
+      name: 'GetOpenWithdrawals',
       requestType: TokenPortalRequest,
       requestStream: false,
       responseType: TokenPortalResponse,
@@ -4788,7 +4856,7 @@ export const KamidenServiceDefinition = {
       options: {},
     },
     getKamiMarketListings: {
-      name: "GetKamiMarketListings",
+      name: 'GetKamiMarketListings',
       requestType: KamiMarketListingsRequest,
       requestStream: false,
       responseType: KamiMarketListingsResponse,
@@ -4796,7 +4864,7 @@ export const KamidenServiceDefinition = {
       options: {},
     },
     getKamiMarketBids: {
-      name: "GetKamiMarketBids",
+      name: 'GetKamiMarketBids',
       requestType: KamiMarketBidsRequest,
       requestStream: false,
       responseType: KamiMarketBidsResponse,
@@ -4804,7 +4872,7 @@ export const KamidenServiceDefinition = {
       options: {},
     },
     getKamiMarketHistory: {
-      name: "GetKamiMarketHistory",
+      name: 'GetKamiMarketHistory',
       requestType: KamiMarketHistoryRequest,
       requestStream: false,
       responseType: KamiMarketHistoryResponse,
@@ -4812,7 +4880,7 @@ export const KamidenServiceDefinition = {
       options: {},
     },
     getPoolPriceHistory: {
-      name: "GetPoolPriceHistory",
+      name: 'GetPoolPriceHistory',
       requestType: PoolPriceRequest,
       requestStream: false,
       responseType: PoolPriceHistory,
@@ -4820,7 +4888,7 @@ export const KamidenServiceDefinition = {
       options: {},
     },
     getKillsByAccount: {
-      name: "GetKillsByAccount",
+      name: 'GetKillsByAccount',
       requestType: LeaderboardRequest,
       requestStream: false,
       responseType: LeaderboardResponse,
@@ -4828,7 +4896,7 @@ export const KamidenServiceDefinition = {
       options: {},
     },
     getDeathsByAccount: {
-      name: "GetDeathsByAccount",
+      name: 'GetDeathsByAccount',
       requestType: LeaderboardRequest,
       requestStream: false,
       responseType: LeaderboardResponse,
@@ -4836,7 +4904,7 @@ export const KamidenServiceDefinition = {
       options: {},
     },
     getMusuByAccount: {
-      name: "GetMusuByAccount",
+      name: 'GetMusuByAccount',
       requestType: LeaderboardRequest,
       requestStream: false,
       responseType: LeaderboardResponse,
@@ -4844,7 +4912,7 @@ export const KamidenServiceDefinition = {
       options: {},
     },
     getMovementsByAccount: {
-      name: "GetMovementsByAccount",
+      name: 'GetMovementsByAccount',
       requestType: LeaderboardRequest,
       requestStream: false,
       responseType: LeaderboardResponse,
@@ -4852,7 +4920,7 @@ export const KamidenServiceDefinition = {
       options: {},
     },
     getKillsByKami: {
-      name: "GetKillsByKami",
+      name: 'GetKillsByKami',
       requestType: LeaderboardRequest,
       requestStream: false,
       responseType: LeaderboardResponse,
@@ -4860,7 +4928,7 @@ export const KamidenServiceDefinition = {
       options: {},
     },
     getDeathsByKami: {
-      name: "GetDeathsByKami",
+      name: 'GetDeathsByKami',
       requestType: LeaderboardRequest,
       requestStream: false,
       responseType: LeaderboardResponse,
@@ -4868,7 +4936,7 @@ export const KamidenServiceDefinition = {
       options: {},
     },
     getPNLByKami: {
-      name: "GetPNLByKami",
+      name: 'GetPNLByKami',
       requestType: LeaderboardRequest,
       requestStream: false,
       responseType: LeaderboardResponse,
@@ -4877,7 +4945,7 @@ export const KamidenServiceDefinition = {
     },
     /** Stream */
     subscribeToStream: {
-      name: "SubscribeToStream",
+      name: 'SubscribeToStream',
       requestType: StreamRequest,
       requestStream: false,
       responseType: StreamResponse,
@@ -4886,7 +4954,7 @@ export const KamidenServiceDefinition = {
     },
     /** Set runtime logger level (admin only) */
     setLogLevel: {
-      name: "SetLogLevel",
+      name: 'SetLogLevel',
       requestType: SetLogLevelRequest,
       requestStream: false,
       responseType: SetLogLevelResponse,
@@ -4898,212 +4966,242 @@ export const KamidenServiceDefinition = {
 
 export interface KamidenServiceImplementation<CallContextExt = {}> {
   /** Requests the latest block number based on the latest ECS state. */
-  getRoomMessages(request: RoomRequest, context: CallContext & CallContextExt): Promise<DeepPartial<RoomResponse>>;
+  getRoomMessages(
+    request: RoomRequest,
+    context: CallContext & CallContextExt
+  ): Promise<DeepPartial<RoomResponse>>;
   getAuctionBuys(
     request: AuctionBuysRequest,
-    context: CallContext & CallContextExt,
+    context: CallContext & CallContextExt
   ): Promise<DeepPartial<AuctionBuysResponse>>;
-  getBattles(request: BattlesRequest, context: CallContext & CallContextExt): Promise<DeepPartial<BattlesResponse>>;
+  getBattles(
+    request: BattlesRequest,
+    context: CallContext & CallContextExt
+  ): Promise<DeepPartial<BattlesResponse>>;
   getBattleStats(
     request: BattleStatsRequest,
-    context: CallContext & CallContextExt,
+    context: CallContext & CallContextExt
   ): Promise<DeepPartial<BattleStatsResponse>>;
   getHarvestRanking(
     request: RankingRequest,
-    context: CallContext & CallContextExt,
+    context: CallContext & CallContextExt
   ): Promise<DeepPartial<LeaderboardResponse>>;
   getKillerRanking(
     request: RankingRequest,
-    context: CallContext & CallContextExt,
+    context: CallContext & CallContextExt
   ): Promise<DeepPartial<LeaderboardResponse>>;
-  getTradeHistory(request: TradesRequest, context: CallContext & CallContextExt): Promise<DeepPartial<TradesResponse>>;
-  getOpenOffers(request: TradesRequest, context: CallContext & CallContextExt): Promise<DeepPartial<TradesResponse>>;
+  getTradeHistory(
+    request: TradesRequest,
+    context: CallContext & CallContextExt
+  ): Promise<DeepPartial<TradesResponse>>;
+  getOpenOffers(
+    request: TradesRequest,
+    context: CallContext & CallContextExt
+  ): Promise<DeepPartial<TradesResponse>>;
   getItemTransfers(
     request: ItemTransferRequest,
-    context: CallContext & CallContextExt,
+    context: CallContext & CallContextExt
   ): Promise<DeepPartial<ItemTransferResponse>>;
   getTokenWithdrawals(
     request: TokenPortalRequest,
-    context: CallContext & CallContextExt,
+    context: CallContext & CallContextExt
   ): Promise<DeepPartial<TokenPortalResponse>>;
   getTokenDeposits(
     request: TokenPortalRequest,
-    context: CallContext & CallContextExt,
+    context: CallContext & CallContextExt
   ): Promise<DeepPartial<TokenPortalResponse>>;
   getOpenWithdrawals(
     request: TokenPortalRequest,
-    context: CallContext & CallContextExt,
+    context: CallContext & CallContextExt
   ): Promise<DeepPartial<TokenPortalResponse>>;
   getKamiMarketListings(
     request: KamiMarketListingsRequest,
-    context: CallContext & CallContextExt,
+    context: CallContext & CallContextExt
   ): Promise<DeepPartial<KamiMarketListingsResponse>>;
   getKamiMarketBids(
     request: KamiMarketBidsRequest,
-    context: CallContext & CallContextExt,
+    context: CallContext & CallContextExt
   ): Promise<DeepPartial<KamiMarketBidsResponse>>;
   getKamiMarketHistory(
     request: KamiMarketHistoryRequest,
-    context: CallContext & CallContextExt,
+    context: CallContext & CallContextExt
   ): Promise<DeepPartial<KamiMarketHistoryResponse>>;
   getPoolPriceHistory(
     request: PoolPriceRequest,
-    context: CallContext & CallContextExt,
+    context: CallContext & CallContextExt
   ): Promise<DeepPartial<PoolPriceHistory>>;
   getKillsByAccount(
     request: LeaderboardRequest,
-    context: CallContext & CallContextExt,
+    context: CallContext & CallContextExt
   ): Promise<DeepPartial<LeaderboardResponse>>;
   getDeathsByAccount(
     request: LeaderboardRequest,
-    context: CallContext & CallContextExt,
+    context: CallContext & CallContextExt
   ): Promise<DeepPartial<LeaderboardResponse>>;
   getMusuByAccount(
     request: LeaderboardRequest,
-    context: CallContext & CallContextExt,
+    context: CallContext & CallContextExt
   ): Promise<DeepPartial<LeaderboardResponse>>;
   getMovementsByAccount(
     request: LeaderboardRequest,
-    context: CallContext & CallContextExt,
+    context: CallContext & CallContextExt
   ): Promise<DeepPartial<LeaderboardResponse>>;
   getKillsByKami(
     request: LeaderboardRequest,
-    context: CallContext & CallContextExt,
+    context: CallContext & CallContextExt
   ): Promise<DeepPartial<LeaderboardResponse>>;
   getDeathsByKami(
     request: LeaderboardRequest,
-    context: CallContext & CallContextExt,
+    context: CallContext & CallContextExt
   ): Promise<DeepPartial<LeaderboardResponse>>;
   getPNLByKami(
     request: LeaderboardRequest,
-    context: CallContext & CallContextExt,
+    context: CallContext & CallContextExt
   ): Promise<DeepPartial<LeaderboardResponse>>;
   /** Stream */
   subscribeToStream(
     request: StreamRequest,
-    context: CallContext & CallContextExt,
+    context: CallContext & CallContextExt
   ): ServerStreamingMethodResult<DeepPartial<StreamResponse>>;
   /** Set runtime logger level (admin only) */
   setLogLevel(
     request: SetLogLevelRequest,
-    context: CallContext & CallContextExt,
+    context: CallContext & CallContextExt
   ): Promise<DeepPartial<SetLogLevelResponse>>;
 }
 
 export interface KamidenServiceClient<CallOptionsExt = {}> {
   /** Requests the latest block number based on the latest ECS state. */
-  getRoomMessages(request: DeepPartial<RoomRequest>, options?: CallOptions & CallOptionsExt): Promise<RoomResponse>;
+  getRoomMessages(
+    request: DeepPartial<RoomRequest>,
+    options?: CallOptions & CallOptionsExt
+  ): Promise<RoomResponse>;
   getAuctionBuys(
     request: DeepPartial<AuctionBuysRequest>,
-    options?: CallOptions & CallOptionsExt,
+    options?: CallOptions & CallOptionsExt
   ): Promise<AuctionBuysResponse>;
-  getBattles(request: DeepPartial<BattlesRequest>, options?: CallOptions & CallOptionsExt): Promise<BattlesResponse>;
+  getBattles(
+    request: DeepPartial<BattlesRequest>,
+    options?: CallOptions & CallOptionsExt
+  ): Promise<BattlesResponse>;
   getBattleStats(
     request: DeepPartial<BattleStatsRequest>,
-    options?: CallOptions & CallOptionsExt,
+    options?: CallOptions & CallOptionsExt
   ): Promise<BattleStatsResponse>;
   getHarvestRanking(
     request: DeepPartial<RankingRequest>,
-    options?: CallOptions & CallOptionsExt,
+    options?: CallOptions & CallOptionsExt
   ): Promise<LeaderboardResponse>;
   getKillerRanking(
     request: DeepPartial<RankingRequest>,
-    options?: CallOptions & CallOptionsExt,
+    options?: CallOptions & CallOptionsExt
   ): Promise<LeaderboardResponse>;
-  getTradeHistory(request: DeepPartial<TradesRequest>, options?: CallOptions & CallOptionsExt): Promise<TradesResponse>;
-  getOpenOffers(request: DeepPartial<TradesRequest>, options?: CallOptions & CallOptionsExt): Promise<TradesResponse>;
+  getTradeHistory(
+    request: DeepPartial<TradesRequest>,
+    options?: CallOptions & CallOptionsExt
+  ): Promise<TradesResponse>;
+  getOpenOffers(
+    request: DeepPartial<TradesRequest>,
+    options?: CallOptions & CallOptionsExt
+  ): Promise<TradesResponse>;
   getItemTransfers(
     request: DeepPartial<ItemTransferRequest>,
-    options?: CallOptions & CallOptionsExt,
+    options?: CallOptions & CallOptionsExt
   ): Promise<ItemTransferResponse>;
   getTokenWithdrawals(
     request: DeepPartial<TokenPortalRequest>,
-    options?: CallOptions & CallOptionsExt,
+    options?: CallOptions & CallOptionsExt
   ): Promise<TokenPortalResponse>;
   getTokenDeposits(
     request: DeepPartial<TokenPortalRequest>,
-    options?: CallOptions & CallOptionsExt,
+    options?: CallOptions & CallOptionsExt
   ): Promise<TokenPortalResponse>;
   getOpenWithdrawals(
     request: DeepPartial<TokenPortalRequest>,
-    options?: CallOptions & CallOptionsExt,
+    options?: CallOptions & CallOptionsExt
   ): Promise<TokenPortalResponse>;
   getKamiMarketListings(
     request: DeepPartial<KamiMarketListingsRequest>,
-    options?: CallOptions & CallOptionsExt,
+    options?: CallOptions & CallOptionsExt
   ): Promise<KamiMarketListingsResponse>;
   getKamiMarketBids(
     request: DeepPartial<KamiMarketBidsRequest>,
-    options?: CallOptions & CallOptionsExt,
+    options?: CallOptions & CallOptionsExt
   ): Promise<KamiMarketBidsResponse>;
   getKamiMarketHistory(
     request: DeepPartial<KamiMarketHistoryRequest>,
-    options?: CallOptions & CallOptionsExt,
+    options?: CallOptions & CallOptionsExt
   ): Promise<KamiMarketHistoryResponse>;
   getPoolPriceHistory(
     request: DeepPartial<PoolPriceRequest>,
-    options?: CallOptions & CallOptionsExt,
+    options?: CallOptions & CallOptionsExt
   ): Promise<PoolPriceHistory>;
   getKillsByAccount(
     request: DeepPartial<LeaderboardRequest>,
-    options?: CallOptions & CallOptionsExt,
+    options?: CallOptions & CallOptionsExt
   ): Promise<LeaderboardResponse>;
   getDeathsByAccount(
     request: DeepPartial<LeaderboardRequest>,
-    options?: CallOptions & CallOptionsExt,
+    options?: CallOptions & CallOptionsExt
   ): Promise<LeaderboardResponse>;
   getMusuByAccount(
     request: DeepPartial<LeaderboardRequest>,
-    options?: CallOptions & CallOptionsExt,
+    options?: CallOptions & CallOptionsExt
   ): Promise<LeaderboardResponse>;
   getMovementsByAccount(
     request: DeepPartial<LeaderboardRequest>,
-    options?: CallOptions & CallOptionsExt,
+    options?: CallOptions & CallOptionsExt
   ): Promise<LeaderboardResponse>;
   getKillsByKami(
     request: DeepPartial<LeaderboardRequest>,
-    options?: CallOptions & CallOptionsExt,
+    options?: CallOptions & CallOptionsExt
   ): Promise<LeaderboardResponse>;
   getDeathsByKami(
     request: DeepPartial<LeaderboardRequest>,
-    options?: CallOptions & CallOptionsExt,
+    options?: CallOptions & CallOptionsExt
   ): Promise<LeaderboardResponse>;
   getPNLByKami(
     request: DeepPartial<LeaderboardRequest>,
-    options?: CallOptions & CallOptionsExt,
+    options?: CallOptions & CallOptionsExt
   ): Promise<LeaderboardResponse>;
   /** Stream */
   subscribeToStream(
     request: DeepPartial<StreamRequest>,
-    options?: CallOptions & CallOptionsExt,
+    options?: CallOptions & CallOptionsExt
   ): AsyncIterable<StreamResponse>;
   /** Set runtime logger level (admin only) */
   setLogLevel(
     request: DeepPartial<SetLogLevelRequest>,
-    options?: CallOptions & CallOptionsExt,
+    options?: CallOptions & CallOptionsExt
   ): Promise<SetLogLevelResponse>;
 }
 
 type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 
-export type DeepPartial<T> = T extends Builtin ? T
-  : T extends globalThis.Array<infer U> ? globalThis.Array<DeepPartial<U>>
-  : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
-  : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
-  : Partial<T>;
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends globalThis.Array<infer U>
+    ? globalThis.Array<DeepPartial<U>>
+    : T extends ReadonlyArray<infer U>
+      ? ReadonlyArray<DeepPartial<U>>
+      : T extends {}
+        ? { [K in keyof T]?: DeepPartial<T[K]> }
+        : Partial<T>;
 
 function longToNumber(int64: { toString(): string }): number {
   const num = globalThis.Number(int64.toString());
   if (num > globalThis.Number.MAX_SAFE_INTEGER) {
-    throw new globalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
+    throw new globalThis.Error('Value is larger than Number.MAX_SAFE_INTEGER');
   }
   if (num < globalThis.Number.MIN_SAFE_INTEGER) {
-    throw new globalThis.Error("Value is smaller than Number.MIN_SAFE_INTEGER");
+    throw new globalThis.Error('Value is smaller than Number.MIN_SAFE_INTEGER');
   }
   return num;
 }
 
-export type ServerStreamingMethodResult<Response> = { [Symbol.asyncIterator](): AsyncIterator<Response, void> };
+export type ServerStreamingMethodResult<Response> = {
+  [Symbol.asyncIterator](): AsyncIterator<Response, void>;
+};
 
 export interface MessageFns<T> {
   encode(message: T, writer?: BinaryWriter): BinaryWriter;

--- a/packages/client/src/clients/kamiden/proto.ts
+++ b/packages/client/src/clients/kamiden/proto.ts
@@ -296,6 +296,11 @@ export interface KamiMarketHistoryRequest {
 export interface LeaderboardRequest {
 }
 
+export interface SetLogLevelRequest {
+  level: string;
+  apiKey: string;
+}
+
 /** RESPONSE */
 export interface RoomResponse {
   Messages: Message[];
@@ -345,6 +350,28 @@ export interface KamiMarketBidsResponse {
 
 export interface KamiMarketHistoryResponse {
   Orders: KamiMarketOrder[];
+}
+
+export interface SetLogLevelResponse {
+  level: string;
+}
+
+export interface PoolPriceRequest {
+  indexA: number;
+  indexB: number;
+  fromTs?: number | undefined;
+  toTs?: number | undefined;
+}
+
+export interface PoolPricePoint {
+  bucketTs: number;
+  price: number;
+}
+
+export interface PoolPriceHistory {
+  points: PoolPricePoint[];
+  baseIndex: number;
+  quoteIndex: number;
 }
 
 export interface LeaderboardRow {
@@ -3707,6 +3734,64 @@ export const LeaderboardRequest: MessageFns<LeaderboardRequest> = {
   },
 };
 
+function createBaseSetLogLevelRequest(): SetLogLevelRequest {
+  return { level: "", apiKey: "" };
+}
+
+export const SetLogLevelRequest: MessageFns<SetLogLevelRequest> = {
+  encode(message: SetLogLevelRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.level !== "") {
+      writer.uint32(10).string(message.level);
+    }
+    if (message.apiKey !== "") {
+      writer.uint32(18).string(message.apiKey);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): SetLogLevelRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSetLogLevelRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.level = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.apiKey = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  create(base?: DeepPartial<SetLogLevelRequest>): SetLogLevelRequest {
+    return SetLogLevelRequest.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<SetLogLevelRequest>): SetLogLevelRequest {
+    const message = createBaseSetLogLevelRequest();
+    message.level = object.level ?? "";
+    message.apiKey = object.apiKey ?? "";
+    return message;
+  },
+};
+
 function createBaseRoomResponse(): RoomResponse {
   return { Messages: [], Feeds: [] };
 }
@@ -4285,6 +4370,262 @@ export const KamiMarketHistoryResponse: MessageFns<KamiMarketHistoryResponse> = 
   },
 };
 
+function createBaseSetLogLevelResponse(): SetLogLevelResponse {
+  return { level: "" };
+}
+
+export const SetLogLevelResponse: MessageFns<SetLogLevelResponse> = {
+  encode(message: SetLogLevelResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.level !== "") {
+      writer.uint32(10).string(message.level);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): SetLogLevelResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSetLogLevelResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.level = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  create(base?: DeepPartial<SetLogLevelResponse>): SetLogLevelResponse {
+    return SetLogLevelResponse.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<SetLogLevelResponse>): SetLogLevelResponse {
+    const message = createBaseSetLogLevelResponse();
+    message.level = object.level ?? "";
+    return message;
+  },
+};
+
+function createBasePoolPriceRequest(): PoolPriceRequest {
+  return { indexA: 0, indexB: 0, fromTs: undefined, toTs: undefined };
+}
+
+export const PoolPriceRequest: MessageFns<PoolPriceRequest> = {
+  encode(message: PoolPriceRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.indexA !== 0) {
+      writer.uint32(8).uint32(message.indexA);
+    }
+    if (message.indexB !== 0) {
+      writer.uint32(16).uint32(message.indexB);
+    }
+    if (message.fromTs !== undefined) {
+      writer.uint32(24).int64(message.fromTs);
+    }
+    if (message.toTs !== undefined) {
+      writer.uint32(32).int64(message.toTs);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): PoolPriceRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBasePoolPriceRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 8) {
+            break;
+          }
+
+          message.indexA = reader.uint32();
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.indexB = reader.uint32();
+          continue;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.fromTs = longToNumber(reader.int64());
+          continue;
+        }
+        case 4: {
+          if (tag !== 32) {
+            break;
+          }
+
+          message.toTs = longToNumber(reader.int64());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  create(base?: DeepPartial<PoolPriceRequest>): PoolPriceRequest {
+    return PoolPriceRequest.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<PoolPriceRequest>): PoolPriceRequest {
+    const message = createBasePoolPriceRequest();
+    message.indexA = object.indexA ?? 0;
+    message.indexB = object.indexB ?? 0;
+    message.fromTs = object.fromTs ?? undefined;
+    message.toTs = object.toTs ?? undefined;
+    return message;
+  },
+};
+
+function createBasePoolPricePoint(): PoolPricePoint {
+  return { bucketTs: 0, price: 0 };
+}
+
+export const PoolPricePoint: MessageFns<PoolPricePoint> = {
+  encode(message: PoolPricePoint, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.bucketTs !== 0) {
+      writer.uint32(8).int64(message.bucketTs);
+    }
+    if (message.price !== 0) {
+      writer.uint32(17).double(message.price);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): PoolPricePoint {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBasePoolPricePoint();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 8) {
+            break;
+          }
+
+          message.bucketTs = longToNumber(reader.int64());
+          continue;
+        }
+        case 2: {
+          if (tag !== 17) {
+            break;
+          }
+
+          message.price = reader.double();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  create(base?: DeepPartial<PoolPricePoint>): PoolPricePoint {
+    return PoolPricePoint.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<PoolPricePoint>): PoolPricePoint {
+    const message = createBasePoolPricePoint();
+    message.bucketTs = object.bucketTs ?? 0;
+    message.price = object.price ?? 0;
+    return message;
+  },
+};
+
+function createBasePoolPriceHistory(): PoolPriceHistory {
+  return { points: [], baseIndex: 0, quoteIndex: 0 };
+}
+
+export const PoolPriceHistory: MessageFns<PoolPriceHistory> = {
+  encode(message: PoolPriceHistory, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    for (const v of message.points) {
+      PoolPricePoint.encode(v!, writer.uint32(10).fork()).join();
+    }
+    if (message.baseIndex !== 0) {
+      writer.uint32(16).uint32(message.baseIndex);
+    }
+    if (message.quoteIndex !== 0) {
+      writer.uint32(24).uint32(message.quoteIndex);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): PoolPriceHistory {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBasePoolPriceHistory();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.points.push(PoolPricePoint.decode(reader, reader.uint32()));
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.baseIndex = reader.uint32();
+          continue;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.quoteIndex = reader.uint32();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  create(base?: DeepPartial<PoolPriceHistory>): PoolPriceHistory {
+    return PoolPriceHistory.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<PoolPriceHistory>): PoolPriceHistory {
+    const message = createBasePoolPriceHistory();
+    message.points = object.points?.map((e) => PoolPricePoint.fromPartial(e)) || [];
+    message.baseIndex = object.baseIndex ?? 0;
+    message.quoteIndex = object.quoteIndex ?? 0;
+    return message;
+  },
+};
+
 function createBaseLeaderboardRow(): LeaderboardRow {
   return { Name: "", Value: "" };
 }
@@ -4470,6 +4811,14 @@ export const KamidenServiceDefinition = {
       responseStream: false,
       options: {},
     },
+    getPoolPriceHistory: {
+      name: "GetPoolPriceHistory",
+      requestType: PoolPriceRequest,
+      requestStream: false,
+      responseType: PoolPriceHistory,
+      responseStream: false,
+      options: {},
+    },
     getKillsByAccount: {
       name: "GetKillsByAccount",
       requestType: LeaderboardRequest,
@@ -4535,6 +4884,15 @@ export const KamidenServiceDefinition = {
       responseStream: true,
       options: {},
     },
+    /** Set runtime logger level (admin only) */
+    setLogLevel: {
+      name: "SetLogLevel",
+      requestType: SetLogLevelRequest,
+      requestStream: false,
+      responseType: SetLogLevelResponse,
+      responseStream: false,
+      options: {},
+    },
   },
 } as const;
 
@@ -4588,6 +4946,10 @@ export interface KamidenServiceImplementation<CallContextExt = {}> {
     request: KamiMarketHistoryRequest,
     context: CallContext & CallContextExt,
   ): Promise<DeepPartial<KamiMarketHistoryResponse>>;
+  getPoolPriceHistory(
+    request: PoolPriceRequest,
+    context: CallContext & CallContextExt,
+  ): Promise<DeepPartial<PoolPriceHistory>>;
   getKillsByAccount(
     request: LeaderboardRequest,
     context: CallContext & CallContextExt,
@@ -4621,6 +4983,11 @@ export interface KamidenServiceImplementation<CallContextExt = {}> {
     request: StreamRequest,
     context: CallContext & CallContextExt,
   ): ServerStreamingMethodResult<DeepPartial<StreamResponse>>;
+  /** Set runtime logger level (admin only) */
+  setLogLevel(
+    request: SetLogLevelRequest,
+    context: CallContext & CallContextExt,
+  ): Promise<DeepPartial<SetLogLevelResponse>>;
 }
 
 export interface KamidenServiceClient<CallOptionsExt = {}> {
@@ -4673,6 +5040,10 @@ export interface KamidenServiceClient<CallOptionsExt = {}> {
     request: DeepPartial<KamiMarketHistoryRequest>,
     options?: CallOptions & CallOptionsExt,
   ): Promise<KamiMarketHistoryResponse>;
+  getPoolPriceHistory(
+    request: DeepPartial<PoolPriceRequest>,
+    options?: CallOptions & CallOptionsExt,
+  ): Promise<PoolPriceHistory>;
   getKillsByAccount(
     request: DeepPartial<LeaderboardRequest>,
     options?: CallOptions & CallOptionsExt,
@@ -4706,6 +5077,11 @@ export interface KamidenServiceClient<CallOptionsExt = {}> {
     request: DeepPartial<StreamRequest>,
     options?: CallOptions & CallOptionsExt,
   ): AsyncIterable<StreamResponse>;
+  /** Set runtime logger level (admin only) */
+  setLogLevel(
+    request: DeepPartial<SetLogLevelRequest>,
+    options?: CallOptions & CallOptionsExt,
+  ): Promise<SetLogLevelResponse>;
 }
 
 type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;


### PR DESCRIPTION
## Pool price history — windowed daily series

  Consumes kamiden's `GetPoolPriceHistory` (RPC on
  `KamidenService`), which now supports an optional
  day-granular time window. Backend: kamigaze v1.4.1.

  ### Request — `PoolPriceRequest`
  | Field | Type | Notes |
  |---|---|---|
  | `index_a`, `index_b` | `uint32` | The two item indices of
  the pool. **Order-independent** — the backend sorts them. |
  | `from_ts` | `int64?` | Optional. Epoch **seconds**,
  inclusive lower bound. |
  | `to_ts` | `int64?` | Optional. Epoch **seconds**, inclusive
  upper bound. |

  Bounds are order-independent (backend sorts them) and each is
  snapped **down** to the start of its UTC day, so a mid-day
  timestamp still includes that whole day.

  ### Response — `PoolPriceHistory`
  - `points[]`: `{ bucket_ts: int64 (day-start, UTC epoch
  seconds), price: double }`, oldest first, one per day.
  - `base_index` / `quote_index`: the canonical sorted pair.
  The series is **quote priced in base** (higher index priced
  in the lower), so a reversed request still returns `price`,
  never `1/price`.

  ### Windowing behavior
  - **No bounds → last 7 days** (current day + preceding 6).
  This is the default; call it with just the two indices for a
  compact recent series.
  - **Both bounds** → clipped to that day range.
  - **One bound** → the other stays open: `from_ts` only runs
  to now; `to_ts` only starts at the pool's first data. Pass
  `from_ts: 0` to get the **all-time** series.
  - The series is **forward-filled** from the pool's first-ever
  sync: a day with no trade carries the previous close, and
  the first day in the window always shows the last known price
  even if the pool's last sync predates it.
  - **"…if present":** the series can't start before the pool's
  first sync or extend past now, so a young pool simply
  returns fewer points than the window requests (e.g. a
  5-day-old pool returns 5, not 7).

  ### Examples
  { index_a: 1, index_b: 2 }                          // last 7
  days
  { index_a: 1, index_b: 2, from_ts: 1785888000 }     // from
  Aug 5 → now
  { index_a: 1, index_b: 2, from_ts: 1785628800, to_ts:
  1786320000 }  // Aug 2 → Aug 10
  { index_a: 1, index_b: 2, from_ts: 0 }              //
  all-time



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added historical pool pricing with selectable 7-day, 30-day, and maximum time ranges.
  * Added a pool chart with interactive price details and automatic quote orientation.
  * Added a “My Positions” view showing liquidity shares and redeemable assets.
  * Added pool controls directly to inventory items.
  * Added support for exact-output swaps and improved MUSU pool liquidity workflows.
  * Added runtime log-level configuration for authorized administrators.
  * Added client support for retrieving pool price histories and updating log levels through the API.

* **Bug Fixes**
  * Improved validation for balances, reserves, and zero-output transactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->