### PR TITLE
fix(client): treat snapshot RESOURCE_EXHAUSTED as backpressure

### DIFF
--- a/packages/client/src/workers/sync/snapshot/fetch.ts
+++ b/packages/client/src/workers/sync/snapshot/fetch.ts
@@ -1,3 +1,5 @@
+import { ClientError, Status } from 'nice-grpc-web';
+
 import { KamigazeServiceClient } from 'clients/kamigaze';
 import { createDecode } from 'engine/encoders';
 import { log } from 'utils/logger';
@@ -15,14 +17,18 @@ const CHUNK_TIMEOUT_MS = 30000;
 const MAX_RETRIES = 20;
 const RETRY_DELAYS = [1000, 2000, 3000, 5000, 10000];
 
+// The snapshot service sheds load past MAX_CONCURRENT with gRPC RESOURCE_EXHAUSTED
+// instead of hanging the caller. That is expected backpressure, not a failure, so
+// it retries on a separate budget with a steady backoff: a sustained saturation
+// window (e.g. a region failover concentrating traffic) is waited out rather than
+// burning the fatal retry budget and failing the whole snapshot load.
+const CAPACITY_RETRY_DELAY_MS = 10000;
+const MAX_CAPACITY_RETRIES = 60;
+
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-const maybeThrow = () => {
-  if (Math.random() < 0.6) {
-    log.warn('[snapshot] Throwing on purpose');
-    throw new Error('[snapshot] [TEST] Random chunk failure (1 in 5)');
-  }
-};
+const isCapacityError = (error: unknown): boolean =>
+  error instanceof ClientError && error.code === Status.RESOURCE_EXHAUSTED;
 
 async function withTimeout<T>(fn: () => Promise<T>, ms: number): Promise<T> {
   return Promise.race([
@@ -55,6 +61,7 @@ async function fetchWithRetry<TChunk>({
   onRetry,
 }: StreamingFetchOptions<TChunk>): Promise<void> {
   let retryCount = 0;
+  let capacityRetryCount = 0;
   let chunkIndex = 0;
   let totalChunks = 0;
   const progressSpan = progressRange.end - progressRange.start;
@@ -87,11 +94,27 @@ async function fetchWithRetry<TChunk>({
           chunkIndex++;
         }, CHUNK_TIMEOUT_MS);
         retryCount = 0;
+        capacityRetryCount = 0;
       }
 
       log.debug(`[snapshot] ${name} completed`, { chunksProcessed: chunkIndex });
       return;
     } catch (error) {
+      if (isCapacityError(error)) {
+        capacityRetryCount++;
+        if (capacityRetryCount > MAX_CAPACITY_RETRIES) throw error;
+
+        log.info(
+          `[snapshot] ${name} server at capacity, backing off ${CAPACITY_RETRY_DELAY_MS / 1000}s (${capacityRetryCount}/${MAX_CAPACITY_RETRIES})`,
+          getRetryContext?.()
+        );
+        await sleep(CAPACITY_RETRY_DELAY_MS);
+
+        totalChunks = 0;
+        onRetry?.();
+        continue;
+      }
+
       retryCount++;
       log.warn(`[snapshot] ${name} error`, { retryCount, error });
       if (retryCount > MAX_RETRIES) throw error;

--- a/packages/client/src/workers/sync/snapshot/fetch.ts
+++ b/packages/client/src/workers/sync/snapshot/fetch.ts
@@ -17,11 +17,9 @@ const CHUNK_TIMEOUT_MS = 30000;
 const MAX_RETRIES = 20;
 const RETRY_DELAYS = [1000, 2000, 3000, 5000, 10000];
 
-// The snapshot service sheds load past MAX_CONCURRENT with gRPC RESOURCE_EXHAUSTED
-// instead of hanging the caller. That is expected backpressure, not a failure, so
-// it retries on a separate budget with a steady backoff: a sustained saturation
-// window (e.g. a region failover concentrating traffic) is waited out rather than
-// burning the fatal retry budget and failing the whole snapshot load.
+// RESOURCE_EXHAUSTED is expected backpressure, not a failure, so it gets its own
+// retry budget separate from the fatal one, keeping transient saturation from
+// failing the whole load.
 const CAPACITY_RETRY_DELAY_MS = 10000;
 const MAX_CAPACITY_RETRIES = 60;
 


### PR DESCRIPTION
## What

Handle the gRPC `RESOURCE_EXHAUSTED` signal the snapshot service now returns
when it's saturated, so the client waits out backpressure instead of failing
the state load.

## Why

The kamigaze snapshot service was patched ([kamigaze #95]) to shed load past
`MAX_CONCURRENT` by returning `codes.ResourceExhausted` on the `GetEntities` and
`GetState` streaming RPCs, rather than silently hanging the caller. Those two
RPCs are the only semaphore-guarded ones server-side, and on the client both
flow through `fetchWithRetry` in `snapshot/fetch.ts`.

Before this change the fetch loop retried `RESOURCE_EXHAUSTED` **generically**:
it logged as an error and counted against the fatal 20-retry budget
(`MAX_RETRIES`). During a sustained saturation window — e.g. taking EU/US
regions down and concentrating traffic on AP — the client would burn the whole
budget in ~3 minutes (max backoff is 10s) and then throw, failing the entire
snapshot load. That's the "client never finishes loading" symptom we saw under
region failover.

## Change

In the `getEntities`/`getState` streaming retry loop:

- Detect `RESOURCE_EXHAUSTED` specifically (`nice-grpc` `ClientError`, code 8).
- Treat it as **expected backpressure**: retry on a separate budget
  (`MAX_CAPACITY_RETRIES = 60`, flat `CAPACITY_RETRY_DELAY_MS = 10s`),
  logged at `info` as `server at capacity, backing off (n/60)`, **without**
  consuming the fatal retry budget.
- Both counters reset on any chunk progress, so the capacity budget bounds only
  *consecutive* saturation (~10 min of patience before it finally surfaces as a
  real error).
- Genuine (non-capacity) errors keep the original bounded backoff path
  unchanged.

Net effect: a temporarily-overloaded snapshot service pauses the client instead
of failing it; a genuinely wedged one (>10 min) still surfaces an error.

### Drive-by

Removed the dead `maybeThrow` test fault-injector in the same file (never
referenced anywhere in the repo; eslint flagged it unused; it throws 60% of the
time if ever wired into the prod fetch path).

## Verification

- `tsc --noEmit`: no new errors in the file (pre-existing unrelated errors in
  generated `ethers-contracts` types + `vite.config.ts` only).
- `eslint` + `prettier`: clean on the touched file.

[kamigaze #95]: server-side companion fix (snapshot semaphore returns ResourceExhausted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Snapshot synchronization now handles temporary capacity limits more gracefully.
  * Retries caused by backpressure use a separate retry allowance and do not consume retries reserved for other failures.
  * Retry tracking resets after successfully processing each snapshot chunk.
  * Removed random test-failure behavior from snapshot fetching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->